### PR TITLE
Refactor/limited requester

### DIFF
--- a/src/api/auth/login.rs
+++ b/src/api/auth/login.rs
@@ -15,7 +15,6 @@ impl Instance {
         &mut self,
         login_schema: &LoginSchema,
     ) -> Result<UserMeta, ChorusLibError> {
-        let mut requester = LimitedRequester;
         let json_schema = json!(login_schema);
         let client = Client::new();
         let endpoint_url = self.urls.get_api().to_string() + "/auth/login";

--- a/src/api/auth/login.rs
+++ b/src/api/auth/login.rs
@@ -15,7 +15,7 @@ impl Instance {
         &mut self,
         login_schema: &LoginSchema,
     ) -> Result<UserMeta, ChorusLibError> {
-        let mut requester = LimitedRequester::new().await;
+        let mut requester = LimitedRequester;
         let json_schema = json!(login_schema);
         let client = Client::new();
         let endpoint_url = self.urls.get_api().to_string() + "/auth/login";
@@ -24,14 +24,13 @@ impl Instance {
         // request (since login is an instance wide limit), which is why we are just cloning the
         // instances' limits to pass them on as user_rate_limits later.
         let mut cloned_limits = self.limits.clone();
-        let response = requester
-            .send_request(
-                request_builder,
-                LimitType::AuthRegister,
-                &mut self.limits,
-                &mut cloned_limits,
-            )
-            .await;
+        let response = LimitedRequester::send_request(
+            request_builder,
+            LimitType::AuthRegister,
+            &mut self.limits,
+            &mut cloned_limits,
+        )
+        .await;
         if response.is_err() {
             return Err(ChorusLibError::NoResponse);
         }

--- a/src/api/auth/register.rs
+++ b/src/api/auth/register.rs
@@ -24,7 +24,6 @@ impl Instance {
         register_schema: &RegisterSchema,
     ) -> Result<UserMeta, ChorusLibError> {
         let json_schema = json!(register_schema);
-        let mut limited_requester = LimitedRequester::new().await;
         let client = Client::new();
         let endpoint_url = self.urls.get_api().to_string() + "/auth/register";
         let request_builder = client.post(endpoint_url).body(json_schema.to_string());
@@ -32,14 +31,13 @@ impl Instance {
         // request (since register is an instance wide limit), which is why we are just cloning
         // the instances' limits to pass them on as user_rate_limits later.
         let mut cloned_limits = self.limits.clone();
-        let response = limited_requester
-            .send_request(
-                request_builder,
-                LimitType::AuthRegister,
-                &mut self.limits,
-                &mut cloned_limits,
-            )
-            .await;
+        let response = LimitedRequester::send_request(
+            request_builder,
+            LimitType::AuthRegister,
+            &mut self.limits,
+            &mut cloned_limits,
+        )
+        .await;
         if response.is_err() {
             return Err(ChorusLibError::NoResponse);
         }

--- a/src/api/channels/permissions.rs
+++ b/src/api/channels/permissions.rs
@@ -5,7 +5,6 @@ use crate::{
     api::handle_request,
     errors::ChorusLibError,
     instance::UserMeta,
-    limit::LimitedRequester,
     types::{self, PermissionOverwrite},
 };
 

--- a/src/api/common.rs
+++ b/src/api/common.rs
@@ -13,15 +13,13 @@ pub async fn handle_request(
     limit_type: LimitType,
 ) -> Result<reqwest::Response, crate::errors::ChorusLibError> {
     let mut belongs_to = user.belongs_to.borrow_mut();
-    match LimitedRequester::new()
-        .await
-        .send_request(
-            request,
-            limit_type,
-            &mut belongs_to.limits,
-            &mut user.limits,
-        )
-        .await
+    match LimitedRequester::send_request(
+        request,
+        limit_type,
+        &mut belongs_to.limits,
+        &mut user.limits,
+    )
+    .await
     {
         Ok(response) => return Ok(response),
         Err(e) => return Err(e),

--- a/src/api/guilds/guilds.rs
+++ b/src/api/guilds/guilds.rs
@@ -180,15 +180,13 @@ impl Guild {
         let request = Client::new()
             .get(format!("{}/guilds/{}/", url_api, guild_id))
             .bearer_auth(token);
-        let response = match LimitedRequester::new()
-            .await
-            .send_request(
-                request,
-                crate::api::limits::LimitType::Guild,
-                limits_instance,
-                limits_user,
-            )
-            .await
+        let response = match LimitedRequester::send_request(
+            request,
+            crate::api::limits::LimitType::Guild,
+            limits_instance,
+            limits_user,
+        )
+        .await
         {
             Ok(response) => response,
             Err(e) => return Err(e),
@@ -242,15 +240,13 @@ impl Channel {
             .post(format!("{}/guilds/{}/channels/", url_api, guild_id))
             .bearer_auth(token)
             .body(to_string(&schema).unwrap());
-        let mut requester = LimitedRequester::new().await;
-        let result = match requester
-            .send_request(
-                request,
-                crate::api::limits::LimitType::Guild,
-                limits_instance,
-                limits_user,
-            )
-            .await
+        let result = match LimitedRequester::send_request(
+            request,
+            crate::api::limits::LimitType::Guild,
+            limits_instance,
+            limits_user,
+        )
+        .await
         {
             Ok(result) => result,
             Err(e) => return Err(e),

--- a/src/api/guilds/member.rs
+++ b/src/api/guilds/member.rs
@@ -1,11 +1,10 @@
 use reqwest::Client;
-use serde_json::from_str;
+
 
 use crate::{
     api::{deserialize_response, handle_request_as_option},
     errors::ChorusLibError,
     instance::UserMeta,
-    limit::LimitedRequester,
     types,
 };
 

--- a/src/api/guilds/member.rs
+++ b/src/api/guilds/member.rs
@@ -1,6 +1,5 @@
 use reqwest::Client;
 
-
 use crate::{
     api::{deserialize_response, handle_request_as_option},
     errors::ChorusLibError,

--- a/src/api/guilds/roles.rs
+++ b/src/api/guilds/roles.rs
@@ -1,11 +1,10 @@
 use reqwest::Client;
-use serde_json::{from_str, to_string};
+use serde_json::{to_string};
 
 use crate::{
     api::deserialize_response,
     errors::ChorusLibError,
     instance::UserMeta,
-    limit::LimitedRequester,
     types::{self, RoleCreateModifySchema, RoleObject},
 };
 

--- a/src/api/guilds/roles.rs
+++ b/src/api/guilds/roles.rs
@@ -1,5 +1,5 @@
 use reqwest::Client;
-use serde_json::{to_string};
+use serde_json::to_string;
 
 use crate::{
     api::deserialize_response,

--- a/src/api/users/users.rs
+++ b/src/api/users/users.rs
@@ -1,5 +1,5 @@
 use reqwest::Client;
-use serde_json::{from_str, to_string};
+use serde_json::{to_string};
 
 use crate::{
     api::{deserialize_response, handle_request_as_option, limits::Limits},

--- a/src/api/users/users.rs
+++ b/src/api/users/users.rs
@@ -110,16 +110,14 @@ impl User {
             url = format!("{}/users/{}", url_api, id.unwrap());
         }
         let request = reqwest::Client::new().get(url).bearer_auth(token);
-        let mut requester = crate::limit::LimitedRequester::new().await;
         let mut cloned_limits = limits_instance.clone();
-        match requester
-            .send_request(
-                request,
-                crate::api::limits::LimitType::Ip,
-                limits_instance,
-                &mut cloned_limits,
-            )
-            .await
+        match LimitedRequester::send_request(
+            request,
+            crate::api::limits::LimitType::Ip,
+            limits_instance,
+            &mut cloned_limits,
+        )
+        .await
         {
             Ok(result) => {
                 let result_text = result.text().await.unwrap();
@@ -138,15 +136,13 @@ impl User {
             .get(format!("{}/users/@me/settings/", url_api))
             .bearer_auth(token);
         let mut cloned_limits = instance_limits.clone();
-        let mut requester = crate::limit::LimitedRequester::new().await;
-        match requester
-            .send_request(
-                request,
-                crate::api::limits::LimitType::Ip,
-                instance_limits,
-                &mut cloned_limits,
-            )
-            .await
+        match LimitedRequester::send_request(
+            request,
+            crate::api::limits::LimitType::Ip,
+            instance_limits,
+            &mut cloned_limits,
+        )
+        .await
         {
             Ok(result) => Ok(serde_json::from_str(&result.text().await.unwrap()).unwrap()),
             Err(e) => Err(e),

--- a/src/api/users/users.rs
+++ b/src/api/users/users.rs
@@ -1,5 +1,5 @@
 use reqwest::Client;
-use serde_json::{to_string};
+use serde_json::to_string;
 
 use crate::{
     api::{deserialize_response, handle_request_as_option, limits::Limits},

--- a/src/limit.rs
+++ b/src/limit.rs
@@ -305,7 +305,7 @@ mod rate_limit {
         );
         let mut instance_rate_limits = Limits::check_limits(urls.api.clone()).await;
         let mut user_rate_limits = Limits::check_limits(urls.api.clone()).await;
-        let mut requester = LimitedRequester;
+        let _requester = LimitedRequester;
         let request_path = urls.api.clone() + "/policies/instance/limits";
         let request_builder = Client::new().get(request_path);
         let request = LimitedRequester::send_request(


### PR DESCRIPTION
This PR includes a small refactor for the Request limiter. It removes the need to instantiate the Request limiter and removes some outdated code.