### PR TITLE
Minor snowflake updates

### DIFF
--- a/src/types/utils/snowflake.rs
+++ b/src/types/utils/snowflake.rs
@@ -53,6 +53,15 @@ impl Display for Snowflake {
     }
 }
 
+impl<T> From<T> for Snowflake
+where
+    T: Into<u64>,
+{
+    fn from(item: T) -> Self {
+        Self(item.into())
+    }
+}
+
 impl serde::Serialize for Snowflake {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
If I already have a Snowflake integer, I currently cannot make a `Snowflake` type out of it, since the inner `u64` of the `Snowflake` struct is private. This pr makes it public.

Another solution that would allow making `Snowflake`s from integers would be to make a public `new()` function for `Snowflake`.