### PR TITLE
remove WebSocketEvent

### DIFF
--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -2,7 +2,6 @@ use crate::errors::GatewayError;
 use crate::errors::ObserverError;
 use crate::gateway::events::Events;
 use crate::types;
-use crate::types::WebSocketEvent;
 use std::sync::Arc;
 
 use futures_util::stream::SplitSink;
@@ -385,7 +384,7 @@ impl Gateway {
 
     /// Deserializes and updates a dispatched event, when we already know its type;
     /// (Called for every event in handle_message)
-    async fn handle_event<'a, T: WebSocketEvent + serde::Deserialize<'a>>(
+    async fn handle_event<'a, T: serde::Deserialize<'a>>(
         data: &'a str,
         event: &mut GatewayEvent<T>,
     ) -> Result<(), serde_json::Error> {
@@ -1686,7 +1685,7 @@ Trait which defines the behavior of an Observer. An Observer is an object which 
 an Observable. The Observer is notified when the Observable's data changes.
 In this case, the Observable is a [`GatewayEvent`], which is a wrapper around a WebSocketEvent.
  */
-pub trait Observer<T: types::WebSocketEvent>: std::fmt::Debug {
+pub trait Observer<T>: std::fmt::Debug {
     fn update(&mut self, data: &T);
 }
 
@@ -1694,13 +1693,13 @@ pub trait Observer<T: types::WebSocketEvent>: std::fmt::Debug {
 change in the WebSocketEvent. GatewayEvents are observable.
  */
 #[derive(Default, Debug)]
-pub struct GatewayEvent<T: types::WebSocketEvent> {
+pub struct GatewayEvent<T> {
     observers: Vec<Arc<Mutex<dyn Observer<T> + Sync + Send>>>,
     pub event_data: T,
     pub is_observed: bool,
 }
 
-impl<T: types::WebSocketEvent> GatewayEvent<T> {
+impl<T> GatewayEvent<T> {
     fn new(event_data: T) -> Self {
         Self {
             is_observed: false,

--- a/src/types/events/application.rs
+++ b/src/types/events/application.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::types::{GuildApplicationCommandPermissions, WebSocketEvent};
+use crate::types::GuildApplicationCommandPermissions;
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#application-command-permissions-update
@@ -8,5 +8,3 @@ pub struct ApplicationCommandPermissionsUpdate {
     #[serde(flatten)]
     pub permissions: GuildApplicationCommandPermissions,
 }
-
-impl WebSocketEvent for ApplicationCommandPermissionsUpdate {}

--- a/src/types/events/auto_moderation.rs
+++ b/src/types/events/auto_moderation.rs
@@ -2,7 +2,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::{
     AutoModerationAction, AutoModerationRule, AutoModerationRuleTriggerType, Snowflake,
-    WebSocketEvent,
 };
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
@@ -12,8 +11,6 @@ pub struct AutoModerationRuleCreate {
     pub rule: AutoModerationRule,
 }
 
-impl WebSocketEvent for AutoModerationRuleCreate {}
-
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#auto-moderation-rule-update
 pub struct AutoModerationRuleUpdate {
@@ -21,16 +18,12 @@ pub struct AutoModerationRuleUpdate {
     pub rule: AutoModerationRule,
 }
 
-impl WebSocketEvent for AutoModerationRuleUpdate {}
-
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#auto-moderation-rule-delete
 pub struct AutoModerationRuleDelete {
     #[serde(flatten)]
     pub rule: AutoModerationRule,
 }
-
-impl WebSocketEvent for AutoModerationRuleDelete {}
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#auto-moderation-action-execution
@@ -47,5 +40,3 @@ pub struct AutoModerationActionExecution {
     pub matched_keyword: Option<String>,
     pub matched_content: Option<String>,
 }
-
-impl WebSocketEvent for AutoModerationActionExecution {}

--- a/src/types/events/call.rs
+++ b/src/types/events/call.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::types::{VoiceState, WebSocketEvent};
+use crate::types::VoiceState;
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 /// Officially Undocumented;
@@ -19,8 +19,6 @@ pub struct CallCreate {
     pub channel_id: String,
 }
 
-impl WebSocketEvent for CallCreate {}
-
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 /// Officially Undocumented;
 /// Updates the client on which calls are ringing, along with a specific call?;
@@ -36,8 +34,6 @@ pub struct CallUpdate {
     pub channel_id: String,
 }
 
-impl WebSocketEvent for CallUpdate {}
-
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 /// Officially Undocumented;
 /// Deletes a ringing call;
@@ -45,8 +41,6 @@ impl WebSocketEvent for CallUpdate {}
 pub struct CallDelete {
     pub channel_id: String,
 }
-
-impl WebSocketEvent for CallDelete {}
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 /// Officially Undocumented;
@@ -56,5 +50,3 @@ impl WebSocketEvent for CallDelete {}
 pub struct CallSync {
     pub channel_id: String,
 }
-
-impl WebSocketEvent for CallSync {}

--- a/src/types/events/channel.rs
+++ b/src/types/events/channel.rs
@@ -1,5 +1,4 @@
 use crate::types::entities::Channel;
-use crate::types::events::WebSocketEvent;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -11,8 +10,6 @@ pub struct ChannelPinsUpdate {
     pub last_pin_timestamp: Option<DateTime<Utc>>,
 }
 
-impl WebSocketEvent for ChannelPinsUpdate {}
-
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#channel-create
 pub struct ChannelCreate {
@@ -20,16 +17,12 @@ pub struct ChannelCreate {
     pub channel: Channel,
 }
 
-impl WebSocketEvent for ChannelCreate {}
-
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#channel-update
 pub struct ChannelUpdate {
     #[serde(flatten)]
     pub channel: Channel,
 }
-
-impl WebSocketEvent for ChannelUpdate {}
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// Officially undocumented.
@@ -49,13 +42,9 @@ pub struct ChannelUnreadUpdateObject {
     pub last_pin_timestamp: Option<String>,
 }
 
-impl WebSocketEvent for ChannelUnreadUpdate {}
-
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#channel-delete
 pub struct ChannelDelete {
     #[serde(flatten)]
     pub channel: Channel,
 }
-
-impl WebSocketEvent for ChannelDelete {}

--- a/src/types/events/guild.rs
+++ b/src/types/events/guild.rs
@@ -2,7 +2,6 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::types::entities::{Guild, PublicUser, UnavailableGuild};
-use crate::types::events::WebSocketEvent;
 use crate::types::{AuditLogEntry, Emoji, GuildMember, GuildScheduledEvent, RoleObject, Sticker};
 
 use super::PresenceUpdate;
@@ -29,8 +28,6 @@ impl Default for GuildCreateDataOption {
     }
 }
 
-impl WebSocketEvent for GuildCreate {}
-
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-ban-add-guild-ban-add-event-fields;
 /// Received to give info about a user being banned from a guild;
@@ -38,8 +35,6 @@ pub struct GuildBanAdd {
     pub guild_id: String,
     pub user: PublicUser,
 }
-
-impl WebSocketEvent for GuildBanAdd {}
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-ban-remove;
@@ -49,8 +44,6 @@ pub struct GuildBanRemove {
     pub user: PublicUser,
 }
 
-impl WebSocketEvent for GuildBanRemove {}
-
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-update;
 /// Received to give info about a guild being updated;
@@ -58,8 +51,6 @@ pub struct GuildUpdate {
     #[serde(flatten)]
     pub guild: Guild,
 }
-
-impl WebSocketEvent for GuildUpdate {}
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-delete;
@@ -69,8 +60,6 @@ pub struct GuildDelete {
     pub guild: UnavailableGuild,
 }
 
-impl WebSocketEvent for GuildDelete {}
-
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-audit-log-entry-create;
 /// Received to the client about an audit log entry being added;
@@ -78,8 +67,6 @@ pub struct GuildAuditLogEntryCreate {
     #[serde(flatten)]
     pub entry: AuditLogEntry,
 }
-
-impl WebSocketEvent for GuildAuditLogEntryCreate {}
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-emojis-update;
@@ -89,8 +76,6 @@ pub struct GuildEmojisUpdate {
     pub emojis: Vec<Emoji>,
 }
 
-impl WebSocketEvent for GuildEmojisUpdate {}
-
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-stickers-update;
 /// Received to tell the client about a change to a guild's sticker list;
@@ -99,15 +84,11 @@ pub struct GuildStickersUpdate {
     pub stickers: Vec<Sticker>,
 }
 
-impl WebSocketEvent for GuildStickersUpdate {}
-
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-integrations-update
 pub struct GuildIntegrationsUpdate {
     pub guild_id: String,
 }
-
-impl WebSocketEvent for GuildIntegrationsUpdate {}
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-member-add;
@@ -118,8 +99,6 @@ pub struct GuildMemberAdd {
     pub guild_id: String,
 }
 
-impl WebSocketEvent for GuildMemberAdd {}
-
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-member-remove;
 /// Received to tell the client about a user leaving a guild;
@@ -127,8 +106,6 @@ pub struct GuildMemberRemove {
     pub guild_id: String,
     pub user: PublicUser,
 }
-
-impl WebSocketEvent for GuildMemberRemove {}
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-member-update
@@ -146,8 +123,6 @@ pub struct GuildMemberUpdate {
     pub communication_disabled_until: Option<DateTime<Utc>>,
 }
 
-impl WebSocketEvent for GuildMemberUpdate {}
-
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-members-chunk
 pub struct GuildMembersChunk {
@@ -160,16 +135,12 @@ pub struct GuildMembersChunk {
     pub nonce: Option<String>,
 }
 
-impl WebSocketEvent for GuildMembersChunk {}
-
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-role-create
 pub struct GuildRoleCreate {
     pub guild_id: String,
     pub role: RoleObject,
 }
-
-impl WebSocketEvent for GuildRoleCreate {}
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-role-update
@@ -178,16 +149,12 @@ pub struct GuildRoleUpdate {
     pub role: RoleObject,
 }
 
-impl WebSocketEvent for GuildRoleUpdate {}
-
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-role-delete
 pub struct GuildRoleDelete {
     pub guild_id: String,
     pub role_id: String,
 }
-
-impl WebSocketEvent for GuildRoleDelete {}
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-create
@@ -196,8 +163,6 @@ pub struct GuildScheduledEventCreate {
     pub event: GuildScheduledEvent,
 }
 
-impl WebSocketEvent for GuildScheduledEventCreate {}
-
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-update
 pub struct GuildScheduledEventUpdate {
@@ -205,16 +170,12 @@ pub struct GuildScheduledEventUpdate {
     pub event: GuildScheduledEvent,
 }
 
-impl WebSocketEvent for GuildScheduledEventUpdate {}
-
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-delete
 pub struct GuildScheduledEventDelete {
     #[serde(flatten)]
     pub event: GuildScheduledEvent,
 }
-
-impl WebSocketEvent for GuildScheduledEventDelete {}
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-user-add
@@ -224,8 +185,6 @@ pub struct GuildScheduledEventUserAdd {
     pub guild_id: String,
 }
 
-impl WebSocketEvent for GuildScheduledEventUserAdd {}
-
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-user-remove
 pub struct GuildScheduledEventUserRemove {
@@ -233,5 +192,3 @@ pub struct GuildScheduledEventUserRemove {
     pub user_id: String,
     pub guild_id: String,
 }
-
-impl WebSocketEvent for GuildScheduledEventUserRemove {}

--- a/src/types/events/heartbeat.rs
+++ b/src/types/events/heartbeat.rs
@@ -1,4 +1,3 @@
-use crate::types::events::WebSocketEvent;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Default, Deserialize, Serialize)]
@@ -7,11 +6,7 @@ pub struct GatewayHeartbeat {
     pub d: Option<u64>,
 }
 
-impl WebSocketEvent for GatewayHeartbeat {}
-
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 pub struct GatewayHeartbeatAck {
     pub op: i32,
 }
-
-impl WebSocketEvent for GatewayHeartbeatAck {}

--- a/src/types/events/hello.rs
+++ b/src/types/events/hello.rs
@@ -1,4 +1,3 @@
-use crate::types::WebSocketEvent;
 use serde::{Deserialize, Serialize};
 
 /// Received on gateway init, tells the client how often to send heartbeats;
@@ -8,8 +7,6 @@ pub struct GatewayHello {
     pub d: HelloData,
 }
 
-impl WebSocketEvent for GatewayHello {}
-
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// Contains info on how often the client should send heartbeats to the server;
 pub struct HelloData {
@@ -17,5 +14,3 @@ pub struct HelloData {
     // u128 because std used u128s for milliseconds
     pub heartbeat_interval: u128,
 }
-
-impl WebSocketEvent for HelloData {}

--- a/src/types/events/identify.rs
+++ b/src/types/events/identify.rs
@@ -1,4 +1,4 @@
-use crate::types::events::{PresenceUpdate, WebSocketEvent};
+use crate::types::events::PresenceUpdate;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
@@ -65,8 +65,6 @@ impl GatewayIdentifyPayload {
         }
     }
 }
-
-impl WebSocketEvent for GatewayIdentifyPayload {}
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde_as]

--- a/src/types/events/integration.rs
+++ b/src/types/events/integration.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::types::{Integration, WebSocketEvent};
+use crate::types::Integration;
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#integration-create
@@ -10,8 +10,6 @@ pub struct IntegrationCreate {
     pub guild_id: String,
 }
 
-impl WebSocketEvent for IntegrationCreate {}
-
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#integration-update
 pub struct IntegrationUpdate {
@@ -20,8 +18,6 @@ pub struct IntegrationUpdate {
     pub guild_id: String,
 }
 
-impl WebSocketEvent for IntegrationUpdate {}
-
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#integration-delete
 pub struct IntegrationDelete {
@@ -29,5 +25,3 @@ pub struct IntegrationDelete {
     pub guild_id: String,
     pub application_id: Option<String>,
 }
-
-impl WebSocketEvent for IntegrationDelete {}

--- a/src/types/events/interaction.rs
+++ b/src/types/events/interaction.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::types::{Interaction, WebSocketEvent};
+use crate::types::Interaction;
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#interaction-create
@@ -8,5 +8,3 @@ pub struct InteractionCreate {
     #[serde(flatten)]
     pub interaction: Interaction,
 }
-
-impl WebSocketEvent for InteractionCreate {}

--- a/src/types/events/invite.rs
+++ b/src/types/events/invite.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::types::{GuildInvite, WebSocketEvent};
+use crate::types::GuildInvite;
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#invite-create
@@ -9,8 +9,6 @@ pub struct InviteCreate {
     pub invite: GuildInvite,
 }
 
-impl WebSocketEvent for InviteCreate {}
-
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#invite-delete
 pub struct InviteDelete {
@@ -18,5 +16,3 @@ pub struct InviteDelete {
     pub guild_id: Option<String>,
     pub code: String,
 }
-
-impl WebSocketEvent for InviteDelete {}

--- a/src/types/events/lazy_request.rs
+++ b/src/types/events/lazy_request.rs
@@ -2,8 +2,6 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use super::WebSocketEvent;
-
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 /// Officially Undocumented
 ///
@@ -24,5 +22,3 @@ pub struct LazyRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub channels: Option<HashMap<String, Vec<Vec<u64>>>>,
 }
-
-impl WebSocketEvent for LazyRequest {}

--- a/src/types/events/message.rs
+++ b/src/types/events/message.rs
@@ -2,8 +2,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::entities::{Emoji, GuildMember, Message, PublicUser};
 
-use super::WebSocketEvent;
-
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct TypingStartEvent {
     pub channel_id: String,
@@ -12,8 +10,6 @@ pub struct TypingStartEvent {
     pub timestamp: i64,
     pub member: Option<GuildMember>,
 }
-
-impl WebSocketEvent for TypingStartEvent {}
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#message-create
@@ -33,8 +29,6 @@ pub struct MessageCreateUser {
     member: Option<GuildMember>,
 }
 
-impl WebSocketEvent for MessageCreate {}
-
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
 pub struct MessageUpdate {
     #[serde(flatten)]
@@ -44,8 +38,6 @@ pub struct MessageUpdate {
     mentions: Option<Vec<MessageCreateUser>>,
 }
 
-impl WebSocketEvent for MessageUpdate {}
-
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
 pub struct MessageDelete {
     id: String,
@@ -53,16 +45,12 @@ pub struct MessageDelete {
     guild_id: Option<String>,
 }
 
-impl WebSocketEvent for MessageDelete {}
-
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
 pub struct MessageDeleteBulk {
     ids: Vec<String>,
     channel_id: String,
     guild_id: Option<String>,
 }
-
-impl WebSocketEvent for MessageDeleteBulk {}
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
 pub struct MessageReactionAdd {
@@ -74,8 +62,6 @@ pub struct MessageReactionAdd {
     emoji: Emoji,
 }
 
-impl WebSocketEvent for MessageReactionAdd {}
-
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
 pub struct MessageReactionRemove {
     user_id: String,
@@ -85,16 +71,12 @@ pub struct MessageReactionRemove {
     emoji: Emoji,
 }
 
-impl WebSocketEvent for MessageReactionRemove {}
-
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
 pub struct MessageReactionRemoveAll {
     channel_id: String,
     message_id: String,
     guild_id: Option<String>,
 }
-
-impl WebSocketEvent for MessageReactionRemoveAll {}
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
 pub struct MessageReactionRemoveEmoji {
@@ -103,8 +85,6 @@ pub struct MessageReactionRemoveEmoji {
     guild_id: Option<String>,
     emoji: Emoji,
 }
-
-impl WebSocketEvent for MessageReactionRemoveEmoji {}
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 /// Officially Undocumented
@@ -126,5 +106,3 @@ pub struct MessageACK {
     pub flags: Option<serde_json::Value>,
     pub channel_id: String,
 }
-
-impl WebSocketEvent for MessageACK {}

--- a/src/types/events/mod.rs
+++ b/src/types/events/mod.rs
@@ -52,8 +52,6 @@ mod user;
 mod voice;
 mod webhooks;
 
-pub trait WebSocketEvent {}
-
 #[derive(Debug, Default, Serialize, Clone)]
 /// The payload used for sending events to the gateway
 ///
@@ -71,8 +69,6 @@ pub struct GatewaySendPayload {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sequence_number: Option<u64>,
 }
-
-impl WebSocketEvent for GatewaySendPayload {}
 
 #[derive(Debug, Default, Deserialize, Clone)]
 /// The payload used for receiving events from the gateway
@@ -93,5 +89,3 @@ pub struct GatewayReceivePayload<'a> {
     #[serde(rename = "t")]
     pub event_name: Option<String>,
 }
-
-impl<'a> WebSocketEvent for GatewayReceivePayload<'a> {}

--- a/src/types/events/passive_update.rs
+++ b/src/types/events/passive_update.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use super::{ChannelUnreadUpdateObject, WebSocketEvent};
+use super::ChannelUnreadUpdateObject;
 use crate::types::{GuildMember, VoiceState};
 
 #[derive(Debug, Deserialize, Serialize, Default)]
@@ -13,5 +13,3 @@ pub struct PassiveUpdateV1 {
     pub guild_id: String,
     pub channels: Vec<ChannelUnreadUpdateObject>,
 }
-
-impl WebSocketEvent for PassiveUpdateV1 {}

--- a/src/types/events/presence.rs
+++ b/src/types/events/presence.rs
@@ -1,4 +1,4 @@
-use crate::types::{events::WebSocketEvent, UserStatus};
+use crate::types::UserStatus;
 use crate::types::{Activity, ClientStatusObject, PublicUser, Snowflake};
 use serde::{Deserialize, Serialize};
 
@@ -25,5 +25,3 @@ pub struct PresenceUpdate {
     pub activities: Vec<Activity>,
     pub client_status: ClientStatusObject,
 }
-
-impl WebSocketEvent for PresenceUpdate {}

--- a/src/types/events/ready.rs
+++ b/src/types/events/ready.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::types::entities::{Guild, User};
-use crate::types::events::{Session, WebSocketEvent};
+use crate::types::events::Session;
 use crate::types::interfaces::ClientStatusObject;
 use crate::types::{Activity, GuildMember, PresenceUpdate, VoiceState};
 
@@ -26,8 +26,6 @@ pub struct GatewayReady {
     pub shard: Option<(u64, u64)>,
 }
 
-impl WebSocketEvent for GatewayReady {}
-
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 /// Officially Undocumented;
 /// Sent after the READY event when a client is a user, seems to somehow add onto the ready event;
@@ -40,8 +38,6 @@ pub struct GatewayReadySupplemental {
     // ? pomelo
     pub disclose: Vec<String>,
 }
-
-impl WebSocketEvent for GatewayReadySupplemental {}
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct MergedPresences {

--- a/src/types/events/relationship.rs
+++ b/src/types/events/relationship.rs
@@ -1,4 +1,4 @@
-use crate::types::{events::WebSocketEvent, Relationship, RelationshipType, Snowflake};
+use crate::types::{Relationship, RelationshipType, Snowflake};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, Default)]
@@ -9,8 +9,6 @@ pub struct RelationshipAdd {
     pub should_notify: bool,
 }
 
-impl WebSocketEvent for RelationshipAdd {}
-
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 /// See https://github.com/spacebarchat/server/issues/203
 pub struct RelationshipRemove {
@@ -18,5 +16,3 @@ pub struct RelationshipRemove {
     #[serde(rename = "type")]
     pub relationship_type: RelationshipType,
 }
-
-impl WebSocketEvent for RelationshipRemove {}

--- a/src/types/events/request_members.rs
+++ b/src/types/events/request_members.rs
@@ -1,4 +1,3 @@
-use crate::types::events::WebSocketEvent;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, Default)]
@@ -11,5 +10,3 @@ pub struct GatewayRequestGuildMembers {
     pub user_ids: Option<String>,
     pub nonce: Option<String>,
 }
-
-impl WebSocketEvent for GatewayRequestGuildMembers {}

--- a/src/types/events/resume.rs
+++ b/src/types/events/resume.rs
@@ -1,4 +1,3 @@
-use crate::types::events::WebSocketEvent;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, Default)]
@@ -7,5 +6,3 @@ pub struct GatewayResume {
     pub session_id: String,
     pub seq: String,
 }
-
-impl WebSocketEvent for GatewayResume {}

--- a/src/types/events/session.rs
+++ b/src/types/events/session.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::types::{Activity, WebSocketEvent};
+use crate::types::Activity;
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 /// Officially Undocumented
@@ -28,5 +28,3 @@ pub struct ClientInfo {
     pub os: String,
     pub version: u8,
 }
-
-impl WebSocketEvent for SessionsReplace {}

--- a/src/types/events/stage_instance.rs
+++ b/src/types/events/stage_instance.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::types::{StageInstance, WebSocketEvent};
+use crate::types::StageInstance;
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#stage-instance-create
@@ -9,8 +9,6 @@ pub struct StageInstanceCreate {
     pub stage_instance: StageInstance,
 }
 
-impl WebSocketEvent for StageInstanceCreate {}
-
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#stage-instance-update
 pub struct StageInstanceUpdate {
@@ -18,13 +16,9 @@ pub struct StageInstanceUpdate {
     pub stage_instance: StageInstance,
 }
 
-impl WebSocketEvent for StageInstanceUpdate {}
-
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#stage-instance-delete
 pub struct StageInstanceDelete {
     #[serde(flatten)]
     pub stage_instance: StageInstance,
 }
-
-impl WebSocketEvent for StageInstanceDelete {}

--- a/src/types/events/thread.rs
+++ b/src/types/events/thread.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
 
 use crate::types::entities::{Channel, ThreadMember};
-use crate::types::events::WebSocketEvent;
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#thread-create
@@ -10,8 +9,6 @@ pub struct ThreadCreate {
     pub thread: Channel,
 }
 
-impl WebSocketEvent for ThreadCreate {}
-
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#thread-update
 pub struct ThreadUpdate {
@@ -19,16 +16,12 @@ pub struct ThreadUpdate {
     pub thread: Channel,
 }
 
-impl WebSocketEvent for ThreadUpdate {}
-
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#thread-delete
 pub struct ThreadDelete {
     #[serde(flatten)]
     pub thread: Channel,
 }
-
-impl WebSocketEvent for ThreadDelete {}
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#thread-list-sync
@@ -39,8 +32,6 @@ pub struct ThreadListSync {
     pub members: Option<Vec<ThreadMember>>,
 }
 
-impl WebSocketEvent for ThreadListSync {}
-
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#thread-member-update
 /// The inner payload is a thread member object with an extra field.
@@ -49,8 +40,6 @@ pub struct ThreadMemberUpdate {
     pub member: ThreadMember,
     pub guild_id: String,
 }
-
-impl WebSocketEvent for ThreadMemberUpdate {}
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#thread-members-update
@@ -62,5 +51,3 @@ pub struct ThreadMembersUpdate {
     pub added_members: Option<Vec<ThreadMember>>,
     pub removed_members: Option<Vec<String>>,
 }
-
-impl WebSocketEvent for ThreadMembersUpdate {}

--- a/src/types/events/user.rs
+++ b/src/types/events/user.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
 
 use crate::types::entities::PublicUser;
-use crate::types::events::WebSocketEvent;
 use crate::types::utils::Snowflake;
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
@@ -11,8 +10,6 @@ pub struct UserUpdate {
     #[serde(flatten)]
     pub user: PublicUser,
 }
-
-impl WebSocketEvent for UserUpdate {}
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// Undocumented;
@@ -36,8 +33,6 @@ pub struct UserGuildSettingsUpdate {
     pub flags: i32,
     pub channel_overrides: Vec<UserGuildSettingsChannelOverride>,
 }
-
-impl WebSocketEvent for UserGuildSettingsUpdate {}
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// Undocumented;

--- a/src/types/events/voice.rs
+++ b/src/types/events/voice.rs
@@ -1,4 +1,4 @@
-use crate::types::{events::WebSocketEvent, VoiceState};
+use crate::types::VoiceState;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, Default)]
@@ -13,8 +13,6 @@ pub struct UpdateVoiceState {
     pub self_deaf: bool,
 }
 
-impl WebSocketEvent for UpdateVoiceState {}
-
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#voice-state-update;
 ///
@@ -26,8 +24,6 @@ pub struct VoiceStateUpdate {
     pub state: VoiceState,
 }
 
-impl WebSocketEvent for VoiceStateUpdate {}
-
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#voice-server-update;
 ///
@@ -37,5 +33,3 @@ pub struct VoiceServerUpdate {
     pub guild_id: String,
     pub endpoint: Option<String>,
 }
-
-impl WebSocketEvent for VoiceServerUpdate {}

--- a/src/types/events/webhooks.rs
+++ b/src/types/events/webhooks.rs
@@ -1,12 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-use super::WebSocketEvent;
-
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#webhooks-update
 pub struct WebhooksUpdate {
     pub guild_id: String,
     pub channel_id: String,
 }
-
-impl WebSocketEvent for WebhooksUpdate {}


### PR DESCRIPTION
The `WebSocketEvent` doesn't have any members and as such isn't needed. Note that it isn't restricted to types provided by Chorus, any user can implement `WebSocketEvent` for their own types.