### PR TITLE
UrlBundle remove getters

### DIFF
--- a/src/api/auth/login.rs
+++ b/src/api/auth/login.rs
@@ -17,7 +17,7 @@ impl Instance {
     ) -> Result<UserMeta, ChorusLibError> {
         let json_schema = json!(login_schema);
         let client = Client::new();
-        let endpoint_url = self.urls.get_api().to_string() + "/auth/login";
+        let endpoint_url = self.urls.api.clone() + "/auth/login";
         let request_builder = client.post(endpoint_url).body(json_schema.to_string());
         // We do not have a user yet, and the UserRateLimits will not be affected by a login
         // request (since login is an instance wide limit), which is why we are just cloning the

--- a/src/api/auth/register.rs
+++ b/src/api/auth/register.rs
@@ -25,7 +25,7 @@ impl Instance {
     ) -> Result<UserMeta, ChorusLibError> {
         let json_schema = json!(register_schema);
         let client = Client::new();
-        let endpoint_url = self.urls.get_api().to_string() + "/auth/register";
+        let endpoint_url = self.urls.api.clone() + "/auth/register";
         let request_builder = client.post(endpoint_url).body(json_schema.to_string());
         // We do not have a user yet, and the UserRateLimits will not be affected by a login
         // request (since register is an instance wide limit), which is why we are just cloning
@@ -59,10 +59,9 @@ impl Instance {
             return Err(ChorusLibError::InvalidFormBodyError { error_type, error });
         }
         let user_object = self.get_user(token.clone(), None).await.unwrap();
-        let settings =
-            UserMeta::get_settings(&token, &self.urls.get_api().to_string(), &mut self.limits)
-                .await
-                .unwrap();
+        let settings = UserMeta::get_settings(&token, &self.urls.api, &mut self.limits)
+            .await
+            .unwrap();
         let user = UserMeta::new(
             Rc::new(RefCell::new(self.clone())),
             token.clone(),

--- a/src/api/channels/channels.rs
+++ b/src/api/channels/channels.rs
@@ -10,7 +10,7 @@ use crate::{
 
 impl Channel {
     pub async fn get(user: &mut UserMeta, channel_id: &str) -> Result<Channel, ChorusLibError> {
-        let url = user.belongs_to.borrow_mut().urls.get_api().to_string();
+        let url = user.belongs_to.borrow_mut().urls.api.clone();
         let request = Client::new()
             .get(format!("{}/channels/{}/", url, channel_id))
             .bearer_auth(user.token());
@@ -47,7 +47,7 @@ impl Channel {
         let request = Client::new()
             .delete(format!(
                 "{}/channels/{}/",
-                user.belongs_to.borrow_mut().urls.get_api(),
+                user.belongs_to.borrow_mut().urls.api,
                 self.id
             ))
             .bearer_auth(user.token());
@@ -78,7 +78,7 @@ impl Channel {
         let request = Client::new()
             .patch(format!(
                 "{}/channels/{}/",
-                user.belongs_to.borrow().urls.get_api(),
+                user.belongs_to.borrow().urls.api,
                 channel_id
             ))
             .bearer_auth(user.token())

--- a/src/api/channels/messages.rs
+++ b/src/api/channels/messages.rs
@@ -25,7 +25,7 @@ impl Message {
         message: &mut MessageSendSchema,
         files: Option<Vec<PartialDiscordFileAttachment>>,
     ) -> Result<Message, crate::errors::ChorusLibError> {
-        let url_api = user.belongs_to.borrow().urls.get_api().to_string();
+        let url_api = user.belongs_to.borrow().urls.api.clone();
 
         if files.is_none() {
             let request = Client::new()

--- a/src/api/channels/permissions.rs
+++ b/src/api/channels/permissions.rs
@@ -28,7 +28,7 @@ impl types::Channel {
         let url = {
             format!(
                 "{}/channels/{}/permissions/{}",
-                user.belongs_to.borrow_mut().urls.get_api(),
+                user.belongs_to.borrow_mut().urls.api,
                 channel_id,
                 overwrite.id
             )
@@ -68,7 +68,7 @@ impl types::Channel {
     ) -> Option<ChorusLibError> {
         let url = format!(
             "{}/channels/{}/permissions/{}",
-            user.belongs_to.borrow_mut().urls.get_api(),
+            user.belongs_to.borrow_mut().urls.api,
             channel_id,
             overwrite_id
         );

--- a/src/api/channels/reactions.rs
+++ b/src/api/channels/reactions.rs
@@ -33,7 +33,7 @@ impl ReactionMeta {
     pub async fn delete_all(&self, user: &mut UserMeta) -> Option<ChorusLibError> {
         let url = format!(
             "{}/channels/{}/messages/{}/reactions/",
-            user.belongs_to.borrow().urls.get_api(),
+            user.belongs_to.borrow().urls.api,
             self.channel_id,
             self.message_id
         );
@@ -64,7 +64,7 @@ impl ReactionMeta {
     pub async fn get(&self, emoji: &str, user: &mut UserMeta) -> Option<ChorusLibError> {
         let url = format!(
             "{}/channels/{}/messages/{}/reactions/{}/",
-            user.belongs_to.borrow().urls.get_api(),
+            user.belongs_to.borrow().urls.api,
             self.channel_id,
             self.message_id,
             emoji
@@ -98,7 +98,7 @@ impl ReactionMeta {
     pub async fn delete_emoji(&self, emoji: &str, user: &mut UserMeta) -> Option<ChorusLibError> {
         let url = format!(
             "{}/channels/{}/messages/{}/reactions/{}/",
-            user.belongs_to.borrow().urls.get_api(),
+            user.belongs_to.borrow().urls.api,
             self.channel_id,
             self.message_id,
             emoji
@@ -136,7 +136,7 @@ impl ReactionMeta {
     pub async fn create(&self, emoji: &str, user: &mut UserMeta) -> Option<ChorusLibError> {
         let url = format!(
             "{}/channels/{}/messages/{}/reactions/{}/@me/",
-            user.belongs_to.borrow().urls.get_api(),
+            user.belongs_to.borrow().urls.api,
             self.channel_id,
             self.message_id,
             emoji
@@ -165,7 +165,7 @@ impl ReactionMeta {
     pub async fn remove(&self, emoji: &str, user: &mut UserMeta) -> Option<ChorusLibError> {
         let url = format!(
             "{}/channels/{}/messages/{}/reactions/{}/@me/",
-            user.belongs_to.borrow().urls.get_api(),
+            user.belongs_to.borrow().urls.api,
             self.channel_id,
             self.message_id,
             emoji
@@ -202,7 +202,7 @@ impl ReactionMeta {
     ) -> Option<ChorusLibError> {
         let url = format!(
             "{}/channels/{}/messages/{}/reactions/{}/{}",
-            user.belongs_to.borrow().urls.get_api(),
+            user.belongs_to.borrow().urls.api,
             self.channel_id,
             self.message_id,
             emoji,

--- a/src/api/guilds/guilds.rs
+++ b/src/api/guilds/guilds.rs
@@ -32,7 +32,7 @@ impl Guild {
         user: &mut UserMeta,
         guild_create_schema: GuildCreateSchema,
     ) -> Result<Guild, ChorusLibError> {
-        let url = format!("{}/guilds/", user.belongs_to.borrow().urls.get_api());
+        let url = format!("{}/guilds/", user.belongs_to.borrow().urls.api);
         let request = reqwest::Client::new()
             .post(url.clone())
             .bearer_auth(user.token.clone())
@@ -67,7 +67,7 @@ impl Guild {
     pub async fn delete(user: &mut UserMeta, guild_id: &str) -> Option<ChorusLibError> {
         let url = format!(
             "{}/guilds/{}/delete/",
-            user.belongs_to.borrow().urls.get_api(),
+            user.belongs_to.borrow().urls.api,
             guild_id
         );
         let request = reqwest::Client::new()
@@ -97,7 +97,7 @@ impl Guild {
         let mut belongs_to = user.belongs_to.borrow_mut();
         Channel::_create(
             &user.token,
-            &format!("{}", belongs_to.urls.get_api()),
+            &format!("{}", belongs_to.urls.api),
             &self.id.to_string(),
             schema,
             &mut user.limits,
@@ -119,7 +119,7 @@ impl Guild {
         let request = Client::new()
             .get(format!(
                 "{}/guilds/{}/channels/",
-                user.belongs_to.borrow().urls.get_api(),
+                user.belongs_to.borrow().urls.api,
                 self.id
             ))
             .bearer_auth(user.token());
@@ -157,7 +157,7 @@ impl Guild {
     pub async fn get(user: &mut UserMeta, guild_id: &str) -> Result<Guild, ChorusLibError> {
         let mut belongs_to = user.belongs_to.borrow_mut();
         Guild::_get(
-            &format!("{}", belongs_to.urls.get_api()),
+            &format!("{}", belongs_to.urls.api),
             guild_id,
             &user.token,
             &mut user.limits,
@@ -217,7 +217,7 @@ impl Channel {
         let mut belongs_to = user.belongs_to.borrow_mut();
         Channel::_create(
             &user.token,
-            &format!("{}", belongs_to.urls.get_api()),
+            &format!("{}", belongs_to.urls.api),
             guild_id,
             schema,
             &mut user.limits,

--- a/src/api/guilds/member.rs
+++ b/src/api/guilds/member.rs
@@ -26,7 +26,7 @@ impl types::GuildMember {
     ) -> Result<types::GuildMember, ChorusLibError> {
         let url = format!(
             "{}/guilds/{}/members/{}/",
-            user.belongs_to.borrow().urls.get_api(),
+            user.belongs_to.borrow().urls.api,
             guild_id,
             member_id
         );
@@ -59,7 +59,7 @@ impl types::GuildMember {
     ) -> Option<ChorusLibError> {
         let url = format!(
             "{}/guilds/{}/members/{}/roles/{}/",
-            user.belongs_to.borrow().urls.get_api(),
+            user.belongs_to.borrow().urls.api,
             guild_id,
             member_id,
             role_id
@@ -88,7 +88,7 @@ impl types::GuildMember {
     ) -> Option<crate::errors::ChorusLibError> {
         let url = format!(
             "{}/guilds/{}/members/{}/roles/{}/",
-            user.belongs_to.borrow().urls.get_api(),
+            user.belongs_to.borrow().urls.api,
             guild_id,
             member_id,
             role_id

--- a/src/api/guilds/roles.rs
+++ b/src/api/guilds/roles.rs
@@ -29,7 +29,7 @@ impl types::RoleObject {
     ) -> Result<Option<Vec<RoleObject>>, ChorusLibError> {
         let url = format!(
             "{}/guilds/{}/roles/",
-            user.belongs_to.borrow().urls.get_api(),
+            user.belongs_to.borrow().urls.api,
             guild_id
         );
         let request = Client::new().get(url).bearer_auth(user.token());
@@ -68,7 +68,7 @@ impl types::RoleObject {
     ) -> Result<RoleObject, ChorusLibError> {
         let url = format!(
             "{}/guilds/{}/roles/{}/",
-            user.belongs_to.borrow().urls.get_api(),
+            user.belongs_to.borrow().urls.api,
             guild_id,
             role_id
         );
@@ -98,7 +98,7 @@ impl types::RoleObject {
     ) -> Result<RoleObject, ChorusLibError> {
         let url = format!(
             "{}/guilds/{}/roles/",
-            user.belongs_to.borrow().urls.get_api(),
+            user.belongs_to.borrow().urls.api,
             guild_id
         );
         let body = to_string::<RoleCreateModifySchema>(&role_create_schema).map_err(|e| {
@@ -132,7 +132,7 @@ impl types::RoleObject {
     ) -> Result<RoleObject, ChorusLibError> {
         let url = format!(
             "{}/guilds/{}/roles/",
-            user.belongs_to.borrow().urls.get_api(),
+            user.belongs_to.borrow().urls.api,
             guild_id
         );
         let body = to_string(&role_position_update_schema).map_err(|e| {
@@ -172,7 +172,7 @@ impl types::RoleObject {
     ) -> Result<RoleObject, ChorusLibError> {
         let url = format!(
             "{}/guilds/{}/roles/{}",
-            user.belongs_to.borrow().urls.get_api(),
+            user.belongs_to.borrow().urls.api,
             guild_id,
             role_id
         );

--- a/src/api/policies/instance/instance.rs
+++ b/src/api/policies/instance/instance.rs
@@ -15,7 +15,7 @@ impl Instance {
         &self,
     ) -> Result<GeneralConfiguration, ChorusLibError> {
         let client = Client::new();
-        let endpoint_url = self.urls.get_api().to_string() + "/policies/instance/";
+        let endpoint_url = self.urls.api.clone() + "/policies/instance/";
         let request = match client.get(&endpoint_url).send().await {
             Ok(result) => result,
             Err(e) => {
@@ -33,7 +33,6 @@ impl Instance {
         }
 
         let body = request.text().await.unwrap();
-        let instance_policies_schema: GeneralConfiguration = from_str(&body).unwrap();
-        Ok(instance_policies_schema)
+        Ok(from_str::<GeneralConfiguration>(&body).unwrap())
     }
 }

--- a/src/api/policies/instance/limits.rs
+++ b/src/api/policies/instance/limits.rs
@@ -311,7 +311,7 @@ pub mod limits {
         /// TODO: Change this to return a Result and handle the errors properly.
         pub async fn check_limits(api_url: String) -> Limits {
             let client = Client::new();
-            let url_parsed = crate::URLBundle::parse_url(api_url) + "/policies/instance/limits";
+            let url_parsed = crate::UrlBundle::parse_url(api_url) + "/policies/instance/limits";
             let result = client
                 .get(url_parsed)
                 .send()

--- a/src/api/users/relationships.rs
+++ b/src/api/users/relationships.rs
@@ -23,7 +23,7 @@ impl UserMeta {
     ) -> Result<Vec<types::PublicUser>, ChorusLibError> {
         let url = format!(
             "{}/users/{}/relationships/",
-            self.belongs_to.borrow().urls.get_api(),
+            self.belongs_to.borrow().urls.api,
             user_id
         );
         let request = Client::new().get(url).bearer_auth(self.token());
@@ -42,7 +42,7 @@ impl UserMeta {
     pub async fn get_relationships(&mut self) -> Result<Vec<types::Relationship>, ChorusLibError> {
         let url = format!(
             "{}/users/@me/relationships/",
-            self.belongs_to.borrow().urls.get_api()
+            self.belongs_to.borrow().urls.api
         );
         let request = Client::new().get(url).bearer_auth(self.token());
         deserialize_response::<Vec<types::Relationship>>(
@@ -67,7 +67,7 @@ impl UserMeta {
     ) -> Option<ChorusLibError> {
         let url = format!(
             "{}/users/@me/relationships/",
-            self.belongs_to.borrow().urls.get_api()
+            self.belongs_to.borrow().urls.api
         );
         let body = to_string(&schema).unwrap();
         let request = Client::new().post(url).bearer_auth(self.token()).body(body);
@@ -140,7 +140,7 @@ impl UserMeta {
     pub async fn remove_relationship(&mut self, user_id: &str) -> Option<ChorusLibError> {
         let url = format!(
             "{}/users/@me/relationships/{}/",
-            self.belongs_to.borrow().urls.get_api(),
+            self.belongs_to.borrow().urls.api,
             user_id
         );
         let request = Client::new().delete(url).bearer_auth(self.token());

--- a/src/api/users/users.rs
+++ b/src/api/users/users.rs
@@ -52,10 +52,7 @@ impl UserMeta {
             return Err(ChorusLibError::PasswordRequiredError);
         }
         let request = Client::new()
-            .patch(format!(
-                "{}/users/@me/",
-                self.belongs_to.borrow().urls.get_api()
-            ))
+            .patch(format!("{}/users/@me/", self.belongs_to.borrow().urls.api))
             .body(to_string(&modify_schema).unwrap())
             .bearer_auth(self.token());
         let user_updated =
@@ -79,7 +76,7 @@ impl UserMeta {
         let request = Client::new()
             .post(format!(
                 "{}/users/@me/delete/",
-                self.belongs_to.borrow().urls.get_api()
+                self.belongs_to.borrow().urls.api
             ))
             .bearer_auth(self.token());
         handle_request_as_option(request, &mut self, crate::api::limits::LimitType::Ip).await
@@ -91,7 +88,7 @@ impl User {
         let mut belongs_to = user.belongs_to.borrow_mut();
         User::_get(
             &user.token(),
-            &format!("{}", belongs_to.urls.get_api()),
+            &format!("{}", belongs_to.urls.api),
             &mut belongs_to.limits,
             id,
         )
@@ -166,6 +163,6 @@ impl Instance {
         token: String,
         id: Option<&String>,
     ) -> Result<User, ChorusLibError> {
-        User::_get(&token, self.urls.get_api(), &mut self.limits, id).await
+        User::_get(&token, &self.urls.api, &mut self.limits, id).await
     }
 }

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -7,14 +7,14 @@ use serde::{Deserialize, Serialize};
 use crate::api::limits::Limits;
 use crate::errors::{ChorusLibError, FieldFormatError};
 use crate::types::{GeneralConfiguration, User, UserSettings};
-use crate::URLBundle;
+use crate::UrlBundle;
 
 #[derive(Debug, Clone)]
 /**
 The [`Instance`] what you will be using to perform all sorts of actions on the Spacebar server.
  */
 pub struct Instance {
-    pub urls: URLBundle,
+    pub urls: UrlBundle,
     pub instance_info: GeneralConfiguration,
     pub limits: Limits,
 }
@@ -26,7 +26,7 @@ impl Instance {
     /// * `requester` - The [`LimitedRequester`] that will be used to make requests to the Spacebar server.
     /// # Errors
     /// * [`InstanceError`] - If the instance cannot be created.
-    pub async fn new(urls: URLBundle) -> Result<Instance, ChorusLibError> {
+    pub async fn new(urls: UrlBundle) -> Result<Instance, ChorusLibError> {
         let mut instance = Instance {
             urls: urls.clone(),
             // Will be overwritten in the next step

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,18 +18,18 @@ pub mod voice;
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
 /// A URLBundle is a struct which bundles together the API-, Gateway- and CDN-URLs of a Spacebar
 /// instance.
-pub struct URLBundle {
+pub struct UrlBundle {
     pub api: String,
     pub wss: String,
     pub cdn: String,
 }
 
-impl URLBundle {
+impl UrlBundle {
     pub fn new(api: String, wss: String, cdn: String) -> Self {
         Self {
-            api: URLBundle::parse_url(api),
-            wss: URLBundle::parse_url(wss),
-            cdn: URLBundle::parse_url(cdn),
+            api: UrlBundle::parse_url(api),
+            wss: UrlBundle::parse_url(wss),
+            cdn: UrlBundle::parse_url(cdn),
         }
     }
 
@@ -44,13 +44,13 @@ impl URLBundle {
         let url = match Url::parse(&url) {
             Ok(url) => {
                 if url.scheme() == "localhost" {
-                    return URLBundle::parse_url(format!("http://{}", url));
+                    return UrlBundle::parse_url(format!("http://{}", url));
                 }
                 url
             }
             Err(ParseError::RelativeUrlWithoutBase) => {
                 let url_fmt = format!("http://{}", url);
-                return URLBundle::parse_url(url_fmt);
+                return UrlBundle::parse_url(url_fmt);
             }
             Err(_) => panic!("Invalid URL"),
         };
@@ -61,18 +61,6 @@ impl URLBundle {
         }
         url_string
     }
-
-    pub fn get_api(&self) -> &str {
-        &self.api
-    }
-
-    pub fn get_cdn(&self) -> &str {
-        &self.cdn
-    }
-
-    pub fn get_wss(&self) -> &str {
-        &self.wss
-    }
 }
 
 #[cfg(test)]
@@ -81,13 +69,13 @@ mod lib {
 
     #[test]
     fn test_parse_url() {
-        let mut result = URLBundle::parse_url(String::from("localhost:3000/"));
+        let mut result = UrlBundle::parse_url(String::from("localhost:3000/"));
         assert_eq!(result, String::from("http://localhost:3000"));
-        result = URLBundle::parse_url(String::from("https://some.url.com/"));
+        result = UrlBundle::parse_url(String::from("https://some.url.com/"));
         assert_eq!(result, String::from("https://some.url.com"));
-        result = URLBundle::parse_url(String::from("https://some.url.com/"));
+        result = UrlBundle::parse_url(String::from("https://some.url.com/"));
         assert_eq!(result, String::from("https://some.url.com"));
-        result = URLBundle::parse_url(String::from("https://some.url.com"));
+        result = UrlBundle::parse_url(String::from("https://some.url.com"));
         assert_eq!(result, String::from("https://some.url.com"));
     }
 }

--- a/src/limit.rs
+++ b/src/limit.rs
@@ -256,13 +256,13 @@ impl LimitedRequester {
 mod rate_limit {
     use serde_json::from_str;
 
-    use crate::{api::limits::Config, URLBundle};
+    use crate::{api::limits::Config, UrlBundle};
 
     use super::*;
 
     #[tokio::test]
     async fn run_into_limit() {
-        let urls = URLBundle::new(
+        let urls = UrlBundle::new(
             String::from("http://localhost:3001/api/"),
             String::from("wss://localhost:3001/"),
             String::from("http://localhost:3001/cdn"),
@@ -289,7 +289,7 @@ mod rate_limit {
 
     #[tokio::test]
     async fn test_send_request() {
-        let urls = URLBundle::new(
+        let urls = UrlBundle::new(
             String::from("http://localhost:3001/api/"),
             String::from("wss://localhost:3001/"),
             String::from("http://localhost:3001/cdn"),

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,12 +4,12 @@ use chorus::{
         Channel, ChannelCreateSchema, Guild, GuildCreateSchema, RegisterSchema,
         RegisterSchemaOptions, RoleCreateModifySchema, RoleObject,
     },
-    URLBundle,
+    UrlBundle,
 };
 
 #[derive(Debug)]
 pub struct TestBundle {
-    pub urls: URLBundle,
+    pub urls: UrlBundle,
     pub user: UserMeta,
     pub instance: Instance,
     pub guild: Guild,
@@ -19,7 +19,7 @@ pub struct TestBundle {
 
 // Set up a test by creating an Instance and a User. Reduces Test boilerplate.
 pub async fn setup() -> TestBundle {
-    let urls = URLBundle::new(
+    let urls = UrlBundle::new(
         "http://localhost:3001/api".to_string(),
         "ws://localhost:3001".to_string(),
         "http://localhost:3001".to_string(),


### PR DESCRIPTION
The fields are public, so no getters necessary.

Also renamed `URLBundle` to `UrlBundle` to stay in line with the [rust api guidelines](https://rust-lang.github.io/api-guidelines/naming.html). Note that if getters were necessary, they recommend omitting the `get_` prefix.