### PR TITLE
Enable saving and loading LimitsConfiguration

### DIFF
--- a/src/api/policies/instance/ratelimits.rs
+++ b/src/api/policies/instance/ratelimits.rs
@@ -1,11 +1,13 @@
 use std::hash::Hash;
 
+use serde::{Deserialize, Serialize};
+
 use crate::types::Snowflake;
 
 /// The different types of ratelimits that can be applied to a request. Includes "Baseline"-variants
 /// for when the Snowflake is not yet known.
 /// See <https://discord.com/developers/docs/topics/rate-limits#rate-limits> for more information.
-#[derive(Clone, Copy, Eq, PartialEq, Debug, Default, Hash)]
+#[derive(Clone, Copy, Eq, PartialEq, Debug, Default, Hash, Serialize, Deserialize)]
 pub enum LimitType {
     AuthRegister,
     AuthLogin,
@@ -25,7 +27,7 @@ pub enum LimitType {
 /// Unlike [`RateLimits`], this struct shows the current ratelimits, not the rate limit
 /// configuration for the instance.
 /// See <https://discord.com/developers/docs/topics/rate-limits#rate-limits> for more information.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Limit {
     pub bucket: LimitType,
     pub limit: u64,

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -25,7 +25,7 @@ pub struct Instance {
     pub client: Client,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LimitsInformation {
     pub ratelimits: HashMap<LimitType, Limit>,
     pub configuration: RateLimits,


### PR DESCRIPTION
Implementing serdes `Deserialize` and `Serialize` for `LimitsConfiguration` and its children types provides one with all the tools needed to store and load this information on disk. Remembering rate limits is important if you want to build things like a Client based on Chorus. Closes #34 