### PR TITLE
Remove openssl, use rustls and rand instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,10 +192,12 @@ dependencies = [
  "lazy_static",
  "log",
  "native-tls",
- "openssl",
  "poem",
+ "rand",
  "regex",
  "reqwest",
+ "rustls",
+ "rustls-native-certs",
  "rusty-hook",
  "serde",
  "serde-aux",
@@ -957,7 +959,7 @@ checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
 dependencies = [
  "base64 0.21.3",
  "pem",
- "ring",
+ "ring 0.16.20",
  "serde",
  "serde_json",
  "simple_asn1",
@@ -974,9 +976,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libm"
@@ -1554,9 +1556,23 @@ dependencies = [
  "libc",
  "once_cell",
  "spin 0.5.2",
- "untrusted",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
+dependencies = [
+ "cc",
+ "getrandom",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1601,6 +1617,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446e14c5cda4f3f30fe71863c34ec70f5ac79d6087097ad0bb433e1be5edf04c"
+dependencies = [
+ "log",
+ "ring 0.17.5",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
+dependencies = [
+ "base64 0.21.3",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring 0.17.5",
+ "untrusted 0.9.0",
+]
+
+[[package]]
 name = "rusty-hook"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1632,6 +1691,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring 0.16.20",
+ "untrusted 0.7.1",
+]
 
 [[package]]
 name = "security-framework"
@@ -2248,6 +2317,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2266,9 +2345,10 @@ checksum = "2b2dbec703c26b00d74844519606ef15d09a7d6857860f84ad223dec002ddea2"
 dependencies = [
  "futures-util",
  "log",
- "native-tls",
+ "rustls",
+ "rustls-native-certs",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tungstenite",
 ]
 
@@ -2369,8 +2449,8 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "native-tls",
  "rand",
+ "rustls",
  "sha1",
  "thiserror",
  "url",
@@ -2445,6 +2525,12 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,12 @@ chrono = { version = "0.4.26", features = ["serde"] }
 regex = "1.9.4"
 custom_error = "1.9.2"
 native-tls = "0.2.11"
-tokio-tungstenite = { version = "0.20.0", features = ["native-tls"] }
+tokio-tungstenite = { version = "0.20.0", features = [
+    "rustls-tls-native-roots",
+    "rustls-native-certs",
+] }
 futures-util = "0.3.28"
 http = "0.2.9"
-openssl = "0.10.56"
 base64 = "0.21.3"
 hostname = "0.3.1"
 bitflags = { version = "2.4.0", features = ["serde"] }
@@ -51,6 +53,9 @@ jsonwebtoken = "8.3.0"
 log = "0.4.20"
 async-trait = "0.1.73"
 chorus-macros = "0.2.0"
+rustls = "0.21.8"
+rustls-native-certs = "0.6.3"
+rand = "0.8.5"
 
 [dev-dependencies]
 tokio = { version = "1.32.0", features = ["full"] }

--- a/src/types/config/types/security_configuration.rs
+++ b/src/types/config/types/security_configuration.rs
@@ -1,4 +1,5 @@
 use base64::Engine;
+use rand::Fill;
 use serde::{Deserialize, Serialize};
 
 use crate::types::config::types::subconfigs::security::{
@@ -22,10 +23,15 @@ pub struct SecurityConfiguration {
 
 impl Default for SecurityConfiguration {
     fn default() -> Self {
+        let mut rng: rand::rngs::ThreadRng = rand::thread_rng();
         let mut req_sig: [u8; 32] = [0; 32];
-        let _ = openssl::rand::rand_bytes(&mut req_sig);
         let mut jwt_secret: [u8; 256] = [0; 256];
-        let _ = openssl::rand::rand_bytes(&mut jwt_secret);
+        req_sig
+            .try_fill(&mut rng)
+            .expect("Unable to generate cryptographically safe secrets.");
+        jwt_secret
+            .try_fill(&mut rng)
+            .expect("Unable to generate cryptographically safe secrets.");
         Self {
             captcha: Default::default(),
             two_factor: Default::default(),


### PR DESCRIPTION
This PR removes the dependency on `openssl`, which is not compatible with the `wasm32-unknown-unknown` target, completely. It is replaced by `rustls` for TLS/SSL and `rand` for cryptographically safe pseudo-RNG.