### PR TITLE
Create Guild Ban

### DIFF
--- a/src/api/guilds/guilds.rs
+++ b/src/api/guilds/guilds.rs
@@ -7,8 +7,8 @@ use crate::errors::ChorusError;
 use crate::errors::ChorusResult;
 use crate::instance::UserMeta;
 use crate::ratelimiter::ChorusRequest;
-use crate::types::Snowflake;
-use crate::types::{Channel, ChannelCreateSchema, Guild, GuildCreateSchema};
+use crate::types::{Channel, ChannelCreateSchema, Guild, GuildBanCreateSchema, GuildCreateSchema};
+use crate::types::{GuildBan, Snowflake};
 
 impl Guild {
     /// Creates a new guild.
@@ -135,6 +135,30 @@ impl Guild {
             limit_type: LimitType::Guild(guild_id),
         };
         let response = chorus_request.deserialize_response::<Guild>(user).await?;
+        Ok(response)
+    }
+
+    pub async fn create_ban(
+        guild_id: Snowflake,
+        user_id: Snowflake,
+        schema: GuildBanCreateSchema,
+        user: &mut UserMeta,
+    ) -> ChorusResult<GuildBan> {
+        let chorus_request = ChorusRequest {
+            request: Client::new()
+                .put(format!(
+                    "{}/guilds/{}/bans/{}",
+                    user.belongs_to.borrow().urls.api,
+                    guild_id,
+                    user_id
+                ))
+                .header("Authorization", user.token())
+                .body(to_string(&schema).unwrap()),
+            limit_type: LimitType::Guild(guild_id),
+        };
+        let response = chorus_request
+            .deserialize_response::<GuildBan>(user)
+            .await?;
         Ok(response)
     }
 }

--- a/src/types/schema/guild.rs
+++ b/src/types/schema/guild.rs
@@ -2,10 +2,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::entities::Channel;
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 /// Represents the schema which needs to be sent to create a Guild.
-/// See: [https://docs.spacebar.chat/routes/#cmp--schemas-guildcreateschema](https://docs.spacebar.chat/routes/#cmp--schemas-guildcreateschema)
+/// See: <https://docs.spacebar.chat/routes/#cmp--schemas-guildcreateschema>
 pub struct GuildCreateSchema {
     pub name: Option<String>,
     pub region: Option<String>,
@@ -14,4 +14,13 @@ pub struct GuildCreateSchema {
     pub guild_template_code: Option<String>,
     pub system_channel_id: Option<String>,
     pub rules_channel_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Default, Clone, Copy, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+/// Represents the schema which needs to be sent to create a Guild Ban.
+/// See: <https://discord-userdoccers.vercel.app/resources/guild#create-guild-ban>
+pub struct GuildBanCreateSchema {
+    pub delete_message_days: Option<u8>,
+    pub delete_message_seconds: Option<u32>,
 }


### PR DESCRIPTION
- Closes #299
- Add derives for `GuildCreateSchema`
- Add `GuildBanCreateSchema`
- Add `Guild::create_ban` 