### PR TITLE
Feature/feature locks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ license = "AGPL-3"
 edition = "2021"
 
 [features]
+default = ["client"]
 backend = ["poem", "sqlx"]
 client = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ bigdecimal = "0.3.1"
 num-bigint = "0.4.3"
 lazy_static = "1.4.0"
 poem = { version = "1.3.55", optional = true }
-sqlx = { version = "0.6.3", features = ["mysql", "sqlite", "json", "chrono", "ipnetwork", "runtime-tokio-native-tls", "any"], optional = true }
+sqlx = { git = "https://github.com/zert3x/sqlx", branch="feature/skip", features = ["mysql", "sqlite", "json", "chrono", "ipnetwork", "runtime-tokio-native-tls", "any"], optional = true }
 thiserror = "1.0.40"
 jsonwebtoken = "8.3.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 license = "AGPL-3"
 edition = "2021"
 
+[features]
+backend = ["poem", "sqlx"]
+client = []
+
 [dependencies]
 tokio = {version = "1.28.1", features = ["rt", "macros", "rt-multi-thread", "full"]}
 serde = {version = "1.0.162", features = ["derive"]}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,15 @@
+#[cfg(feature = "client")]
 pub mod api;
+#[cfg(feature = "client")]
 pub mod errors;
+#[cfg(feature = "client")]
 pub mod gateway;
+#[cfg(feature = "client")]
 pub mod instance;
+#[cfg(feature = "client")]
 pub mod limit;
 pub mod types;
+#[cfg(feature = "client")]
 pub mod voice;
 
 use url::{ParseError, Url};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "client")]
 pub mod api;
-#[cfg(feature = "client")]
 pub mod errors;
 #[cfg(feature = "client")]
 pub mod gateway;

--- a/src/types/entities/application.rs
+++ b/src/types/entities/application.rs
@@ -22,9 +22,6 @@ pub struct Application {
     pub verify_key: String,
     #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub owner: User,
-    #[cfg(feature = "sqlx")]
-    #[serde(skip)]
-    pub owner_id: Snowflake,
     pub flags: u64,
     #[cfg(feature = "sqlx")]
     pub redirect_uris: Option<sqlx::types::Json<Vec<String>>>,
@@ -38,11 +35,6 @@ pub struct Application {
     pub integration_require_code_grant: bool,
     pub discoverability_state: i64,
     pub discovery_eligibility_flags: i64,
-    #[cfg_attr(feature = "sqlx", sqlx(skip))]
-    pub bot_user: Option<User>,
-    #[cfg(feature = "sqlx")]
-    #[serde(skip)]
-    pub bot_user_id: Option<Snowflake>,
     #[cfg(feature = "sqlx")]
     pub tags: Option<sqlx::types::Json<Vec<String>>>,
     #[cfg(not(feature = "sqlx"))]
@@ -56,9 +48,6 @@ pub struct Application {
     pub privacy_policy_url: Option<String>,
     #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub team: Option<Team>,
-    #[cfg(feature = "sqlx")]
-    #[serde(skip)]
-    pub team_id: Option<Snowflake>,
 }
 
 impl Application {

--- a/src/types/entities/application.rs
+++ b/src/types/entities/application.rs
@@ -23,6 +23,7 @@ pub struct Application {
     #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub owner: User,
     #[cfg(feature = "sqlx")]
+    #[serde(skip)]
     pub owner_id: Snowflake,
     pub flags: u64,
     #[cfg(feature = "sqlx")]
@@ -40,6 +41,7 @@ pub struct Application {
     #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub bot_user: Option<User>,
     #[cfg(feature = "sqlx")]
+    #[serde(skip)]
     pub bot_user_id: Option<Snowflake>,
     #[cfg(feature = "sqlx")]
     pub tags: Option<sqlx::types::Json<Vec<String>>>,
@@ -55,6 +57,7 @@ pub struct Application {
     #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub team: Option<Team>,
     #[cfg(feature = "sqlx")]
+    #[serde(skip)]
     pub team_id: Option<Snowflake>,
 }
 

--- a/src/types/entities/application.rs
+++ b/src/types/entities/application.rs
@@ -1,4 +1,5 @@
 use crate::types::utils::Snowflake;
+use crate::types::{Team, User};
 use bitflags::{bitflags, Flags};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -19,6 +20,9 @@ pub struct Application {
     pub bot_public: bool,
     pub bot_require_code_grant: bool,
     pub verify_key: String,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
+    pub owner: User,
+    #[cfg(feature = "sqlx")]
     pub owner_id: Snowflake,
     pub flags: u64,
     #[cfg(feature = "sqlx")]
@@ -33,7 +37,10 @@ pub struct Application {
     pub integration_require_code_grant: bool,
     pub discoverability_state: i64,
     pub discovery_eligibility_flags: i64,
-    pub bot_user_id: Snowflake,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
+    pub bot_user: Option<User>,
+    #[cfg(feature = "sqlx")]
+    pub bot_user_id: Option<Snowflake>,
     #[cfg(feature = "sqlx")]
     pub tags: Option<sqlx::types::Json<Vec<String>>>,
     #[cfg(not(feature = "sqlx"))]
@@ -45,6 +52,9 @@ pub struct Application {
     pub install_params: Option<InstallParams>,
     pub terms_of_service_url: Option<String>,
     pub privacy_policy_url: Option<String>,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
+    pub team: Option<Team>,
+    #[cfg(feature = "sqlx")]
     pub team_id: Option<Snowflake>,
 }
 

--- a/src/types/entities/application.rs
+++ b/src/types/entities/application.rs
@@ -2,11 +2,9 @@ use crate::types::utils::Snowflake;
 use bitflags::{bitflags, Flags};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-#[cfg(feature = "sqlx")]
-use sqlx::FromRow;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(feature = "sqlx", derive(FromRow))]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 pub struct Application {
     pub id: Snowflake,
     pub name: String,

--- a/src/types/entities/attachment.rs
+++ b/src/types/entities/attachment.rs
@@ -19,7 +19,7 @@ pub struct Attachment {
     pub duration_secs: Option<f32>,
     pub waveform: Option<String>,
     #[serde(skip_serializing)]
-    #[cfg_attr(feature = "sqlx", sqlx(default)]
+    #[cfg_attr(feature = "sqlx", sqlx(default))]
     pub content: Vec<u8>,
 }
 

--- a/src/types/entities/attachment.rs
+++ b/src/types/entities/attachment.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::types::utils::Snowflake;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 pub struct Attachment {
     pub id: Snowflake,
     pub filename: String,
@@ -18,6 +19,7 @@ pub struct Attachment {
     pub duration_secs: Option<f32>,
     pub waveform: Option<String>,
     #[serde(skip_serializing)]
+    #[cfg_attr(feature = "sqlx", sqlx(default)]
     pub content: Vec<u8>,
 }
 

--- a/src/types/entities/attachment.rs
+++ b/src/types/entities/attachment.rs
@@ -15,8 +15,6 @@ pub struct Attachment {
     pub proxy_url: String,
     pub height: Option<u64>,
     pub width: Option<u64>,
-    #[cfg(feature = "sqlx")]
-    pub message_id: Option<Snowflake>,
     #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub message: Option<Message>,
     pub ephemeral: Option<bool>,

--- a/src/types/entities/attachment.rs
+++ b/src/types/entities/attachment.rs
@@ -1,3 +1,4 @@
+use crate::types::Message;
 use serde::{Deserialize, Serialize};
 
 use crate::types::utils::Snowflake;
@@ -14,7 +15,10 @@ pub struct Attachment {
     pub proxy_url: String,
     pub height: Option<u64>,
     pub width: Option<u64>,
-    pub message_id: Snowflake,
+    #[cfg(feature = "sqlx")]
+    pub message_id: Option<Snowflake>,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
+    pub message: Option<Message>,
     pub ephemeral: Option<bool>,
     pub duration_secs: Option<f32>,
     pub waveform: Option<String>,

--- a/src/types/entities/attachment.rs
+++ b/src/types/entities/attachment.rs
@@ -15,8 +15,6 @@ pub struct Attachment {
     pub proxy_url: String,
     pub height: Option<u64>,
     pub width: Option<u64>,
-    #[cfg_attr(feature = "sqlx", sqlx(skip))]
-    pub message: Option<Message>,
     pub ephemeral: Option<bool>,
     pub duration_secs: Option<f32>,
     pub waveform: Option<String>,

--- a/src/types/entities/channel.rs
+++ b/src/types/entities/channel.rs
@@ -1,3 +1,4 @@
+use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
@@ -7,12 +8,17 @@ use crate::types::{
 };
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 pub struct Channel {
     pub id: Snowflake,
+    pub created_at: chrono::DateTime<Utc>,
     #[serde(rename = "type")]
     pub channel_type: ChannelType,
     pub guild_id: Option<Snowflake>,
     pub position: Option<i32>,
+    #[cfg(feature = "sqlx")]
+    pub permission_overwrites: Option<sqlx::types::Json<Vec<PermissionOverwrite>>>,
+    #[cfg(not(feature = "sqlx"))]
     pub permission_overwrites: Option<Vec<PermissionOverwrite>>,
     pub name: Option<String>,
     pub topic: Option<String>,
@@ -21,6 +27,7 @@ pub struct Channel {
     pub bitrate: Option<i32>,
     pub user_limit: Option<i32>,
     pub rate_limit_per_user: Option<i32>,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub recipients: Option<Vec<User>>,
     pub icon: Option<String>,
     pub owner_id: Option<String>,
@@ -31,14 +38,25 @@ pub struct Channel {
     pub video_quality_mode: Option<i32>,
     pub message_count: Option<i32>,
     pub member_count: Option<i32>,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub thread_metadata: Option<ThreadMetadata>,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub member: Option<ThreadMember>,
     pub default_auto_archive_duration: Option<i32>,
     pub permissions: Option<String>,
     pub flags: Option<i32>,
     pub total_message_sent: Option<i32>,
+    #[cfg(feature = "sqlx")]
+    pub available_tags: Option<sqlx::types::Json<Vec<Tag>>>,
+    #[cfg(not(feature = "sqlx"))]
     pub available_tags: Option<Vec<Tag>>,
+    #[cfg(feature = "sqlx")]
+    pub applied_tags: Option<sqlx::types::Json<Vec<String>>>,
+    #[cfg(not(feature = "sqlx"))]
     pub applied_tags: Option<Vec<String>>,
+    #[cfg(feature = "sqlx")]
+    pub default_reaction_emoji: Option<sqlx::types::Json<DefaultReaction>>,
+    #[cfg(not(feature = "sqlx"))]
     pub default_reaction_emoji: Option<DefaultReaction>,
     pub default_thread_rate_limit_per_user: Option<i32>,
     pub default_sort_order: Option<i32>,
@@ -89,6 +107,7 @@ pub struct DefaultReaction {
 }
 
 #[derive(Default, Clone, Copy, Debug, Serialize_repr, Deserialize_repr, PartialEq, Eq)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[repr(i32)]
 pub enum ChannelType {

--- a/src/types/entities/channel.rs
+++ b/src/types/entities/channel.rs
@@ -30,8 +30,9 @@ pub struct Channel {
     #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub recipients: Option<Vec<User>>,
     pub icon: Option<String>,
-    pub owner_id: Option<String>,
-    pub application_id: Option<String>,
+    pub owner_id: Option<Snowflake>,
+    pub application_id: Option<Snowflake>,
+    pub managed: Option<bool>,
     pub parent_id: Option<String>,
     pub last_pin_timestamp: Option<String>,
     pub rtc_region: Option<String>,

--- a/src/types/entities/emoji.rs
+++ b/src/types/entities/emoji.rs
@@ -12,14 +12,6 @@ pub struct Emoji {
     pub roles: Option<sqlx::types::Json<Vec<Snowflake>>>,
     #[cfg(not(feature = "sqlx"))]
     pub roles: Option<Vec<Snowflake>>,
-    #[cfg(feature = "sqlx")]
-    #[serde(skip)]
-    pub guild_id: Snowflake,
-    #[cfg_attr(feature = "sqlx", sqlx(skip))]
-    pub guild: Guild,
-    #[cfg(feature = "sqlx")]
-    #[serde(skip)]
-    pub user_id: Option<Snowflake>,
     #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub user: Option<User>,
     pub require_colons: Option<bool>,

--- a/src/types/entities/emoji.rs
+++ b/src/types/entities/emoji.rs
@@ -13,10 +13,12 @@ pub struct Emoji {
     #[cfg(not(feature = "sqlx"))]
     pub roles: Option<Vec<Snowflake>>,
     #[cfg(feature = "sqlx")]
+    #[serde(skip)]
     pub guild_id: Snowflake,
     #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub guild: Guild,
     #[cfg(feature = "sqlx")]
+    #[serde(skip)]
     pub user_id: Option<Snowflake>,
     #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub user: Option<User>,

--- a/src/types/entities/emoji.rs
+++ b/src/types/entities/emoji.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::types::entities::User;
 use crate::types::{Guild, Snowflake};
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize, Default)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 pub struct Emoji {
     pub id: Option<Snowflake>,

--- a/src/types/entities/emoji.rs
+++ b/src/types/entities/emoji.rs
@@ -1,12 +1,24 @@
 use serde::{Deserialize, Serialize};
 
 use crate::types::entities::User;
+use crate::types::{Guild, Snowflake};
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 pub struct Emoji {
-    pub id: Option<u64>,
+    pub id: Option<Snowflake>,
     pub name: Option<String>,
-    pub roles: Option<Vec<u64>>,
+    #[cfg(feature = "sqlx")]
+    pub roles: Option<sqlx::types::Json<Vec<Snowflake>>>,
+    #[cfg(not(feature = "sqlx"))]
+    pub roles: Option<Vec<Snowflake>>,
+    #[cfg(feature = "sqlx")]
+    pub guild_id: Snowflake,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
+    pub guild: Guild,
+    #[cfg(feature = "sqlx")]
+    pub user_id: Option<Snowflake>,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub user: Option<User>,
     pub require_colons: Option<bool>,
     pub managed: Option<bool>,

--- a/src/types/entities/guild.rs
+++ b/src/types/entities/guild.rs
@@ -8,7 +8,8 @@ use crate::types::{
 };
 
 /// See https://discord.com/developers/docs/resources/guild
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 pub struct Guild {
     pub id: Snowflake,
     pub name: String,
@@ -16,24 +17,27 @@ pub struct Guild {
     pub icon_hash: Option<String>,
     pub splash: Option<String>,
     pub discovery_splash: Option<String>,
-    pub owner: Option<User>,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
+    pub owner: bool, // True if requesting user is owner
     pub owner_id: Option<Snowflake>,
     pub permissions: Option<String>,
     pub afk_channel_id: Option<Snowflake>,
     pub afk_timeout: Option<u8>,
     pub widget_enabled: Option<bool>,
     pub widget_channel_id: Option<Snowflake>,
-    pub widget_channel: Option<Channel>,
     pub verification_level: Option<u8>,
     pub default_message_notifications: Option<u8>,
     pub explicit_content_filter: Option<u8>,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub roles: Vec<RoleObject>,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub emojis: Vec<Emoji>,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub features: Vec<String>,
     pub application_id: Option<String>,
     pub system_channel_id: Option<Snowflake>,
     pub system_channel_flags: Option<u8>,
-    pub rules_channel_id: Option<String>,
+    pub rules_channel_id: Option<Snowflake>,
     pub rules_channel: Option<String>,
     pub max_presences: Option<u64>,
     pub max_members: Option<u64>,
@@ -44,47 +48,48 @@ pub struct Guild {
     pub premium_subscription_count: Option<u64>,
     pub preferred_locale: Option<String>,
     pub public_updates_channel_id: Option<Snowflake>,
-    pub public_updates_channel: Option<Channel>,
     pub max_video_channel_users: Option<u8>,
     pub max_stage_video_channel_users: Option<u8>,
     pub approximate_member_count: Option<u64>,
     pub approximate_presence_count: Option<u64>,
-    pub member_count: Option<u64>,
-    pub presence_count: Option<u64>,
+    #[cfg(feature = "sqlx")]
+    pub welcome_screen: Option<sqlx::types::Json<WelcomeScreenObject>>,
+    #[cfg(not(feature = "sqlx"))]
     pub welcome_screen: Option<WelcomeScreenObject>,
     pub nsfw_level: u8,
-    pub nsfw: bool,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub stickers: Option<Vec<Sticker>>,
     pub premium_progress_bar_enabled: Option<bool>,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub joined_at: String,
-    pub afk_channel: Option<Channel>,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub bans: Option<Vec<GuildBan>>,
     pub primary_category_id: Option<Snowflake>,
     pub large: Option<bool>,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub channels: Option<Vec<Channel>>,
-    pub template_id: Option<Snowflake>,
-    pub template: Option<GuildTemplate>,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub invites: Option<Vec<GuildInvite>>,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub voice_states: Option<Vec<VoiceState>>,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub webhooks: Option<Vec<Webhook>>,
     pub mfa_level: Option<u8>,
     pub region: Option<String>,
-    pub unavailable: bool,
-    pub parent: Option<String>,
 }
 
 /// See https://docs.spacebar.chat/routes/#get-/guilds/-guild_id-/bans/-user-
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 pub struct GuildBan {
-    pub id: Snowflake,
     pub user_id: Snowflake,
     pub guild_id: Snowflake,
-    pub executor_id: Snowflake,
     pub reason: Option<String>,
 }
 
 /// See https://docs.spacebar.chat/routes/#cmp--schemas-invite
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 pub struct GuildInvite {
     pub code: String,
     pub temporary: Option<bool>,

--- a/src/types/entities/guild.rs
+++ b/src/types/entities/guild.rs
@@ -110,13 +110,13 @@ pub struct GuildInvite {
     pub vanity_url: Option<bool>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct UnavailableGuild {
     id: String,
     unavailable: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct GuildCreateResponse {
     pub id: String,
 }

--- a/src/types/entities/integration.rs
+++ b/src/types/entities/integration.rs
@@ -7,6 +7,7 @@ use crate::types::{
 };
 
 #[derive(Default, Debug, Deserialize, Serialize, Clone)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 /// See https://discord.com/developers/docs/resources/guild#integration-object-integration-structure
 pub struct Integration {
     pub id: Snowflake,
@@ -19,11 +20,14 @@ pub struct Integration {
     pub enabled_emoticons: Option<bool>,
     pub expire_behaviour: Option<u8>,
     pub expire_grace_period: Option<u16>,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub user: Option<User>,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub account: IntegrationAccount,
     pub synced_at: Option<DateTime<Utc>>,
     pub subscriber_count: Option<f64>,
     pub revoked: Option<bool>,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub application: Option<Application>,
     pub scopes: Option<Vec<String>>,
 }

--- a/src/types/entities/message.rs
+++ b/src/types/entities/message.rs
@@ -8,43 +8,62 @@ use crate::types::{
     utils::Snowflake,
 };
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 pub struct Message {
-    id: Snowflake,
+    pub id: Snowflake,
     pub channel_id: Snowflake,
-    author: User,
-    content: String,
-    timestamp: String,
-    edited_timestamp: Option<String>,
-    tts: bool,
-    mention_everyone: bool,
-    mentions: Vec<User>,
-    mention_roles: Vec<String>,
-    mention_channels: Option<Vec<ChannelMention>>,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
+    pub author: User,
+    pub content: String,
+    pub timestamp: String,
+    pub edited_timestamp: Option<String>,
+    pub tts: bool,
+    pub mention_everyone: bool,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
+    pub mentions: Vec<User>,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
+    pub mention_roles: Vec<Snowflake>,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
+    pub mention_channels: Option<Vec<ChannelMention>>,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub attachments: Vec<Attachment>,
-    embeds: Vec<Embed>,
-    reactions: Option<Vec<Reaction>>,
-    nonce: Option<serde_json::Value>,
-    pinned: bool,
-    webhook_id: Option<String>,
+    #[cfg(feature = "sqlx")]
+    pub embeds: Vec<sqlx::types::Json<Embed>>,
+    #[cfg(not(feature = "sqlx"))]
+    pub embeds: Vec<Embed>,
+    #[cfg(feature = "sqlx")]
+    pub reactions: Option<sqlx::types::Json<Vec<Reaction>>>,
+    #[cfg(not(feature = "sqlx"))]
+    pub reactions: Option<Vec<Reaction>>,
+    pub nonce: Option<serde_json::Value>,
+    pub pinned: bool,
+    pub webhook_id: Option<Snowflake>,
     #[serde(rename = "type")]
-    message_type: i32,
-    activity: Option<MessageActivity>,
-    application: Option<Application>,
-    application_id: Option<String>,
-    message_reference: Option<MessageReference>,
-    flags: Option<i32>,
-    referenced_message: Option<Box<Message>>,
-    interaction: Option<MessageInteraction>,
-    thread: Option<Channel>,
-    components: Option<Vec<Component>>,
-    sticker_items: Option<Vec<StickerItem>>,
-    stickers: Option<Vec<Sticker>>,
-    position: Option<i32>,
-    role_subscription_data: Option<RoleSubscriptionData>,
+    pub message_type: i32,
+    #[cfg(feature = "sqlx")]
+    pub activity: Option<sqlx::types::Json<MessageActivity>>,
+    #[cfg(not(feature = "sqlx"))]
+    pub activity: Option<MessageActivity>,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
+    pub application: Option<Application>,
+    pub application_id: Option<Snowflake>,
+    #[cfg(feature = "sqlx")]
+    pub message_reference: Option<sqlx::types::Json<MessageReference>>,
+    #[cfg(not(feature = "sqlx"))]
+    pub message_reference: Option<MessageReference>,
+    pub flags: Option<u64>,
+    pub referenced_message: Option<Box<Message>>,
+    pub interaction: Option<MessageInteraction>,
+    pub thread: Option<Channel>,
+    pub components: Option<Vec<Component>>,
+    pub sticker_items: Option<Vec<StickerItem>>,
+    pub stickers: Option<Vec<Sticker>>,
+    pub position: Option<i32>,
+    pub role_subscription_data: Option<RoleSubscriptionData>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct MessageReference {
     pub message_id: Snowflake,
     pub channel_id: Snowflake,
@@ -52,7 +71,7 @@ pub struct MessageReference {
     pub fail_if_not_exists: Option<bool>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 pub struct MessageInteraction {
     pub id: Snowflake,
     #[serde(rename = "type")]
@@ -62,7 +81,7 @@ pub struct MessageInteraction {
     pub member: Option<GuildMember>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct AllowedMention {
     parse: Vec<AllowedMentionType>,
     roles: Vec<Snowflake>,
@@ -70,7 +89,7 @@ pub struct AllowedMention {
     replied_user: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AllowedMentionType {
     Roles,
@@ -78,16 +97,16 @@ pub enum AllowedMentionType {
     Everyone,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-struct ChannelMention {
-    id: Snowflake,
-    guild_id: Snowflake,
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ChannelMention {
+    pub id: Snowflake,
+    pub guild_id: Snowflake,
     #[serde(rename = "type")]
     channel_type: i32,
     name: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Embed {
     title: Option<String>,
     #[serde(rename = "type")]
@@ -105,30 +124,30 @@ pub struct Embed {
     fields: Option<Vec<EmbedField>>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-struct EmbedFooter {
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct EmbedFooter {
     text: String,
     icon_url: Option<String>,
     proxy_icon_url: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-struct EmbedImage {
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct EmbedImage {
     url: String,
     proxy_url: String,
     height: Option<i32>,
     width: Option<i32>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-struct EmbedThumbnail {
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct EmbedThumbnail {
     url: String,
     proxy_url: Option<String>,
     height: Option<i32>,
     width: Option<i32>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 struct EmbedVideo {
     url: Option<String>,
     proxy_url: Option<String>,
@@ -136,29 +155,29 @@ struct EmbedVideo {
     width: Option<i32>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-struct EmbedProvider {
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct EmbedProvider {
     name: Option<String>,
     url: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-struct EmbedAuthor {
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct EmbedAuthor {
     name: String,
     url: Option<String>,
     icon_url: Option<String>,
     proxy_icon_url: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 
-struct EmbedField {
+pub struct EmbedField {
     name: String,
     value: String,
     inline: Option<bool>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Reaction {
     pub count: i32,
     pub me: bool,
@@ -177,7 +196,7 @@ pub enum Component {
     ChannelSelect = 8,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct MessageActivity {
     #[serde(rename = "type")]
     pub activity_type: i64,

--- a/src/types/entities/message.rs
+++ b/src/types/entities/message.rs
@@ -184,7 +184,7 @@ pub struct Reaction {
     pub emoji: Emoji,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
 pub enum Component {
     ActionRow = 1,
     Button = 2,

--- a/src/types/entities/role.rs
+++ b/src/types/entities/role.rs
@@ -2,7 +2,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::utils::Snowflake;
 
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 /// See https://discord.com/developers/docs/topics/permissions#role-object
 pub struct RoleObject {
     pub id: Snowflake,
@@ -19,7 +20,7 @@ pub struct RoleObject {
     //pub tags: Option<RoleTags>
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RoleSubscriptionData {
     pub role_subscription_listing_id: Snowflake,
     pub tier_name: String,

--- a/src/types/entities/security_key.rs
+++ b/src/types/entities/security_key.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::types::utils::Snowflake;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 pub struct SecurityKey {
     pub id: String,
     pub user_id: String,

--- a/src/types/entities/sticker.rs
+++ b/src/types/entities/sticker.rs
@@ -2,7 +2,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::{entities::User, utils::Snowflake};
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 pub struct Sticker {
     pub id: Snowflake,
     pub pack_id: Option<Snowflake>,
@@ -14,12 +15,13 @@ pub struct Sticker {
     pub sticker_type: u8,
     pub format_type: u8,
     pub available: Option<bool>,
-    pub guild_id: Option<u64>,
+    pub guild_id: Option<Snowflake>,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub user: Option<User>,
     pub sort_value: Option<u8>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StickerItem {
     pub id: Snowflake,
     pub name: String,

--- a/src/types/entities/team.rs
+++ b/src/types/entities/team.rs
@@ -1,20 +1,23 @@
 use serde::{Deserialize, Serialize};
 
 use crate::types::entities::User;
+use crate::types::Snowflake;
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 pub struct Team {
     pub icon: Option<String>,
-    pub id: u64,
+    pub id: Snowflake,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub members: Vec<TeamMember>,
     pub name: String,
-    pub owner_user_id: u64,
+    pub owner_user_id: Snowflake,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, PartialEq, Deserialize, Serialize, Clone)]
 pub struct TeamMember {
     pub membership_state: u8,
     pub permissions: Vec<String>,
-    pub team_id: u64,
+    pub team_id: Snowflake,
     pub user: User,
 }

--- a/src/types/entities/template.rs
+++ b/src/types/entities/template.rs
@@ -7,18 +7,21 @@ use crate::types::{
 };
 
 /// See https://docs.spacebar.chat/routes/#cmp--schemas-template
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 pub struct GuildTemplate {
     pub code: String,
     pub name: String,
     pub description: Option<String>,
     pub usage_count: Option<u64>,
     pub creator_id: Snowflake,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub creator: User,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub source_guild_id: String,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub source_guild: Vec<Guild>, // Unsure how a {recursive: Guild} looks like, might be a Vec?
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub serialized_source_guild: Vec<Guild>,
-    id: Snowflake,
 }

--- a/src/types/entities/user.rs
+++ b/src/types/entities/user.rs
@@ -49,12 +49,6 @@ pub struct User {
     pub purchased_flags: i32,
     pub premium_usage_flags: i32,
     pub disabled: Option<bool>,
-    #[cfg_attr(feature = "sqlx", sqlx(skip))]
-    pub settings: UserSettings,
-    #[cfg(feature = "sqlx")]
-    pub extended_settings: sqlx::types::Json<Value>,
-    #[cfg(not(feature = "sqlx"))]
-    pub extended_settings: Value,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/types/entities/user.rs
+++ b/src/types/entities/user.rs
@@ -1,8 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
-#[cfg(feature = "sqlx")]
-use sqlx::{FromRow, Type};
 
 use crate::types::{
     errors::Error,
@@ -10,7 +8,7 @@ use crate::types::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[cfg_attr(feature = "sqlx", derive(Type))]
+#[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 pub struct UserData {
     pub valid_tokens_since: DateTime<Utc>,
     pub hash: Option<String>,
@@ -23,32 +21,34 @@ impl User {
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 pub struct User {
     pub id: Snowflake,
-    username: String,
-    discriminator: String,
-    avatar: Option<String>,
-    bot: bool,
-    system: Option<bool>,
-    mfa_enabled: Option<bool>,
-    accent_color: Option<u8>,
-    locale: Option<String>,
-    verified: Option<bool>,
-    email: Option<String>,
-    flags: String,
-    premium_since: Option<DateTime<Utc>>,
-    premium_type: u8,
-    pronouns: Option<String>,
-    public_flags: Option<u16>,
-    banner: Option<String>,
-    bio: String,
-    theme_colors: Option<Vec<u8>>,
-    phone: Option<String>,
-    nsfw_allowed: bool,
-    premium: bool,
-    purchased_flags: i32,
-    premium_usage_flags: i32,
-    disabled: Option<bool>,
+    pub username: String,
+    pub discriminator: String,
+    pub avatar: Option<String>,
+    pub bot: bool,
+    pub system: Option<bool>,
+    pub mfa_enabled: Option<bool>,
+    pub accent_color: Option<u8>,
+    #[cfg_attr(feature = "sqlx", sqlx(default))]
+    pub locale: Option<String>,
+    pub verified: Option<bool>,
+    pub email: Option<String>,
+    pub flags: String,
+    pub premium_since: Option<DateTime<Utc>>,
+    pub premium_type: u8,
+    pub pronouns: Option<String>,
+    pub public_flags: Option<u16>,
+    pub banner: Option<String>,
+    pub bio: String,
+    pub theme_colors: Option<Vec<u8>>,
+    pub phone: Option<String>,
+    pub nsfw_allowed: bool,
+    pub premium: bool,
+    pub purchased_flags: i32,
+    pub premium_usage_flags: i32,
+    pub disabled: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -92,7 +92,7 @@ const CUSTOM_USER_FLAG_OFFSET: u64 = 1 << 32;
 
 bitflags::bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
-    #[cfg_attr(feature = "sqlx", derive(Type))]
+    #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
     pub struct UserFlags: u64 {
         const DISCORD_EMPLOYEE = 1 << 0;
         const PARTNERED_SERVER_OWNER = 1 << 1;

--- a/src/types/entities/user.rs
+++ b/src/types/entities/user.rs
@@ -2,7 +2,10 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
-use crate::types::{errors::Error, utils::Snowflake, UserSettings};
+use crate::types::{
+    errors::Error,
+    utils::Snowflake, //util::{email::adjust_email, entities::user_setting::UserSettings},
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]

--- a/src/types/entities/user.rs
+++ b/src/types/entities/user.rs
@@ -2,10 +2,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
-use crate::types::{
-    errors::Error,
-    utils::Snowflake, //util::{email::adjust_email, entities::user_setting::UserSettings},
-};
+use crate::types::{errors::Error, utils::Snowflake, UserSettings};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]

--- a/src/types/entities/user.rs
+++ b/src/types/entities/user.rs
@@ -49,6 +49,12 @@ pub struct User {
     pub purchased_flags: i32,
     pub premium_usage_flags: i32,
     pub disabled: Option<bool>,
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
+    pub settings: UserSettings,
+    #[cfg(feature = "sqlx")]
+    pub extended_settings: sqlx::types::Json<Value>,
+    #[cfg(not(feature = "sqlx"))]
+    pub extended_settings: Value,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/types/entities/user_settings.rs
+++ b/src/types/entities/user_settings.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::types::utils::Snowflake;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[serde(rename_all = "lowercase")]
 pub enum UserStatus {
     #[default]
@@ -23,6 +24,7 @@ pub enum UserTheme {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 pub struct UserSettings {
     pub afk_timeout: u16,
     pub allow_accessibility_detection: bool,
@@ -30,6 +32,9 @@ pub struct UserSettings {
     pub animate_stickers: u8,
     pub contact_sync_enabled: bool,
     pub convert_emoticons: bool,
+    #[cfg(feature = "sqlx")]
+    pub custom_status: Option<sqlx::types::Json<CustomStatus>>,
+    #[cfg(not(feature = "sqlx"))]
     pub custom_status: Option<CustomStatus>,
     pub default_guilds_restricted: bool,
     pub detect_platform_accounts: bool,
@@ -37,10 +42,19 @@ pub struct UserSettings {
     pub disable_games_tab: bool,
     pub enable_tts_command: bool,
     pub explicit_content_filter: u8,
+    #[cfg(feature = "sqlx")]
+    pub friend_source_flags: sqlx::types::Json<FriendSourceFlags>,
+    #[cfg(not(feature = "sqlx"))]
     pub friend_source_flags: FriendSourceFlags,
     pub gateway_connected: bool,
     pub gif_auto_play: bool,
+    #[cfg(feature = "sqlx")]
+    pub guild_folders: sqlx::types::Json<Vec<GuildFolder>>,
+    #[cfg(not(feature = "sqlx"))]
     pub guild_folders: Vec<GuildFolder>,
+    #[cfg(feature = "sqlx")]
+    pub guild_positions: sqlx::types::Json<Vec<String>>,
+    #[cfg(not(feature = "sqlx"))]
     pub guild_positions: Vec<String>,
     pub inline_attachment_media: bool,
     pub inline_embed_media: bool,
@@ -49,6 +63,9 @@ pub struct UserSettings {
     pub native_phone_integration_enabled: bool,
     pub render_embeds: bool,
     pub render_reactions: bool,
+    #[cfg(feature = "sqlx")]
+    pub restricted_guilds: sqlx::types::Json<Vec<String>>,
+    #[cfg(not(feature = "sqlx"))]
     pub restricted_guilds: Vec<String>,
     pub show_current_game: bool,
     pub status: UserStatus,
@@ -73,11 +90,11 @@ impl Default for UserSettings {
             disable_games_tab: true,
             enable_tts_command: false,
             explicit_content_filter: 0,
-            friend_source_flags: FriendSourceFlags::default(),
+            friend_source_flags: Default::default(),
             gateway_connected: false,
             gif_auto_play: false,
-            guild_folders: Vec::new(),
-            guild_positions: Vec::new(),
+            guild_folders: Default::default(),
+            guild_positions: Default::default(),
             inline_attachment_media: true,
             inline_embed_media: true,
             locale: "en-US".to_string(),
@@ -85,7 +102,7 @@ impl Default for UserSettings {
             native_phone_integration_enabled: true,
             render_embeds: true,
             render_reactions: true,
-            restricted_guilds: Vec::new(),
+            restricted_guilds: Default::default(),
             show_current_game: true,
             status: UserStatus::Online,
             stream_notifications_enabled: false,
@@ -96,6 +113,7 @@ impl Default for UserSettings {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 pub struct CustomStatus {
     pub emoji_id: Option<String>,
     pub emoji_name: Option<String>,

--- a/src/types/entities/user_settings.rs
+++ b/src/types/entities/user_settings.rs
@@ -16,6 +16,7 @@ pub enum UserStatus {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[serde(rename_all = "lowercase")]
 pub enum UserTheme {
     #[default]

--- a/src/types/entities/voice_state.rs
+++ b/src/types/entities/voice_state.rs
@@ -7,17 +7,14 @@ use crate::types::{
 };
 
 /// See https://docs.spacebar.chat/routes/#cmp--schemas-voicestate
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 pub struct VoiceState {
     pub guild_id: Snowflake,
-    pub guild: Option<Guild>,
     pub channel_id: Snowflake,
-    pub channel: Option<Channel>,
     pub user_id: Snowflake,
-    pub user: Option<User>,
     pub member: Option<GuildMember>,
     pub session_id: Snowflake,
-    pub token: String,
     pub deaf: bool,
     pub mute: bool,
     pub self_deaf: bool,
@@ -26,5 +23,4 @@ pub struct VoiceState {
     pub self_video: bool,
     pub suppress: bool,
     pub request_to_speak_timestamp: Option<DateTime<Utc>>,
-    pub id: Snowflake,
 }

--- a/src/types/entities/webhook.rs
+++ b/src/types/entities/webhook.rs
@@ -6,27 +6,24 @@ use crate::types::{
 };
 
 /// See https://docs.spacebar.chat/routes/#cmp--schemas-webhook
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 pub struct Webhook {
+    pub id: Snowflake,
     #[serde(rename = "type")]
     pub webhook_type: i32,
     pub name: String,
     pub avatar: String,
     pub token: String,
     pub guild_id: Snowflake,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub guild: Option<Guild>,
     pub channel_id: Snowflake,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub channel: Option<Channel>,
     pub application_id: Snowflake,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub application: Option<Application>,
-    pub user_id: Snowflake,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub user: Option<User>,
-    pub source_guild_id: Snowflake,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub source_guild: Option<Guild>,
-    pub id: Snowflake,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
 }

--- a/src/types/interfaces/guild_welcome_screen.rs
+++ b/src/types/interfaces/guild_welcome_screen.rs
@@ -1,14 +1,14 @@
 use crate::types::utils::Snowflake;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct WelcomeScreenObject {
     pub enabled: bool,
     pub description: Option<String>,
     pub welcome_channels: Vec<WelcomeScreenChannel>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct WelcomeScreenChannel {
     pub channel_id: Snowflake,
     pub description: String,


### PR DESCRIPTION
This commit edit's almost all of the type structs, 
- Adding additional derives like PartialEq, Clone, and Copy to enums.
- Adding feature locks to swap between field types
- Extracts some fields that are only used on the server side of things
