### PR TITLE
More consistent use of snowflakes

### DIFF
--- a/src/api/channels/channels.rs
+++ b/src/api/channels/channels.rs
@@ -5,7 +5,7 @@ use crate::{
     api::common,
     errors::ChorusLibError,
     instance::UserMeta,
-    types::{Channel, ChannelModifySchema},
+    types::{Channel, ChannelModifySchema, Message, Snowflake},
 };
 
 impl Channel {
@@ -51,10 +51,8 @@ impl Channel {
                 self.id
             ))
             .bearer_auth(user.token());
-        let response =
-            common::handle_request_as_result(request, user, crate::api::limits::LimitType::Channel)
-                .await;
-        response
+        common::handle_request_as_result(request, user, crate::api::limits::LimitType::Channel)
+            .await
     }
 
     /// Modifies a channel.
@@ -73,7 +71,7 @@ impl Channel {
     /// A `Result` that contains a `Channel` object if the request was successful, or an `ChorusLibError` if an error occurred during the request.
     pub async fn modify(
         modify_data: ChannelModifySchema,
-        channel_id: &str,
+        channel_id: Snowflake,
         user: &mut UserMeta,
     ) -> Result<Channel, ChorusLibError> {
         let request = Client::new()
@@ -84,13 +82,11 @@ impl Channel {
             ))
             .bearer_auth(user.token())
             .body(to_string(&modify_data).unwrap());
-        let channel = common::deserialize_response::<Channel>(
+        common::deserialize_response::<Channel>(
             request,
             user,
             crate::api::limits::LimitType::Channel,
         )
         .await
-        .unwrap();
-        Ok(channel)
     }
 }

--- a/src/api/channels/messages.rs
+++ b/src/api/channels/messages.rs
@@ -5,7 +5,7 @@ use serde_json::to_string;
 
 use crate::api::deserialize_response;
 use crate::instance::UserMeta;
-use crate::types::{Message, MessageSendSchema, PartialDiscordFileAttachment};
+use crate::types::{Message, MessageSendSchema, PartialDiscordFileAttachment, Snowflake};
 
 impl Message {
     /**
@@ -21,7 +21,7 @@ impl Message {
      */
     pub async fn send(
         user: &mut UserMeta,
-        channel_id: String,
+        channel_id: Snowflake,
         message: &mut MessageSendSchema,
         files: Option<Vec<PartialDiscordFileAttachment>>,
     ) -> Result<Message, crate::errors::ChorusLibError> {
@@ -89,7 +89,7 @@ impl UserMeta {
     pub async fn send_message(
         &mut self,
         message: &mut MessageSendSchema,
-        channel_id: String,
+        channel_id: Snowflake,
         files: Option<Vec<PartialDiscordFileAttachment>>,
     ) -> Result<Message, crate::errors::ChorusLibError> {
         Message::send(self, channel_id, message, files).await

--- a/src/api/channels/permissions.rs
+++ b/src/api/channels/permissions.rs
@@ -2,10 +2,10 @@ use reqwest::Client;
 use serde_json::to_string;
 
 use crate::{
-    api::{handle_request, handle_request_as_result},
+    api::handle_request_as_result,
     errors::ChorusLibError,
     instance::UserMeta,
-    types::{self, PermissionOverwrite},
+    types::{self, PermissionOverwrite, Snowflake},
 };
 
 impl types::Channel {
@@ -22,7 +22,7 @@ impl types::Channel {
     /// This function returns a result that is either [`Ok(())`] if the request is successful, or an [`Err(ChorusLibError)`].
     pub async fn edit_permissions(
         user: &mut UserMeta,
-        channel_id: &str,
+        channel_id: Snowflake,
         overwrite: PermissionOverwrite,
     ) -> Result<(), ChorusLibError> {
         let url = {
@@ -58,8 +58,8 @@ impl types::Channel {
     /// This function returns a Result that is either [`Ok(())`] if the request is successfulm or an [`Err(ChorusLibError)`].
     pub async fn delete_permission(
         user: &mut UserMeta,
-        channel_id: &str,
-        overwrite_id: &str,
+        channel_id: Snowflake,
+        overwrite_id: Snowflake,
     ) -> Result<(), ChorusLibError> {
         let url = format!(
             "{}/channels/{}/permissions/{}",

--- a/src/api/channels/reactions.rs
+++ b/src/api/channels/reactions.rs
@@ -1,11 +1,6 @@
 use reqwest::Client;
 
-use crate::{
-    api::{handle_request, handle_request_as_result},
-    errors::ChorusLibError,
-    instance::UserMeta,
-    types,
-};
+use crate::{api::handle_request_as_result, errors::ChorusLibError, instance::UserMeta, types};
 
 /**
 Useful metadata for working with [`types::Reaction`], bundled together nicely.

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -1,9 +1,7 @@
 use crate::errors::GatewayError;
-use crate::errors::ObserverError;
 use crate::gateway::events::Events;
 use crate::types;
 use crate::types::WebSocketEvent;
-use std::any::Any;
 use std::sync::Arc;
 
 use futures_util::stream::SplitSink;

--- a/src/types/entities/audit_log.rs
+++ b/src/types/entities/audit_log.rs
@@ -7,7 +7,7 @@ use crate::types::utils::Snowflake;
 pub struct AuditLogEntry {
     pub target_id: Option<String>,
     pub changes: Option<Vec<AuditLogChange>>,
-    pub user_id: Option<String>,
+    pub user_id: Option<Snowflake>,
     pub id: Snowflake,
     // to:do implement an enum for these types
     pub action_type: u8,

--- a/src/types/entities/channel.rs
+++ b/src/types/entities/channel.rs
@@ -1,9 +1,6 @@
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
-use serde_aux::prelude::{
-    deserialize_number_from_string, deserialize_option_number_from_string,
-    deserialize_string_from_number,
-};
+use serde_aux::prelude::deserialize_string_from_number;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::types::{
@@ -27,7 +24,7 @@ pub struct Channel {
     pub name: Option<String>,
     pub topic: Option<String>,
     pub nsfw: Option<bool>,
-    pub last_message_id: Option<String>,
+    pub last_message_id: Option<Snowflake>,
     pub bitrate: Option<i32>,
     pub user_limit: Option<i32>,
     pub rate_limit_per_user: Option<i32>,
@@ -37,7 +34,7 @@ pub struct Channel {
     pub owner_id: Option<Snowflake>,
     pub application_id: Option<Snowflake>,
     pub managed: Option<bool>,
-    pub parent_id: Option<String>,
+    pub parent_id: Option<Snowflake>,
     pub last_pin_timestamp: Option<String>,
     pub rtc_region: Option<String>,
     pub video_quality_mode: Option<i32>,
@@ -70,20 +67,16 @@ pub struct Channel {
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct Tag {
-    #[serde(default)]
-    #[serde(deserialize_with = "deserialize_number_from_string")]
-    pub id: u64,
+    pub id: Snowflake,
     pub name: String,
     pub moderated: bool,
-    #[serde(default)]
-    #[serde(deserialize_with = "deserialize_option_number_from_string")]
-    pub emoji_id: Option<u64>,
+    pub emoji_id: Option<Snowflake>,
     pub emoji_name: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct PermissionOverwrite {
-    pub id: String,
+    pub id: Snowflake,
     #[serde(rename = "type")]
     #[serde(deserialize_with = "deserialize_string_from_number")]
     pub overwrite_type: String,
@@ -107,8 +100,8 @@ pub struct ThreadMetadata {
 
 #[derive(Default, Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct ThreadMember {
-    pub id: Option<u64>,
-    pub user_id: Option<u64>,
+    pub id: Option<Snowflake>,
+    pub user_id: Option<Snowflake>,
     pub join_timestamp: Option<String>,
     pub flags: Option<u64>,
     pub member: Option<GuildMember>,
@@ -117,8 +110,7 @@ pub struct ThreadMember {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct DefaultReaction {
     #[serde(default)]
-    #[serde(deserialize_with = "deserialize_option_number_from_string")]
-    pub emoji_id: Option<u64>,
+    pub emoji_id: Option<Snowflake>,
     pub emoji_name: Option<String>,
 }
 

--- a/src/types/entities/guild.rs
+++ b/src/types/entities/guild.rs
@@ -16,7 +16,7 @@ pub struct Guild {
     pub afk_channel_id: Option<Snowflake>,
     pub afk_timeout: Option<i32>,
     #[cfg_attr(feature = "sqlx", sqlx(skip))]
-    pub application_id: Option<String>,
+    pub application_id: Option<Snowflake>,
     #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub approximate_member_count: Option<i32>,
     #[cfg_attr(feature = "sqlx", sqlx(skip))]
@@ -110,13 +110,13 @@ pub struct GuildInvite {
     pub max_age: Option<i32>,
     pub created_at: DateTime<Utc>,
     pub expires_at: Option<DateTime<Utc>>,
-    pub guild_id: String,
+    pub guild_id: Snowflake,
     pub guild: Option<Guild>,
-    pub channel_id: String,
+    pub channel_id: Snowflake,
     pub channel: Option<Channel>,
-    pub inviter_id: Option<String>,
+    pub inviter_id: Option<Snowflake>,
     pub inviter: Option<User>,
-    pub target_user_id: Option<String>,
+    pub target_user_id: Option<Snowflake>,
     pub target_user: Option<String>,
     pub target_user_type: Option<i32>,
     pub vanity_url: Option<bool>,
@@ -124,22 +124,22 @@ pub struct GuildInvite {
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct UnavailableGuild {
-    id: String,
+    id: Snowflake,
     unavailable: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct GuildCreateResponse {
-    pub id: String,
+    pub id: Snowflake,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 /// See https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object
 pub struct GuildScheduledEvent {
-    pub id: String,
-    pub guild_id: String,
-    pub channel_id: Option<String>,
-    pub creator_id: Option<String>,
+    pub id: Snowflake,
+    pub guild_id: Snowflake,
+    pub channel_id: Option<Snowflake>,
+    pub creator_id: Option<Snowflake>,
     pub name: String,
     pub description: String,
     pub scheduled_start_time: DateTime<Utc>,
@@ -147,7 +147,7 @@ pub struct GuildScheduledEvent {
     pub privacy_level: GuildScheduledEventPrivacyLevel,
     pub status: GuildScheduledEventStatus,
     pub entity_type: GuildScheduledEventEntityType,
-    pub entity_id: Option<String>,
+    pub entity_id: Option<Snowflake>,
     pub entity_metadata: Option<GuildScheduledEventEntityMetadata>,
     pub creator: Option<User>,
     pub user_count: Option<u64>,

--- a/src/types/entities/template.rs
+++ b/src/types/entities/template.rs
@@ -19,7 +19,7 @@ pub struct GuildTemplate {
     pub creator: User,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
-    pub source_guild_id: String,
+    pub source_guild_id: Snowflake,
     #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub source_guild: Vec<Guild>,
     // Unsure how a {recursive: Guild} looks like, might be a Vec?

--- a/src/types/events/call.rs
+++ b/src/types/events/call.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::types::{VoiceState, WebSocketEvent};
+use crate::types::{Snowflake, VoiceState, WebSocketEvent};
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 /// Officially Undocumented;
@@ -13,10 +13,10 @@ pub struct CallCreate {
     pub ringing: Vec<String>,
     pub region: String,
     // milan
-    pub message_id: String,
+    pub message_id: Snowflake,
     /// What is this?
     pub embedded_activities: Vec<serde_json::Value>,
-    pub channel_id: String,
+    pub channel_id: Snowflake,
 }
 
 impl WebSocketEvent for CallCreate {}
@@ -28,12 +28,12 @@ impl WebSocketEvent for CallCreate {}
 /// Ex: {"t":"CALL_UPDATE","s":5,"op":0,"d":{"ringing":["837606544539254834"],"region":"milan","message_id":"1107191540234846308","guild_id":null,"channel_id":"837609115475771392"}}
 pub struct CallUpdate {
     /// Seems like a vec of channel ids
-    pub ringing: Vec<String>,
+    pub ringing: Vec<Snowflake>,
     pub region: String,
     // milan
-    pub message_id: String,
-    pub guild_id: Option<String>,
-    pub channel_id: String,
+    pub message_id: Snowflake,
+    pub guild_id: Option<Snowflake>,
+    pub channel_id: Snowflake,
 }
 
 impl WebSocketEvent for CallUpdate {}
@@ -43,7 +43,7 @@ impl WebSocketEvent for CallUpdate {}
 /// Deletes a ringing call;
 /// Ex: {"t":"CALL_DELETE","s":8,"op":0,"d":{"channel_id":"837609115475771392"}}
 pub struct CallDelete {
-    pub channel_id: String,
+    pub channel_id: Snowflake,
 }
 
 impl WebSocketEvent for CallDelete {}
@@ -54,7 +54,7 @@ impl WebSocketEvent for CallDelete {}
 ///
 /// Ex: {"op":13,"d":{"channel_id":"837609115475771392"}}
 pub struct CallSync {
-    pub channel_id: String,
+    pub channel_id: Snowflake,
 }
 
 impl WebSocketEvent for CallSync {}

--- a/src/types/events/channel.rs
+++ b/src/types/events/channel.rs
@@ -1,13 +1,13 @@
-use crate::types::entities::Channel;
 use crate::types::events::WebSocketEvent;
+use crate::types::{entities::Channel, Snowflake};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Default, Deserialize, Serialize)]
 /// See https://discord.com/developers/docs/topics/gateway-events#channel-pins-update
 pub struct ChannelPinsUpdate {
-    pub guild_id: Option<String>,
-    pub channel_id: String,
+    pub guild_id: Option<Snowflake>,
+    pub channel_id: Snowflake,
     pub last_pin_timestamp: Option<DateTime<Utc>>,
 }
 
@@ -37,15 +37,15 @@ impl WebSocketEvent for ChannelUpdate {}
 /// {"channel_unread_updates": [{"id": "816412869766938648", "last_message_id": "1085892012085104680"}}
 pub struct ChannelUnreadUpdate {
     pub channel_unread_updates: Vec<ChannelUnreadUpdateObject>,
-    pub guild_id: String,
+    pub guild_id: Snowflake,
 }
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// Contains very few fields from [Channel]
 /// See also [ChannelUnreadUpdates]
 pub struct ChannelUnreadUpdateObject {
-    pub id: String,
-    pub last_message_id: String,
+    pub id: Snowflake,
+    pub last_message_id: Snowflake,
     pub last_pin_timestamp: Option<String>,
 }
 

--- a/src/types/events/guild.rs
+++ b/src/types/events/guild.rs
@@ -3,7 +3,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::entities::{Guild, PublicUser, UnavailableGuild};
 use crate::types::events::WebSocketEvent;
-use crate::types::{AuditLogEntry, Emoji, GuildMember, GuildScheduledEvent, RoleObject, Sticker};
+use crate::types::{
+    AuditLogEntry, Emoji, GuildMember, GuildScheduledEvent, RoleObject, Snowflake, Sticker,
+};
 
 use super::PresenceUpdate;
 
@@ -35,7 +37,7 @@ impl WebSocketEvent for GuildCreate {}
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-ban-add-guild-ban-add-event-fields;
 /// Received to give info about a user being banned from a guild;
 pub struct GuildBanAdd {
-    pub guild_id: String,
+    pub guild_id: Snowflake,
     pub user: PublicUser,
 }
 
@@ -45,7 +47,7 @@ impl WebSocketEvent for GuildBanAdd {}
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-ban-remove;
 /// Received to give info about a user being unbanned from a guild;
 pub struct GuildBanRemove {
-    pub guild_id: String,
+    pub guild_id: Snowflake,
     pub user: PublicUser,
 }
 
@@ -85,7 +87,7 @@ impl WebSocketEvent for GuildAuditLogEntryCreate {}
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-emojis-update;
 /// Received to tell the client about a change to a guild's emoji list;
 pub struct GuildEmojisUpdate {
-    pub guild_id: String,
+    pub guild_id: Snowflake,
     pub emojis: Vec<Emoji>,
 }
 
@@ -95,7 +97,7 @@ impl WebSocketEvent for GuildEmojisUpdate {}
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-stickers-update;
 /// Received to tell the client about a change to a guild's sticker list;
 pub struct GuildStickersUpdate {
-    pub guild_id: String,
+    pub guild_id: Snowflake,
     pub stickers: Vec<Sticker>,
 }
 
@@ -104,7 +106,7 @@ impl WebSocketEvent for GuildStickersUpdate {}
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-integrations-update
 pub struct GuildIntegrationsUpdate {
-    pub guild_id: String,
+    pub guild_id: Snowflake,
 }
 
 impl WebSocketEvent for GuildIntegrationsUpdate {}
@@ -115,7 +117,7 @@ impl WebSocketEvent for GuildIntegrationsUpdate {}
 pub struct GuildMemberAdd {
     #[serde(flatten)]
     pub member: GuildMember,
-    pub guild_id: String,
+    pub guild_id: Snowflake,
 }
 
 impl WebSocketEvent for GuildMemberAdd {}
@@ -124,7 +126,7 @@ impl WebSocketEvent for GuildMemberAdd {}
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-member-remove;
 /// Received to tell the client about a user leaving a guild;
 pub struct GuildMemberRemove {
-    pub guild_id: String,
+    pub guild_id: Snowflake,
     pub user: PublicUser,
 }
 
@@ -133,8 +135,8 @@ impl WebSocketEvent for GuildMemberRemove {}
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-member-update
 pub struct GuildMemberUpdate {
-    pub guild_id: String,
-    pub roles: Vec<String>,
+    pub guild_id: Snowflake,
+    pub roles: Vec<Snowflake>,
     pub user: PublicUser,
     pub nick: Option<String>,
     pub avatar: Option<String>,
@@ -151,11 +153,11 @@ impl WebSocketEvent for GuildMemberUpdate {}
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-members-chunk
 pub struct GuildMembersChunk {
-    pub guild_id: String,
+    pub guild_id: Snowflake,
     pub members: Vec<GuildMember>,
     pub chunk_index: u16,
     pub chunk_count: u16,
-    pub not_found: Option<Vec<String>>,
+    pub not_found: Option<Vec<Snowflake>>,
     pub presences: Option<PresenceUpdate>,
     pub nonce: Option<String>,
 }
@@ -165,7 +167,7 @@ impl WebSocketEvent for GuildMembersChunk {}
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-role-create
 pub struct GuildRoleCreate {
-    pub guild_id: String,
+    pub guild_id: Snowflake,
     pub role: RoleObject,
 }
 
@@ -174,7 +176,7 @@ impl WebSocketEvent for GuildRoleCreate {}
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-role-update
 pub struct GuildRoleUpdate {
-    pub guild_id: String,
+    pub guild_id: Snowflake,
     pub role: RoleObject,
 }
 
@@ -183,8 +185,8 @@ impl WebSocketEvent for GuildRoleUpdate {}
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-role-delete
 pub struct GuildRoleDelete {
-    pub guild_id: String,
-    pub role_id: String,
+    pub guild_id: Snowflake,
+    pub role_id: Snowflake,
 }
 
 impl WebSocketEvent for GuildRoleDelete {}
@@ -219,9 +221,9 @@ impl WebSocketEvent for GuildScheduledEventDelete {}
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-user-add
 pub struct GuildScheduledEventUserAdd {
-    pub guild_scheduled_event_id: String,
-    pub user_id: String,
-    pub guild_id: String,
+    pub guild_scheduled_event_id: Snowflake,
+    pub user_id: Snowflake,
+    pub guild_id: Snowflake,
 }
 
 impl WebSocketEvent for GuildScheduledEventUserAdd {}
@@ -229,9 +231,9 @@ impl WebSocketEvent for GuildScheduledEventUserAdd {}
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-user-remove
 pub struct GuildScheduledEventUserRemove {
-    pub guild_scheduled_event_id: String,
-    pub user_id: String,
-    pub guild_id: String,
+    pub guild_scheduled_event_id: Snowflake,
+    pub user_id: Snowflake,
+    pub guild_id: Snowflake,
 }
 
 impl WebSocketEvent for GuildScheduledEventUserRemove {}

--- a/src/types/events/integration.rs
+++ b/src/types/events/integration.rs
@@ -1,13 +1,13 @@
 use serde::{Deserialize, Serialize};
 
-use crate::types::{Integration, WebSocketEvent};
+use crate::types::{Integration, Snowflake, WebSocketEvent};
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#integration-create
 pub struct IntegrationCreate {
     #[serde(flatten)]
     pub integration: Integration,
-    pub guild_id: String,
+    pub guild_id: Snowflake,
 }
 
 impl WebSocketEvent for IntegrationCreate {}
@@ -17,7 +17,7 @@ impl WebSocketEvent for IntegrationCreate {}
 pub struct IntegrationUpdate {
     #[serde(flatten)]
     pub integration: Integration,
-    pub guild_id: String,
+    pub guild_id: Snowflake,
 }
 
 impl WebSocketEvent for IntegrationUpdate {}
@@ -25,9 +25,9 @@ impl WebSocketEvent for IntegrationUpdate {}
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#integration-delete
 pub struct IntegrationDelete {
-    pub id: String,
-    pub guild_id: String,
-    pub application_id: Option<String>,
+    pub id: Snowflake,
+    pub guild_id: Snowflake,
+    pub application_id: Option<Snowflake>,
 }
 
 impl WebSocketEvent for IntegrationDelete {}

--- a/src/types/events/invite.rs
+++ b/src/types/events/invite.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::types::{GuildInvite, WebSocketEvent};
+use crate::types::{GuildInvite, Snowflake, WebSocketEvent};
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#invite-create
@@ -14,8 +14,8 @@ impl WebSocketEvent for InviteCreate {}
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#invite-delete
 pub struct InviteDelete {
-    pub channel_id: String,
-    pub guild_id: Option<String>,
+    pub channel_id: Snowflake,
+    pub guild_id: Option<Snowflake>,
     pub code: String,
 }
 

--- a/src/types/events/lazy_request.rs
+++ b/src/types/events/lazy_request.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
+use crate::types::Snowflake;
+
 use super::WebSocketEvent;
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
@@ -15,7 +17,7 @@ use super::WebSocketEvent;
 ///
 /// {"op":14,"d":{"guild_id":"848582562217590824","typing":true,"activities":true,"threads":true}}
 pub struct LazyRequest {
-    pub guild_id: String,
+    pub guild_id: Snowflake,
     pub typing: bool,
     pub activities: bool,
     pub threads: bool,

--- a/src/types/events/message.rs
+++ b/src/types/events/message.rs
@@ -1,14 +1,17 @@
 use serde::{Deserialize, Serialize};
 
-use crate::types::entities::{Emoji, GuildMember, Message, PublicUser};
+use crate::types::{
+    entities::{Emoji, GuildMember, Message, PublicUser},
+    Snowflake,
+};
 
 use super::WebSocketEvent;
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct TypingStartEvent {
-    pub channel_id: String,
-    pub guild_id: Option<String>,
-    pub user_id: String,
+    pub channel_id: Snowflake,
+    pub guild_id: Option<Snowflake>,
+    pub user_id: Snowflake,
     pub timestamp: i64,
     pub member: Option<GuildMember>,
 }
@@ -20,7 +23,7 @@ impl WebSocketEvent for TypingStartEvent {}
 pub struct MessageCreate {
     #[serde(flatten)]
     message: Message,
-    guild_id: Option<String>,
+    guild_id: Option<Snowflake>,
     member: Option<GuildMember>,
     mentions: Option<Vec<MessageCreateUser>>,
 }
@@ -39,7 +42,7 @@ impl WebSocketEvent for MessageCreate {}
 pub struct MessageUpdate {
     #[serde(flatten)]
     message: Message,
-    guild_id: Option<String>,
+    guild_id: Option<Snowflake>,
     member: Option<GuildMember>,
     mentions: Option<Vec<MessageCreateUser>>,
 }
@@ -48,28 +51,28 @@ impl WebSocketEvent for MessageUpdate {}
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
 pub struct MessageDelete {
-    id: String,
-    channel_id: String,
-    guild_id: Option<String>,
+    id: Snowflake,
+    channel_id: Snowflake,
+    guild_id: Option<Snowflake>,
 }
 
 impl WebSocketEvent for MessageDelete {}
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
 pub struct MessageDeleteBulk {
-    ids: Vec<String>,
-    channel_id: String,
-    guild_id: Option<String>,
+    ids: Vec<Snowflake>,
+    channel_id: Snowflake,
+    guild_id: Option<Snowflake>,
 }
 
 impl WebSocketEvent for MessageDeleteBulk {}
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
 pub struct MessageReactionAdd {
-    user_id: String,
-    channel_id: String,
-    message_id: String,
-    guild_id: Option<String>,
+    user_id: Snowflake,
+    channel_id: Snowflake,
+    message_id: Snowflake,
+    guild_id: Option<Snowflake>,
     member: Option<GuildMember>,
     emoji: Emoji,
 }
@@ -78,10 +81,10 @@ impl WebSocketEvent for MessageReactionAdd {}
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
 pub struct MessageReactionRemove {
-    user_id: String,
-    channel_id: String,
-    message_id: String,
-    guild_id: Option<String>,
+    user_id: Snowflake,
+    channel_id: Snowflake,
+    message_id: Snowflake,
+    guild_id: Option<Snowflake>,
     emoji: Emoji,
 }
 
@@ -89,18 +92,18 @@ impl WebSocketEvent for MessageReactionRemove {}
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
 pub struct MessageReactionRemoveAll {
-    channel_id: String,
-    message_id: String,
-    guild_id: Option<String>,
+    channel_id: Snowflake,
+    message_id: Snowflake,
+    guild_id: Option<Snowflake>,
 }
 
 impl WebSocketEvent for MessageReactionRemoveAll {}
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
 pub struct MessageReactionRemoveEmoji {
-    channel_id: String,
-    message_id: String,
-    guild_id: Option<String>,
+    channel_id: Snowflake,
+    message_id: Snowflake,
+    guild_id: Option<Snowflake>,
     emoji: Emoji,
 }
 
@@ -118,13 +121,13 @@ impl WebSocketEvent for MessageReactionRemoveEmoji {}
 pub struct MessageACK {
     /// ?
     pub version: u16,
-    pub message_id: String,
+    pub message_id: Snowflake,
     /// This is an integer???
     /// Not even unix, see '3070'???
     pub last_viewed: Option<u64>,
     /// What flags?
     pub flags: Option<serde_json::Value>,
-    pub channel_id: String,
+    pub channel_id: Snowflake,
 }
 
 impl WebSocketEvent for MessageACK {}

--- a/src/types/events/passive_update.rs
+++ b/src/types/events/passive_update.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::{ChannelUnreadUpdateObject, WebSocketEvent};
-use crate::types::{GuildMember, VoiceState};
+use crate::types::{GuildMember, Snowflake, VoiceState};
 
 #[derive(Debug, Deserialize, Serialize, Default)]
 /// Officially Undocumented
@@ -10,7 +10,7 @@ use crate::types::{GuildMember, VoiceState};
 pub struct PassiveUpdateV1 {
     pub voice_states: Vec<VoiceState>,
     pub members: Option<Vec<GuildMember>>,
-    pub guild_id: String,
+    pub guild_id: Snowflake,
     pub channels: Vec<ChannelUnreadUpdateObject>,
 }
 

--- a/src/types/events/request_members.rs
+++ b/src/types/events/request_members.rs
@@ -1,14 +1,15 @@
-use crate::types::events::WebSocketEvent;
+use crate::types::{events::WebSocketEvent, Snowflake};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, Default)]
 /// See https://discord.com/developers/docs/topics/gateway-events#request-guild-members-request-guild-members-structure
 pub struct GatewayRequestGuildMembers {
-    pub guild_id: String,
+    pub guild_id: Snowflake,
     pub query: Option<String>,
     pub limit: u64,
     pub presences: Option<bool>,
-    pub user_ids: Option<String>,
+    // TODO: allow array
+    pub user_ids: Option<Snowflake>,
     pub nonce: Option<String>,
 }
 

--- a/src/types/events/thread.rs
+++ b/src/types/events/thread.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::entities::{Channel, ThreadMember};
 use crate::types::events::WebSocketEvent;
+use crate::types::Snowflake;
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#thread-create
@@ -33,8 +34,8 @@ impl WebSocketEvent for ThreadDelete {}
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#thread-list-sync
 pub struct ThreadListSync {
-    pub guild_id: String,
-    pub channel_ids: Option<Vec<String>>,
+    pub guild_id: Snowflake,
+    pub channel_ids: Option<Vec<Snowflake>>,
     pub threads: Vec<Channel>,
     pub members: Option<Vec<ThreadMember>>,
 }
@@ -47,7 +48,7 @@ impl WebSocketEvent for ThreadListSync {}
 pub struct ThreadMemberUpdate {
     #[serde(flatten)]
     pub member: ThreadMember,
-    pub guild_id: String,
+    pub guild_id: Snowflake,
 }
 
 impl WebSocketEvent for ThreadMemberUpdate {}
@@ -55,12 +56,12 @@ impl WebSocketEvent for ThreadMemberUpdate {}
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#thread-members-update
 pub struct ThreadMembersUpdate {
-    pub id: String,
-    pub guild_id: String,
+    pub id: Snowflake,
+    pub guild_id: Snowflake,
     /// Capped at 50
     pub member_count: u8,
     pub added_members: Option<Vec<ThreadMember>>,
-    pub removed_members: Option<Vec<String>>,
+    pub removed_members: Option<Vec<Snowflake>>,
 }
 
 impl WebSocketEvent for ThreadMembersUpdate {}

--- a/src/types/events/voice.rs
+++ b/src/types/events/voice.rs
@@ -1,4 +1,4 @@
-use crate::types::{events::WebSocketEvent, VoiceState};
+use crate::types::{events::WebSocketEvent, Snowflake, VoiceState};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, Default)]
@@ -7,8 +7,8 @@ use serde::{Deserialize, Serialize};
 ///
 /// Not to be confused with [VoiceStateUpdate];
 pub struct UpdateVoiceState {
-    pub guild_id: Option<String>,
-    pub channel_id: Option<String>,
+    pub guild_id: Option<Snowflake>,
+    pub channel_id: Option<Snowflake>,
     pub self_mute: bool,
     pub self_deaf: bool,
 }
@@ -34,7 +34,7 @@ impl WebSocketEvent for VoiceStateUpdate {}
 /// Received to indicate which voice endpoint, token and guild_id to use;
 pub struct VoiceServerUpdate {
     pub token: String,
-    pub guild_id: String,
+    pub guild_id: Snowflake,
     pub endpoint: Option<String>,
 }
 

--- a/src/types/events/webhooks.rs
+++ b/src/types/events/webhooks.rs
@@ -1,12 +1,14 @@
 use serde::{Deserialize, Serialize};
 
+use crate::types::Snowflake;
+
 use super::WebSocketEvent;
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 /// See https://discord.com/developers/docs/topics/gateway-events#webhooks-update
 pub struct WebhooksUpdate {
-    pub guild_id: String,
-    pub channel_id: String,
+    pub guild_id: Snowflake,
+    pub channel_id: Snowflake,
 }
 
 impl WebSocketEvent for WebhooksUpdate {}

--- a/src/types/interfaces/activity.rs
+++ b/src/types/interfaces/activity.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::types::entities::Emoji;
+use crate::types::{entities::Emoji, Snowflake};
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Activity {
@@ -10,7 +10,7 @@ pub struct Activity {
     url: Option<String>,
     created_at: i64,
     timestamps: Option<ActivityTimestamps>,
-    application_id: Option<String>,
+    application_id: Option<Snowflake>,
     details: Option<String>,
     state: Option<String>,
     emoji: Option<Emoji>,

--- a/src/types/schema/channel.rs
+++ b/src/types/schema/channel.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::types::entities::PermissionOverwrite;
+use crate::types::{entities::PermissionOverwrite, Snowflake};
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -15,8 +15,8 @@ pub struct ChannelCreateSchema {
     pub rate_limit_per_user: Option<i32>,
     pub position: Option<i32>,
     pub permission_overwrites: Option<Vec<PermissionOverwrite>>,
-    pub parent_id: Option<String>,
-    pub id: Option<String>,
+    pub parent_id: Option<Snowflake>,
+    pub id: Option<Snowflake>,
     pub nsfw: Option<bool>,
     pub rtc_region: Option<String>,
     pub default_auto_archive_duration: Option<i32>,
@@ -38,7 +38,7 @@ pub struct ChannelModifySchema {
     pub rate_limit_per_user: Option<i32>,
     pub position: Option<i32>,
     pub permission_overwrites: Option<Vec<PermissionOverwrite>>,
-    pub parent_id: Option<String>,
+    pub parent_id: Option<Snowflake>,
     pub nsfw: Option<bool>,
     pub rtc_region: Option<String>,
     pub default_auto_archive_duration: Option<i32>,

--- a/tests/channel.rs
+++ b/tests/channel.rs
@@ -47,13 +47,9 @@ async fn modify_channel() {
         default_thread_rate_limit_per_user: None,
         video_quality_mode: None,
     };
-    let result = Channel::modify(
-        modify_data,
-        &bundle.channel.id.to_string(),
-        &mut bundle.user,
-    )
-    .await
-    .unwrap();
+    let result = Channel::modify(modify_data, bundle.channel.id, &mut bundle.user)
+        .await
+        .unwrap();
     assert_eq!(result.name, Some("beepboop".to_string()));
 
     let permission_override = PermissionFlags::from_vec(Vec::from([
@@ -61,7 +57,7 @@ async fn modify_channel() {
         PermissionFlags::MANAGE_MESSAGES,
     ]));
     let permission_override = PermissionOverwrite {
-        id: bundle.user.object.id.to_string(),
+        id: bundle.user.object.id,
         overwrite_type: "1".to_string(),
         allow: permission_override,
         deny: "0".to_string(),
@@ -69,19 +65,15 @@ async fn modify_channel() {
 
     Channel::edit_permissions(
         &mut bundle.user,
-        bundle.channel.id.to_string().as_str(),
+        bundle.channel.id,
         permission_override.clone(),
     )
     .await
     .unwrap();
 
-    Channel::delete_permission(
-        &mut bundle.user,
-        bundle.channel.id.to_string().as_str(),
-        &permission_override.id,
-    )
-    .await
-    .unwrap();
+    Channel::delete_permission(&mut bundle.user, bundle.channel.id, permission_override.id)
+        .await
+        .unwrap();
 
     common::teardown(bundle).await
 }

--- a/tests/message.rs
+++ b/tests/message.rs
@@ -14,7 +14,7 @@ async fn send_message() {
     };
     let _ = bundle
         .user
-        .send_message(&mut message, bundle.channel.id.to_string(), None)
+        .send_message(&mut message, bundle.channel.id, None)
         .await
         .unwrap();
     common::teardown(bundle).await
@@ -57,7 +57,7 @@ async fn send_message_attachment() {
         .user
         .send_message(
             &mut message,
-            bundle.channel.id.to_string(),
+            bundle.channel.id,
             Some(vec![attachment.clone()]),
         )
         .await
@@ -76,7 +76,7 @@ async fn read_messages() {
     };
     let _ = bundle
         .user
-        .send_message(&mut message, bundle.channel.id.to_string(), None)
+        .send_message(&mut message, bundle.channel.id, None)
         .await
         .unwrap();
     common::teardown(bundle).await


### PR DESCRIPTION
I've definitely missed some, but these should be most. Sadly the Spacebar api docs use the type `string` both for strings and for snowflakes.