### PR TITLE
Revert actions build back to debug

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -32,6 +32,6 @@ jobs:
       working-directory: ./server
     - uses: Swatinem/rust-cache@v2
     - name: Build
-      run: cargo build --release --verbose
+      run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose


### PR DESCRIPTION
Cargo build --release is faster for builds, but test uses debug built libraries, so it rebuilds them