### PR TITLE
Minor improvements to message events

### DIFF
--- a/src/types/events/message.rs
+++ b/src/types/events/message.rs
@@ -8,6 +8,8 @@ use crate::types::{
 use super::WebSocketEvent;
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
+/// # Reference
+/// See <https://discord.com/developers/docs/topics/gateway-events#typing-start>
 pub struct TypingStartEvent {
     pub channel_id: Snowflake,
     pub guild_id: Option<Snowflake>,
@@ -22,89 +24,103 @@ impl WebSocketEvent for TypingStartEvent {}
 /// See <https://discord.com/developers/docs/topics/gateway-events#message-create>
 pub struct MessageCreate {
     #[serde(flatten)]
-    message: Message,
-    guild_id: Option<Snowflake>,
-    member: Option<GuildMember>,
-    mentions: Option<Vec<MessageCreateUser>>,
+    pub message: Message,
+    pub guild_id: Option<Snowflake>,
+    pub member: Option<GuildMember>,
+    pub mentions: Option<Vec<MessageCreateUser>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
 /// See <https://discord.com/developers/docs/topics/gateway-events#message-create-message-create-extra-fields>
 pub struct MessageCreateUser {
     #[serde(flatten)]
-    user: PublicUser,
-    member: Option<GuildMember>,
+    pub user: PublicUser,
+    pub member: Option<GuildMember>,
 }
 
 impl WebSocketEvent for MessageCreate {}
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
+/// # Reference
+/// See <https://discord.com/developers/docs/topics/gateway-events#message-update>
 pub struct MessageUpdate {
     #[serde(flatten)]
-    message: Message,
-    guild_id: Option<Snowflake>,
-    member: Option<GuildMember>,
-    mentions: Option<Vec<MessageCreateUser>>,
+    pub message: Message,
+    pub guild_id: Option<Snowflake>,
+    pub member: Option<GuildMember>,
+    pub mentions: Option<Vec<MessageCreateUser>>,
 }
 
 impl WebSocketEvent for MessageUpdate {}
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
+/// # Reference
+/// See <https://discord.com/developers/docs/topics/gateway-events#message-delete>
 pub struct MessageDelete {
-    id: Snowflake,
-    channel_id: Snowflake,
-    guild_id: Option<Snowflake>,
+    pub id: Snowflake,
+    pub channel_id: Snowflake,
+    pub guild_id: Option<Snowflake>,
 }
 
 impl WebSocketEvent for MessageDelete {}
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
+/// # Reference
+/// See <https://discord.com/developers/docs/topics/gateway-events#message-delete-bulk>
 pub struct MessageDeleteBulk {
-    ids: Vec<Snowflake>,
-    channel_id: Snowflake,
-    guild_id: Option<Snowflake>,
+    pub ids: Vec<Snowflake>,
+    pub channel_id: Snowflake,
+    pub guild_id: Option<Snowflake>,
 }
 
 impl WebSocketEvent for MessageDeleteBulk {}
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
+/// # Reference
+/// See <https://discord.com/developers/docs/topics/gateway-events#message-reaction-add>
 pub struct MessageReactionAdd {
-    user_id: Snowflake,
-    channel_id: Snowflake,
-    message_id: Snowflake,
-    guild_id: Option<Snowflake>,
-    member: Option<GuildMember>,
-    emoji: Emoji,
+    pub user_id: Snowflake,
+    pub channel_id: Snowflake,
+    pub message_id: Snowflake,
+    pub guild_id: Option<Snowflake>,
+    pub member: Option<GuildMember>,
+    pub emoji: Emoji,
 }
 
 impl WebSocketEvent for MessageReactionAdd {}
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
+/// # Reference
+/// See <https://discord.com/developers/docs/topics/gateway-events#message-reaction-remove>
 pub struct MessageReactionRemove {
-    user_id: Snowflake,
-    channel_id: Snowflake,
-    message_id: Snowflake,
-    guild_id: Option<Snowflake>,
-    emoji: Emoji,
+    pub user_id: Snowflake,
+    pub channel_id: Snowflake,
+    pub message_id: Snowflake,
+    pub guild_id: Option<Snowflake>,
+    pub emoji: Emoji,
 }
 
 impl WebSocketEvent for MessageReactionRemove {}
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
+/// # Reference
+/// See <https://discord.com/developers/docs/topics/gateway-events#message-reaction-remove-all>
 pub struct MessageReactionRemoveAll {
-    channel_id: Snowflake,
-    message_id: Snowflake,
-    guild_id: Option<Snowflake>,
+    pub channel_id: Snowflake,
+    pub message_id: Snowflake,
+    pub guild_id: Option<Snowflake>,
 }
 
 impl WebSocketEvent for MessageReactionRemoveAll {}
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
+/// # Reference
+/// See <https://discord.com/developers/docs/topics/gateway-events#message-reaction-remove-emoji>
 pub struct MessageReactionRemoveEmoji {
-    channel_id: Snowflake,
-    message_id: Snowflake,
-    guild_id: Option<Snowflake>,
-    emoji: Emoji,
+    pub channel_id: Snowflake,
+    pub message_id: Snowflake,
+    pub guild_id: Option<Snowflake>,
+    pub emoji: Emoji,
 }
 
 impl WebSocketEvent for MessageReactionRemoveEmoji {}


### PR DESCRIPTION
Turns out a few Message related gateway events had private fields and didn't have a linked reference (despite being officially documented)

Quickly fixed that :)