### PR TITLE
Improve auto updating structs usage

### DIFF
--- a/src/api/auth/register.rs
+++ b/src/api/auth/register.rs
@@ -3,6 +3,8 @@ use std::{cell::RefCell, rc::Rc};
 use reqwest::Client;
 use serde_json::to_string;
 
+use crate::gateway::Gateway;
+use crate::types::GatewayIdentifyPayload;
 use crate::{
     api::policies::instance::LimitType,
     errors::ChorusResult,
@@ -35,7 +37,8 @@ impl Instance {
         // We do not have a user yet, and the UserRateLimits will not be affected by a login
         // request (since register is an instance wide limit), which is why we are just cloning
         // the instances' limits to pass them on as user_rate_limits later.
-        let mut shell = UserMeta::shell(Rc::new(RefCell::new(self.clone())), "None".to_string());
+        let mut shell =
+            UserMeta::shell(Rc::new(RefCell::new(self.clone())), "None".to_string()).await;
         let token = chorus_request
             .deserialize_response::<Token>(&mut shell)
             .await?
@@ -45,12 +48,17 @@ impl Instance {
         }
         let user_object = self.get_user(token.clone(), None).await.unwrap();
         let settings = UserMeta::get_settings(&token, &self.urls.api.clone(), self).await?;
+        let mut identify = GatewayIdentifyPayload::common();
+        let gateway = Gateway::new(self.urls.wss.clone()).await.unwrap();
+        identify.token = token.clone();
+        gateway.send_identify(identify).await;
         let user = UserMeta::new(
             Rc::new(RefCell::new(self.clone())),
             token.clone(),
             self.clone_limits_if_some(),
             settings,
             user_object,
+            gateway,
         );
         Ok(user)
     }

--- a/src/api/users/users.rs
+++ b/src/api/users/users.rs
@@ -122,7 +122,8 @@ impl User {
         let request: reqwest::RequestBuilder = Client::new()
             .get(format!("{}/users/@me/settings/", url_api))
             .bearer_auth(token);
-        let mut user = UserMeta::shell(Rc::new(RefCell::new(instance.clone())), token.clone());
+        let mut user =
+            UserMeta::shell(Rc::new(RefCell::new(instance.clone())), token.clone()).await;
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::Global,
@@ -151,7 +152,7 @@ impl Instance {
     This function is a wrapper around [`User::get`].
      */
     pub async fn get_user(&mut self, token: String, id: Option<&String>) -> ChorusResult<User> {
-        let mut user = UserMeta::shell(Rc::new(RefCell::new(self.clone())), token);
+        let mut user = UserMeta::shell(Rc::new(RefCell::new(self.clone())), token).await;
         let result = User::get(&mut user, id).await;
         if self.limits_information.is_some() {
             self.limits_information.as_mut().unwrap().ratelimits =

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,3 +1,4 @@
+use chorus::gateway::Gateway;
 use chorus::{
     instance::{Instance, UserMeta},
     types::{
@@ -18,8 +19,8 @@ pub(crate) struct TestBundle {
     pub channel: Channel,
 }
 
+#[allow(unused)]
 impl TestBundle {
-    #[allow(unused)]
     pub(crate) async fn create_user(&mut self, username: &str) -> UserMeta {
         let register_schema = RegisterSchema {
             username: username.to_string(),
@@ -31,6 +32,16 @@ impl TestBundle {
             .register_account(&register_schema)
             .await
             .unwrap()
+    }
+    pub(crate) async fn clone_user_without_gateway(&self) -> UserMeta {
+        UserMeta {
+            belongs_to: self.user.belongs_to.clone(),
+            token: self.user.token.clone(),
+            limits: self.user.limits.clone(),
+            settings: self.user.settings.clone(),
+            object: self.user.object.clone(),
+            gateway: Gateway::new(self.instance.urls.wss.clone()).await.unwrap(),
+        }
     }
 }
 

--- a/tests/gateway.rs
+++ b/tests/gateway.rs
@@ -8,7 +8,8 @@ use chorus::types::{self, Channel};
 async fn test_gateway_establish() {
     let bundle = common::setup().await;
 
-    Gateway::new(bundle.urls.wss).await.unwrap();
+    Gateway::new(bundle.urls.wss.clone()).await.unwrap();
+    common::teardown(bundle).await
 }
 
 #[tokio::test]
@@ -16,25 +17,21 @@ async fn test_gateway_establish() {
 async fn test_gateway_authenticate() {
     let bundle = common::setup().await;
 
-    let gateway = Gateway::new(bundle.urls.wss).await.unwrap();
+    let gateway = Gateway::new(bundle.urls.wss.clone()).await.unwrap();
 
     let mut identify = types::GatewayIdentifyPayload::common();
-    identify.token = bundle.user.token;
+    identify.token = bundle.user.token.clone();
 
     gateway.send_identify(identify).await;
+    common::teardown(bundle).await
 }
 
 #[tokio::test]
 async fn test_self_updating_structs() {
     let mut bundle = common::setup().await;
-    let gateway = Gateway::new(bundle.urls.wss).await.unwrap();
-    let mut identify = types::GatewayIdentifyPayload::common();
-    identify.token = bundle.user.token.clone();
-    gateway.send_identify(identify).await;
-    let channel_receiver = gateway.observe(bundle.channel.clone()).await;
-    let received_channel = channel_receiver.borrow();
-    assert_eq!(*received_channel, bundle.channel);
-    drop(received_channel);
+    let channel_updater = bundle.user.gateway.observe(bundle.channel.clone()).await;
+    let received_channel = channel_updater.borrow().clone();
+    assert_eq!(received_channel, bundle.channel);
     let channel = &mut bundle.channel;
     let modify_data = types::ChannelModifySchema {
         name: Some("beepboop".to_string()),
@@ -43,6 +40,7 @@ async fn test_self_updating_structs() {
     Channel::modify(channel, modify_data, channel.id, &mut bundle.user)
         .await
         .unwrap();
-    let received_channel = channel_receiver.borrow();
+    let received_channel = channel_updater.borrow();
     assert_eq!(received_channel.name.as_ref().unwrap(), "beepboop");
+    common::teardown(bundle).await
 }

--- a/tests/invites.rs
+++ b/tests/invites.rs
@@ -1,14 +1,12 @@
-use chorus::types::CreateChannelInviteSchema;
-
 mod common;
-
+use chorus::types::CreateChannelInviteSchema;
 #[tokio::test]
 async fn create_accept_invite() {
     let mut bundle = common::setup().await;
     let channel = bundle.channel.clone();
-    let mut user = bundle.user.clone();
-    let create_channel_invite_schema = CreateChannelInviteSchema::default();
     let mut other_user = bundle.create_user("testuser1312").await;
+    let user = &mut bundle.user;
+    let create_channel_invite_schema = CreateChannelInviteSchema::default();
     assert!(chorus::types::Guild::get(bundle.guild.id, &mut other_user)
         .await
         .is_err());


### PR DESCRIPTION
By adding `GatewayHandle` to `UserMeta` (which we should do anyways), the initalization code for the gateway connection can be moved there, which cleans up the usage of auto updating structs by deduplicating/removing boilerplate.