### PR TITLE
Make ban test a little more meaningful

### DIFF
--- a/tests/guilds.rs
+++ b/tests/guilds.rs
@@ -56,5 +56,13 @@ async fn guild_create_ban() {
     )
     .await
     .unwrap();
+    assert!(Guild::create_ban(
+        guild.id,
+        other_user_id,
+        GuildBanCreateSchema::default(),
+        &mut bundle.user,
+    )
+    .await
+    .is_err());
     common::teardown(bundle).await
 }


### PR DESCRIPTION
By checking for an error on trying to ban the same person again, we can kind of gauge if the ban functionality actually works.