### PR TITLE
Refactor/change channel modify

### DIFF
--- a/src/api/channels/channels.rs
+++ b/src/api/channels/channels.rs
@@ -88,11 +88,7 @@ impl Channel {
             user,
             crate::api::limits::LimitType::Channel,
         )
-        .await
-        {
-            Ok(channel) => channel,
-            Err(e) => return Err(e),
-        };
+        .await?;
         let _ = std::mem::replace(self, new_channel);
         Ok(())
     }

--- a/src/api/channels/channels.rs
+++ b/src/api/channels/channels.rs
@@ -83,7 +83,7 @@ impl Channel {
             ))
             .bearer_auth(user.token())
             .body(to_string(&modify_data).unwrap());
-        let new_channel = match common::deserialize_response::<Channel>(
+        let new_channel = common::deserialize_response::<Channel>(
             request,
             user,
             crate::api::limits::LimitType::Channel,

--- a/tests/channel.rs
+++ b/tests/channel.rs
@@ -31,6 +31,7 @@ async fn delete_channel() {
 #[tokio::test]
 async fn modify_channel() {
     let mut bundle = common::setup().await;
+    let channel = &mut bundle.channel;
     let modify_data: types::ChannelModifySchema = types::ChannelModifySchema {
         name: Some("beepboop".to_string()),
         channel_type: None,
@@ -50,10 +51,10 @@ async fn modify_channel() {
         default_thread_rate_limit_per_user: None,
         video_quality_mode: None,
     };
-    let result = Channel::modify(modify_data, bundle.channel.id, &mut bundle.user)
+    Channel::modify(channel, modify_data, channel.id, &mut bundle.user)
         .await
         .unwrap();
-    assert_eq!(result.name, Some("beepboop".to_string()));
+    assert_eq!(channel.name, Some("beepboop".to_string()));
 
     let permission_override = PermissionFlags::from_vec(Vec::from([
         PermissionFlags::MANAGE_CHANNELS,


### PR DESCRIPTION
This PR makes it so that `Channel::modify()` takes `&mut self` as a parameter. Read https://github.com/polyphony-chat/chorus/pull/128#issuecomment-1602995159 for more info.