### PR TITLE
Make GatewayHandle Clone and remove Arc

### DIFF
--- a/src/api/auth/login.rs
+++ b/src/api/auth/login.rs
@@ -46,7 +46,7 @@ impl Instance {
             self.clone_limits_if_some(),
             login_result.settings,
             Arc::new(RwLock::new(object)),
-            Arc::new(gateway),
+            gateway,
         );
         Ok(user)
     }

--- a/src/api/auth/register.rs
+++ b/src/api/auth/register.rs
@@ -54,7 +54,7 @@ impl Instance {
             self.clone_limits_if_some(),
             Arc::new(RwLock::new(settings)),
             Arc::new(RwLock::new(user_object)),
-            Arc::new(gateway),
+            gateway,
         );
         Ok(user)
     }

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -158,7 +158,7 @@ pub type ObservableObject = dyn Send + Sync + Any;
 /// [`GatewayEvents`](GatewayEvent), which you can subscribe to. Gateway events include all currently
 /// implemented types with the trait [`WebSocketEvent`]
 /// Using this handle you can also send Gateway Events directly.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct GatewayHandle {
     pub url: String,
     pub events: Arc<Mutex<Events>>,
@@ -170,7 +170,6 @@ pub struct GatewayHandle {
             >,
         >,
     >,
-    pub handle: JoinHandle<()>,
     /// Tells gateway tasks to close
     kill_send: tokio::sync::broadcast::Sender<()>,
     pub(crate) store: Arc<Mutex<HashMap<Snowflake, Arc<RwLock<ObservableObject>>>>>,
@@ -410,7 +409,7 @@ impl Gateway {
         };
 
         // Now we can continuously check for messages in a different task, since we aren't going to receive another hello
-        let handle: JoinHandle<()> = task::spawn(async move {
+        task::spawn(async move {
             gateway.gateway_listen_task().await;
         });
 
@@ -418,7 +417,6 @@ impl Gateway {
             url: websocket_url.clone(),
             events: shared_events,
             websocket_send: shared_websocket_send.clone(),
-            handle,
             kill_send: kill_send.clone(),
             store,
         })

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -94,7 +94,7 @@ pub struct ChorusUser {
     pub limits: Option<HashMap<LimitType, Limit>>,
     pub settings: Arc<RwLock<UserSettings>>,
     pub object: Arc<RwLock<User>>,
-    pub gateway: Arc<GatewayHandle>, // TODO: Can this be an Arc<GatewayHandle>? That way we could have Clone implemented on ChorusUser
+    pub gateway: GatewayHandle,
 }
 
 impl ChorusUser {
@@ -117,7 +117,7 @@ impl ChorusUser {
         limits: Option<HashMap<LimitType, Limit>>,
         settings: Arc<RwLock<UserSettings>>,
         object: Arc<RwLock<User>>,
-        gateway: Arc<GatewayHandle>,
+        gateway: GatewayHandle,
     ) -> ChorusUser {
         ChorusUser {
             belongs_to,
@@ -139,7 +139,7 @@ impl ChorusUser {
         let object = Arc::new(RwLock::new(User::default()));
         let wss_url = instance.read().unwrap().urls.wss.clone();
         // Dummy gateway object
-        let gateway = Arc::new(Gateway::new(wss_url).await.unwrap());
+        let gateway = Gateway::new(wss_url).await.unwrap();
         ChorusUser {
             token,
             belongs_to: instance.clone(),

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -42,7 +42,7 @@ impl TestBundle {
             limits: self.user.limits.clone(),
             settings: self.user.settings.clone(),
             object: self.user.object.clone(),
-            gateway: Arc::new(Gateway::new(self.instance.urls.wss.clone()).await.unwrap()),
+            gateway: Gateway::new(self.instance.urls.wss.clone()).await.unwrap(),
         }
     }
 }


### PR DESCRIPTION
As `GatewayHandle` in itself is just a bundle of refrences, this pr makes it clonable and removes the `Arc` from `ChorusUser`.