### PR TITLE
Always use Snowflakes in args

### DIFF
--- a/src/api/channels/channels.rs
+++ b/src/api/channels/channels.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 impl Channel {
-    pub async fn get(user: &mut UserMeta, channel_id: &str) -> ChorusResult<Channel> {
+    pub async fn get(user: &mut UserMeta, channel_id: Snowflake) -> ChorusResult<Channel> {
         let url = user.belongs_to.borrow_mut().urls.api.clone();
         let request = Client::new()
             .get(format!("{}/channels/{}/", url, channel_id))

--- a/src/api/channels/reactions.rs
+++ b/src/api/channels/reactions.rs
@@ -1,6 +1,11 @@
 use reqwest::Client;
 
-use crate::{api::handle_request_as_result, errors::ChorusResult, instance::UserMeta, types};
+use crate::{
+    api::handle_request_as_result,
+    errors::ChorusResult,
+    instance::UserMeta,
+    types::{self, Snowflake},
+};
 
 /**
 Useful metadata for working with [`types::Reaction`], bundled together nicely.
@@ -157,7 +162,7 @@ impl ReactionMeta {
     This endpoint requires the MANAGE_MESSAGES permission to be present on the current user.
 
     # Arguments
-    * `user_id` - A string slice containing the ID of the user whose reaction is to be deleted.
+    * `user_id` - ID of the user whose reaction is to be deleted.
     * `emoji` - A string slice containing the emoji to delete. The `emoji` must be URL Encoded or
     the request will fail with 10014: Unknown Emoji. To use custom emoji, you must encode it in the
     format name:id with the emoji name and emoji id.
@@ -172,7 +177,7 @@ impl ReactionMeta {
      */
     pub async fn delete_user(
         &self,
-        user_id: &str,
+        user_id: Snowflake,
         emoji: &str,
         user: &mut UserMeta,
     ) -> ChorusResult<()> {

--- a/src/api/guilds/member.rs
+++ b/src/api/guilds/member.rs
@@ -4,7 +4,7 @@ use crate::{
     api::{deserialize_response, handle_request_as_result},
     errors::ChorusResult,
     instance::UserMeta,
-    types,
+    types::{self, Snowflake},
 };
 
 impl types::GuildMember {
@@ -21,8 +21,8 @@ impl types::GuildMember {
     /// A [`Result`] containing a [`GuildMember`] if the request succeeds, or a [`ChorusLibError`] if the request fails.
     pub async fn get(
         user: &mut UserMeta,
-        guild_id: &str,
-        member_id: &str,
+        guild_id: Snowflake,
+        member_id: Snowflake,
     ) -> ChorusResult<types::GuildMember> {
         let url = format!(
             "{}/guilds/{}/members/{}/",
@@ -53,9 +53,9 @@ impl types::GuildMember {
     /// An `Result` containing a `ChorusLibError` if the request fails, or `()` if the request succeeds.
     pub async fn add_role(
         user: &mut UserMeta,
-        guild_id: &str,
-        member_id: &str,
-        role_id: &str,
+        guild_id: Snowflake,
+        member_id: Snowflake,
+        role_id: Snowflake,
     ) -> ChorusResult<()> {
         let url = format!(
             "{}/guilds/{}/members/{}/roles/{}/",
@@ -82,9 +82,9 @@ impl types::GuildMember {
     /// A `Result` containing a `ChorusLibError` if the request fails, or `()` if the request succeeds.
     pub async fn remove_role(
         user: &mut UserMeta,
-        guild_id: &str,
-        member_id: &str,
-        role_id: &str,
+        guild_id: Snowflake,
+        member_id: Snowflake,
+        role_id: Snowflake,
     ) -> Result<(), crate::errors::ChorusLibError> {
         let url = format!(
             "{}/guilds/{}/members/{}/roles/{}/",

--- a/src/api/guilds/roles.rs
+++ b/src/api/guilds/roles.rs
@@ -5,7 +5,7 @@ use crate::{
     api::deserialize_response,
     errors::{ChorusLibError, ChorusResult},
     instance::UserMeta,
-    types::{self, RoleCreateModifySchema, RoleObject},
+    types::{self, RoleCreateModifySchema, RoleObject, Snowflake},
 };
 
 impl types::RoleObject {
@@ -25,7 +25,7 @@ impl types::RoleObject {
     /// Returns a [`ChorusLibError`] if the request fails or if the response is invalid.
     pub async fn get_all(
         user: &mut UserMeta,
-        guild_id: &str,
+        guild_id: Snowflake,
     ) -> ChorusResult<Option<Vec<RoleObject>>> {
         let url = format!(
             "{}/guilds/{}/roles/",
@@ -63,8 +63,8 @@ impl types::RoleObject {
     /// Returns a [`ChorusLibError`] if the request fails or if the response is invalid.
     pub async fn get(
         user: &mut UserMeta,
-        guild_id: &str,
-        role_id: &str,
+        guild_id: Snowflake,
+        role_id: Snowflake,
     ) -> ChorusResult<RoleObject> {
         let url = format!(
             "{}/guilds/{}/roles/{}/",
@@ -93,7 +93,7 @@ impl types::RoleObject {
     /// Returns a [`ChorusLibError`] if the request fails or if the response is invalid.
     pub async fn create(
         user: &mut UserMeta,
-        guild_id: &str,
+        guild_id: Snowflake,
         role_create_schema: RoleCreateModifySchema,
     ) -> ChorusResult<RoleObject> {
         let url = format!(
@@ -127,7 +127,7 @@ impl types::RoleObject {
     /// Returns a [`ChorusLibError`] if the request fails or if the response is invalid.
     pub async fn position_update(
         user: &mut UserMeta,
-        guild_id: &str,
+        guild_id: Snowflake,
         role_position_update_schema: types::RolePositionUpdateSchema,
     ) -> ChorusResult<RoleObject> {
         let url = format!(
@@ -166,8 +166,8 @@ impl types::RoleObject {
     /// Returns a [`ChorusLibError`] if the request fails or if the response is invalid.
     pub async fn update(
         user: &mut UserMeta,
-        guild_id: &str,
-        role_id: &str,
+        guild_id: Snowflake,
+        role_id: Snowflake,
         role_create_schema: RoleCreateModifySchema,
     ) -> ChorusResult<RoleObject> {
         let url = format!(

--- a/src/api/users/relationships.rs
+++ b/src/api/users/relationships.rs
@@ -5,7 +5,7 @@ use crate::{
     api::{deserialize_response, handle_request_as_result},
     errors::ChorusResult,
     instance::UserMeta,
-    types::{self, CreateUserRelationshipSchema, RelationshipType},
+    types::{self, CreateUserRelationshipSchema, RelationshipType, Snowflake},
 };
 
 impl UserMeta {
@@ -13,13 +13,13 @@ impl UserMeta {
     ///
     /// # Arguments
     ///
-    /// * `user_id` - A string slice that holds the ID of the user to retrieve the mutual relationships with.
+    /// * `user_id` - ID of the user to retrieve the mutual relationships with.
     ///
     /// # Returns
     /// This function returns a [`ChorusResult<Vec<PublicUser>>`].
     pub async fn get_mutual_relationships(
         &mut self,
-        user_id: &str,
+        user_id: Snowflake,
     ) -> ChorusResult<Vec<types::PublicUser>> {
         let url = format!(
             "{}/users/{}/relationships/",
@@ -78,7 +78,7 @@ impl UserMeta {
     ///
     /// # Arguments
     ///
-    /// * `user_id` - A string slice that holds the ID of the user to modify the relationship with.
+    /// * `user_id` - ID of the user to modify the relationship with.
     /// * `relationship_type` - A [`RelationshipType`] enum that specifies the type of relationship to modify.
     ///     * [`RelationshipType::None`]: Removes the relationship between the two users.
     ///     * [`RelationshipType::Friends`] | [`RelationshipType::Incoming`] | [`RelationshipType::Outgoing`]:
@@ -90,7 +90,7 @@ impl UserMeta {
     /// This function returns an [`Result`] that holds a [`ChorusLibError`] if the request fails.
     pub async fn modify_user_relationship(
         &mut self,
-        user_id: &str,
+        user_id: Snowflake,
         relationship_type: RelationshipType,
     ) -> ChorusResult<()> {
         let api_url = self.belongs_to.borrow().urls.api.clone();
@@ -133,11 +133,11 @@ impl UserMeta {
     ///
     /// # Arguments
     ///
-    /// * `user_id` - A string slice that holds the ID of the user to remove the relationship with.
+    /// * `user_id` - ID of the user to remove the relationship with.
     ///
     /// # Returns
     /// This function returns a [`Result`] that holds a [`ChorusLibError`] if the request fails.
-    pub async fn remove_relationship(&mut self, user_id: &str) -> ChorusResult<()> {
+    pub async fn remove_relationship(&mut self, user_id: Snowflake) -> ChorusResult<()> {
         let url = format!(
             "{}/users/@me/relationships/{}/",
             self.belongs_to.borrow().urls.api,

--- a/src/types/entities/guild_member.rs
+++ b/src/types/entities/guild_member.rs
@@ -1,13 +1,13 @@
 use serde::{Deserialize, Serialize};
 
-use crate::types::entities::PublicUser;
+use crate::types::{entities::PublicUser, Snowflake};
 
 #[derive(Debug, Deserialize, Default, Serialize, Clone, PartialEq, Eq)]
 pub struct GuildMember {
     pub user: Option<PublicUser>,
     pub nick: Option<String>,
     pub avatar: Option<String>,
-    pub roles: Vec<String>,
+    pub roles: Vec<Snowflake>,
     pub joined_at: String,
     pub premium_since: Option<String>,
     pub deaf: bool,

--- a/tests/channel.rs
+++ b/tests/channel.rs
@@ -13,9 +13,7 @@ async fn get_channel() {
 
     assert_eq!(
         bundle_channel,
-        Channel::get(bundle_user, &bundle_channel.id.to_string())
-            .await
-            .unwrap()
+        Channel::get(bundle_user, bundle_channel.id).await.unwrap()
     );
     common::teardown(bundle).await
 }
@@ -23,7 +21,7 @@ async fn get_channel() {
 #[tokio::test]
 async fn delete_channel() {
     let mut bundle = common::setup().await;
-    let result = bundle.channel.clone().delete(&mut bundle.user).await;
+    let result = Channel::delete(bundle.channel.clone(), &mut bundle.user).await;
     assert!(result.is_ok());
     common::teardown(bundle).await
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,5 @@
 use chorus::{
+    errors::ChorusResult,
     instance::{Instance, UserMeta},
     types::{
         Channel, ChannelCreateSchema, Guild, GuildCreateSchema, RegisterSchema,
@@ -63,7 +64,7 @@ pub async fn setup() -> TestBundle {
     };
     let mut user = instance.register_account(&reg).await.unwrap();
     let guild = Guild::create(&mut user, guild_create_schema).await.unwrap();
-    let channel = Channel::create(&mut user, &guild.id.to_string(), channel_create_schema)
+    let channel = Channel::create(&mut user, guild.id, channel_create_schema)
         .await
         .unwrap();
 
@@ -77,8 +78,7 @@ pub async fn setup() -> TestBundle {
         position: None,
         color: None,
     };
-    let guild_id = guild.id.clone().to_string();
-    let role = chorus::types::RoleObject::create(&mut user, &guild_id, role_create_schema)
+    let role = chorus::types::RoleObject::create(&mut user, guild.id, role_create_schema)
         .await
         .unwrap();
 
@@ -95,6 +95,8 @@ pub async fn setup() -> TestBundle {
 // Teardown method to clean up after a test.
 #[allow(dead_code)]
 pub async fn teardown(mut bundle: TestBundle) {
-    Guild::delete(&mut bundle.user, &bundle.guild.id.to_string()).await;
-    bundle.user.delete().await;
+    Guild::delete(&mut bundle.user, bundle.guild.id)
+        .await
+        .unwrap();
+    bundle.user.delete().await.unwrap()
 }

--- a/tests/guild.rs
+++ b/tests/guild.rs
@@ -20,9 +20,7 @@ async fn guild_creation_deletion() {
         .await
         .unwrap();
 
-    assert!(Guild::delete(&mut bundle.user, &guild.id.to_string())
-        .await
-        .is_ok());
+    assert!(Guild::delete(&mut bundle.user, guild.id).await.is_ok());
     common::teardown(bundle).await
 }
 

--- a/tests/relationships.rs
+++ b/tests/relationships.rs
@@ -21,7 +21,7 @@ async fn test_get_mutual_relationships() {
     };
     other_user.send_friend_request(friend_request_schema).await;
     let relationships = user
-        .get_mutual_relationships(&other_user.object.id.to_string())
+        .get_mutual_relationships(other_user.object.id)
         .await
         .unwrap();
     println!("{:?}", relationships);
@@ -65,10 +65,7 @@ async fn test_modify_relationship_friends() {
     let user = &mut bundle.user;
     let mut other_user = belongs_to.register_account(&register_schema).await.unwrap();
     other_user
-        .modify_user_relationship(
-            &user.object.id.to_string(),
-            types::RelationshipType::Friends,
-        )
+        .modify_user_relationship(user.object.id, types::RelationshipType::Friends)
         .await;
     let relationships = user.get_relationships().await.unwrap();
     assert_eq!(relationships.get(0).unwrap().id, other_user.object.id);
@@ -82,11 +79,8 @@ async fn test_modify_relationship_friends() {
         relationships.get(0).unwrap().relationship_type,
         RelationshipType::Outgoing
     );
-    user.modify_user_relationship(
-        other_user.object.id.to_string().as_str(),
-        RelationshipType::Friends,
-    )
-    .await;
+    user.modify_user_relationship(other_user.object.id, RelationshipType::Friends)
+        .await;
     assert_eq!(
         other_user
             .get_relationships()
@@ -97,8 +91,7 @@ async fn test_modify_relationship_friends() {
             .relationship_type,
         RelationshipType::Friends
     );
-    user.remove_relationship(other_user.object.id.to_string().as_str())
-        .await;
+    user.remove_relationship(other_user.object.id).await;
     assert_eq!(
         other_user.get_relationships().await.unwrap(),
         Vec::<Relationship>::new()
@@ -120,10 +113,7 @@ async fn test_modify_relationship_block() {
     let user = &mut bundle.user;
     let mut other_user = belongs_to.register_account(&register_schema).await.unwrap();
     other_user
-        .modify_user_relationship(
-            &user.object.id.to_string(),
-            types::RelationshipType::Blocked,
-        )
+        .modify_user_relationship(user.object.id, types::RelationshipType::Blocked)
         .await;
     let relationships = user.get_relationships().await.unwrap();
     assert_eq!(relationships, Vec::<Relationship>::new());
@@ -133,9 +123,7 @@ async fn test_modify_relationship_block() {
         relationships.get(0).unwrap().relationship_type,
         RelationshipType::Blocked
     );
-    other_user
-        .remove_relationship(user.object.id.to_string().as_str())
-        .await;
+    other_user.remove_relationship(user.object.id).await;
     assert_eq!(
         other_user.get_relationships().await.unwrap(),
         Vec::<Relationship>::new()

--- a/tests/roles.rs
+++ b/tests/roles.rs
@@ -17,12 +17,12 @@ async fn create_and_get_roles() {
         position: None,
         color: None,
     };
-    let guild_id = bundle.guild.id.clone().to_string();
-    let role = types::RoleObject::create(&mut bundle.user, &guild_id, role_create_schema)
+    let guild = bundle.guild.id;
+    let role = types::RoleObject::create(&mut bundle.user, guild, role_create_schema)
         .await
         .unwrap();
 
-    let expected = types::RoleObject::get_all(&mut bundle.user, &guild_id)
+    let expected = types::RoleObject::get_all(&mut bundle.user, guild)
         .await
         .unwrap()
         .unwrap()[2]
@@ -35,8 +35,8 @@ async fn create_and_get_roles() {
 #[tokio::test]
 async fn get_singular_role() {
     let mut bundle = common::setup().await;
-    let guild_id = &bundle.guild.id.to_string();
-    let role_id = &bundle.role.id.to_string();
+    let guild_id = bundle.guild.id;
+    let role_id = bundle.role.id;
     let role = bundle.role.clone();
     let same_role = chorus::types::RoleObject::get(&mut bundle.user, guild_id, role_id)
         .await


### PR DESCRIPTION
Covers function arguments missed by #122. This also lead to an elimination of a bunch of clone calls.