### PR TITLE
initial wasm32 'support'

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+runner = 'wasm-bindgen-test-runner'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -38,10 +38,10 @@ jobs:
       run: |
         rustup target add wasm32-unknown-unknown
         curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-        GECKODRIVER=/usr/local/share/gecko_driver CHROMEDRIVER=/usr/local/share/chromedriver-linux64 sudo cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"
+        cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.88" --force
+        GECKODRIVER=/usr/local/share/gecko_driver CHROMEDRIVER=/usr/local/share/chromedriver-linux64 cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"
         if [ -n "${{ secrets.COVERALLS_REPO_TOKEN }}" ]; then
           curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-          cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.88" --force
           cargo binstall --no-confirm cargo-tarpaulin --force
           cargo tarpaulin --all-features --avoid-cfg-tarpaulin --tests --verbose --skip-clean --coveralls ${{ secrets.COVERALLS_REPO_TOKEN }} --timeout 120
         else

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -40,7 +40,7 @@ jobs:
         curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
         curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
         cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.88" --force
-        GECKODRIVER=/usr/local/share/gecko_driver cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"
+        CHROMEDRIVER=/usr/local/share/chromedriver-linux64 cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"
         if [ -n "${{ secrets.COVERALLS_REPO_TOKEN }}" ]; then
           cargo binstall --no-confirm cargo-tarpaulin --force
           cargo tarpaulin --all-features --avoid-cfg-tarpaulin --tests --verbose --skip-clean --coveralls ${{ secrets.COVERALLS_REPO_TOKEN }} --timeout 120

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,12 +36,8 @@ jobs:
         prefix-key: "linux"
     - name: Build, Test and Publish Coverage
       run: |
-        rustup target add wasm32-unknown-unknown
-        curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-        curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-        cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.88" --force
-        CHROMEDRIVER=/usr/local/share/chromedriver-linux64 cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"
         if [ -n "${{ secrets.COVERALLS_REPO_TOKEN }}" ]; then
+          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
           cargo binstall --no-confirm cargo-tarpaulin --force
           cargo tarpaulin --all-features --avoid-cfg-tarpaulin --tests --verbose --skip-clean --coveralls ${{ secrets.COVERALLS_REPO_TOKEN }} --timeout 120
         else
@@ -77,3 +73,5 @@ jobs:
         curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
         cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.88" --force
         SAFARIDRIVER=$(which safaridriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"
+        GECKODRIVER=$(which geckodriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"
+        CHROMEDRIVER=$(which chromedriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -74,4 +74,6 @@ jobs:
     - name: Build, Test wasm with Safari
       run: |
         rustup target add wasm32-unknown-unknown
+        curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+        cargo binstall --no-confirm wasm-bindgen-cli --vers "0.2.88" --force
         SAFARIDRIVER=$(which safaridriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -40,7 +40,7 @@ jobs:
         curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
         curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
         cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.88" --force
-        GECKODRIVER=/usr/local/share/gecko_driver CHROMEDRIVER=/usr/local/share/chromedriver-linux64 cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"
+        GECKODRIVER=/usr/local/share/gecko_driver cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"
         if [ -n "${{ secrets.COVERALLS_REPO_TOKEN }}" ]; then
           cargo binstall --no-confirm cargo-tarpaulin --force
           cargo tarpaulin --all-features --avoid-cfg-tarpaulin --tests --verbose --skip-clean --coveralls ${{ secrets.COVERALLS_REPO_TOKEN }} --timeout 120

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,9 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - name: Set coverage flag
-      id: cov-flag
-      run: echo ::set-output name=flag::${{ github.event.pull_request.head.repo.fork == false }}
     - uses: actions/checkout@v4
     - name: Clone spacebar server
       run: |
@@ -49,7 +46,7 @@ jobs:
           cargo test --verbose --all-features
         fi
     - name: Upload coverage for Linux
-      if: steps.cov-flag.outputs.flag == 'true'
+      if: ${{ secrets.COVERALLS_REPO_TOKEN }}
       uses: actions/upload-artifact@v2
       with:
         name: coverage-linux
@@ -57,9 +54,6 @@ jobs:
   macos:
     runs-on: macos-latest
     steps:
-    - name: Set coverage flag
-      id: cov-flag
-      run: echo ::set-output name=flag::${{ github.event.pull_request.head.repo.fork == false }}
     - uses: actions/checkout@v4
     - name: Clone spacebar server
       run: |
@@ -92,7 +86,7 @@ jobs:
           SAFARIDRIVER=$(which safaridriver) CHROMEDRIVER=$(which chromedriver) GECKODRIVER=$(which geckodriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"
         fi
     - name: Upload coverage for macOS
-      if: steps.cov-flag.outputs.flag == 'true'
+      if: ${{ secrets.COVERALLS_REPO_TOKEN }}
       uses: actions/upload-artifact@v2
       with:
         name: coverage-macos
@@ -100,7 +94,7 @@ jobs:
         
   upload-coverage:
     needs: [linux, macos]
-    if: needs.linux.outputs.flag == 'true' && needs.macos.outputs.flag == 'true'
+    if: ${{ secrets.COVERALLS_REPO_TOKEN }}
     runs-on: ubuntu-latest
     steps:
     - name: Download all workflow run artifacts

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
+    - name: Set coverage flag
+      id: cov-flag
+      run: echo ::set-output name=flag::${{ github.event.pull_request.head.repo.fork == false }}
     - uses: actions/checkout@v4
     - name: Clone spacebar server
       run: |
@@ -46,7 +49,7 @@ jobs:
           cargo test --verbose --all-features
         fi
     - name: Upload coverage for Linux
-      if: ${{ secrets.COVERALLS_REPO_TOKEN }}
+      if: steps.cov-flag.outputs.flag == 'true'
       uses: actions/upload-artifact@v2
       with:
         name: coverage-linux
@@ -54,6 +57,9 @@ jobs:
   macos:
     runs-on: macos-latest
     steps:
+    - name: Set coverage flag
+      id: cov-flag
+      run: echo ::set-output name=flag::${{ github.event.pull_request.head.repo.fork == false }}
     - uses: actions/checkout@v4
     - name: Clone spacebar server
       run: |
@@ -86,7 +92,7 @@ jobs:
           SAFARIDRIVER=$(which safaridriver) CHROMEDRIVER=$(which chromedriver) GECKODRIVER=$(which geckodriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"
         fi
     - name: Upload coverage for macOS
-      if: ${{ secrets.COVERALLS_REPO_TOKEN }}
+      if: steps.cov-flag.outputs.flag == 'true'
       uses: actions/upload-artifact@v2
       with:
         name: coverage-macos
@@ -94,7 +100,7 @@ jobs:
         
   upload-coverage:
     needs: [linux, macos]
-    if: ${{ secrets.COVERALLS_REPO_TOKEN }}
+    if: needs.linux.outputs.flag == 'true' && needs.macos.outputs.flag == 'true'
     runs-on: ubuntu-latest
     steps:
     - name: Download all workflow run artifacts

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -48,7 +48,7 @@ jobs:
           cargo build --verbose --all-features
           cargo test --verbose --all-features
         fi
-        GECKODRIVER=/usr/local/share/gecko_driver CHROMEDRIVER=/usr/local/share/chromedriver-linux64 cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"
+        GECKODRIVER=$(which geckodriver) CHROMEDRIVER=$(which chromedriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"
   macos:
     runs-on: macos-latest
     steps:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -40,6 +40,7 @@ jobs:
         curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
         if [ -n "${{ secrets.COVERALLS_REPO_TOKEN }}" ]; then
           curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+          cargo binstall --no-confirm wasm-bindgen-cli --vers "0.2.88" --force
           cargo binstall --no-confirm cargo-tarpaulin --force
           cargo tarpaulin --all-features --avoid-cfg-tarpaulin --tests --verbose --skip-clean --coveralls ${{ secrets.COVERALLS_REPO_TOKEN }} --timeout 120
         else

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -44,4 +44,6 @@ jobs:
           cargo build --verbose --all-features
           cargo test --verbose --all-features
         fi
+        curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        GECKODRIVER=/usr/local/share/gecko_driver CHROMEDRIVER=/usr/local/share/chromedriver-linux64 cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"
         

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -38,10 +38,10 @@ jobs:
       run: |
         rustup target add wasm32-unknown-unknown
         curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
         cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.88" --force
         GECKODRIVER=/usr/local/share/gecko_driver CHROMEDRIVER=/usr/local/share/chromedriver-linux64 cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"
         if [ -n "${{ secrets.COVERALLS_REPO_TOKEN }}" ]; then
-          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
           cargo binstall --no-confirm cargo-tarpaulin --force
           cargo tarpaulin --all-features --avoid-cfg-tarpaulin --tests --verbose --skip-clean --coveralls ${{ secrets.COVERALLS_REPO_TOKEN }} --timeout 120
         else

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         rustup target add wasm32-unknown-unknown
         curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-        GECKODRIVER=$(which geckodriver) CHROMEDRIVER=$(which chromedriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"
+        GECKODRIVER=/usr/local/share/gecko_driver CHROMEDRIVER=/usr/local/share/chromedriver-linux64 sudo cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"
         if [ -n "${{ secrets.COVERALLS_REPO_TOKEN }}" ]; then
           curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
           cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.88" --force

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -37,6 +37,7 @@ jobs:
     - name: Build, Test and Publish Coverage
       run: |
         rustup target add wasm32-unknown-unknown
+        curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
         if [ -n "${{ secrets.COVERALLS_REPO_TOKEN }}" ]; then
           curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
           cargo binstall --no-confirm cargo-tarpaulin --force
@@ -46,7 +47,6 @@ jobs:
           cargo build --verbose --all-features
           cargo test --verbose --all-features
         fi
-        curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
         GECKODRIVER=/usr/local/share/gecko_driver CHROMEDRIVER=/usr/local/share/chromedriver-linux64 cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"
   macos:
     runs-on: macos-latest

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,6 +36,7 @@ jobs:
         prefix-key: "linux"
     - name: Build, Test and Publish Coverage
       run: |
+        rustup target add wasm32-unknown-unknown
         if [ -n "${{ secrets.COVERALLS_REPO_TOKEN }}" ]; then
           curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
           cargo binstall --no-confirm cargo-tarpaulin --force
@@ -70,4 +71,6 @@ jobs:
         cache-all-crates: "true"
         prefix-key: "macos"
     - name: Build, Test wasm with Safari
-      run: SAFARIDRIVER=$(which safaridriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"
+      run: |
+        rustup target add wasm32-unknown-unknown
+        SAFARIDRIVER=$(which safaridriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -38,6 +38,7 @@ jobs:
       run: |
         rustup target add wasm32-unknown-unknown
         curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        GECKODRIVER=$(which geckodriver) CHROMEDRIVER=$(which chromedriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"
         if [ -n "${{ secrets.COVERALLS_REPO_TOKEN }}" ]; then
           curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
           cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.88" --force
@@ -48,7 +49,6 @@ jobs:
           cargo build --verbose --all-features
           cargo test --verbose --all-features
         fi
-        GECKODRIVER=$(which geckodriver) CHROMEDRIVER=$(which chromedriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"
   macos:
     runs-on: macos-latest
     steps:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -67,7 +67,7 @@ jobs:
       with:
         cache-all-crates: "true"
         prefix-key: "macos"
-    - name: Build, Test wasm with Safari
+    - name: Run WASM tests with Safari, Firefox, Chrome
       run: |
         rustup target add wasm32-unknown-unknown
         curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  rust:
+  linux:
 
     runs-on: ubuntu-latest
     
@@ -33,6 +33,7 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         cache-all-crates: "true"
+        prefix-key: "linux"
     - name: Build, Test and Publish Coverage
       run: |
         if [ -n "${{ secrets.COVERALLS_REPO_TOKEN }}" ]; then
@@ -46,4 +47,27 @@ jobs:
         fi
         curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
         GECKODRIVER=/usr/local/share/gecko_driver CHROMEDRIVER=/usr/local/share/chromedriver-linux64 cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"
-        
+  macos:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Clone spacebar server
+      run: |
+        git clone https://github.com/bitfl0wer/server.git
+    - uses: actions/setup-node@v3
+      with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: server/package-lock.json
+    - name: Prepare and start Spacebar server
+      run: |
+        npm install
+        npm run setup
+        npm run start &
+      working-directory: ./server
+    - uses: Swatinem/rust-cache@v2 
+      with:
+        cache-all-crates: "true"
+        prefix-key: "macos"
+    - name: Build, Test wasm with Safari
+      run: SAFARIDRIVER=$(which safaridriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -39,12 +39,18 @@ jobs:
         if [ -n "${{ secrets.COVERALLS_REPO_TOKEN }}" ]; then
           curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
           cargo binstall --no-confirm cargo-tarpaulin --force
-          cargo tarpaulin --all-features --avoid-cfg-tarpaulin --tests --verbose --skip-clean --coveralls ${{ secrets.COVERALLS_REPO_TOKEN }} --timeout 120
+          cargo tarpaulin --all-features --avoid-cfg-tarpaulin --tests --verbose --skip-clean --timeout 120 --output-dir ./cargo/output-linux.lcov --out Lcov
         else
           echo "Code Coverage step is skipped on forks!"
           cargo build --verbose --all-features
           cargo test --verbose --all-features
         fi
+    - name: Upload coverage for Linux
+      if: ${{ secrets.COVERALLS_REPO_TOKEN }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: coverage-linux
+        path: ./cargo/output-linux.lcov
   macos:
     runs-on: macos-latest
     steps:
@@ -72,6 +78,26 @@ jobs:
         rustup target add wasm32-unknown-unknown
         curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
         cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.88" --force
-        SAFARIDRIVER=$(which safaridriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"
-        GECKODRIVER=$(which geckodriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"
-        CHROMEDRIVER=$(which chromedriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"
+        if [ -n "${{ secrets.COVERALLS_REPO_TOKEN }}" ]; then
+          cargo binstall --no-confirm cargo-tarpaulin --force
+          SAFARIDRIVER=$(which safaridriver) CHROMEDRIVER=$(which chromedriver) GECKODRIVER=$(which geckodriver) cargo tarpaulin --target wasm32-unknown-unknown --no-default-features --features="client, rt" --avoid-cfg-tarpaulin --tests --verbose --skip-clean --timeout 120 --output-dir ./cargo/output-macos.lcov --out Lcov
+        else
+          echo "Code Coverage step is skipped on forks!"
+          SAFARIDRIVER=$(which safaridriver) CHROMEDRIVER=$(which chromedriver) GECKODRIVER=$(which geckodriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"
+        fi
+    - name: Upload coverage for macOS
+      if: ${{ secrets.COVERALLS_REPO_TOKEN }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: coverage-macos
+        path: ./cargo/output-macos.lcov
+        
+  upload-coverage:
+    needs: [linux, macos]
+    if: ${{ secrets.COVERALLS_REPO_TOKEN }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download all workflow run artifacts
+      uses: actions/download-artifact@v2
+    - name: Upload coverage to Coveralls.io
+      uses: coverallsapp/github-action@v2

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -40,7 +40,7 @@ jobs:
         curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
         if [ -n "${{ secrets.COVERALLS_REPO_TOKEN }}" ]; then
           curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-          cargo binstall --no-confirm wasm-bindgen-cli --vers "0.2.88" --force
+          cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.88" --force
           cargo binstall --no-confirm cargo-tarpaulin --force
           cargo tarpaulin --all-features --avoid-cfg-tarpaulin --tests --verbose --skip-clean --coveralls ${{ secrets.COVERALLS_REPO_TOKEN }} --timeout 120
         else
@@ -75,5 +75,5 @@ jobs:
       run: |
         rustup target add wasm32-unknown-unknown
         curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-        cargo binstall --no-confirm wasm-bindgen-cli --vers "0.2.88" --force
+        cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.88" --force
         SAFARIDRIVER=$(which safaridriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -39,18 +39,12 @@ jobs:
         if [ -n "${{ secrets.COVERALLS_REPO_TOKEN }}" ]; then
           curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
           cargo binstall --no-confirm cargo-tarpaulin --force
-          cargo tarpaulin --all-features --avoid-cfg-tarpaulin --tests --verbose --skip-clean --timeout 120 --output-dir ./cargo/output-linux.lcov --out Lcov
+          cargo tarpaulin --all-features --avoid-cfg-tarpaulin --tests --verbose --skip-clean --coveralls ${{ secrets.COVERALLS_REPO_TOKEN }} --timeout 120
         else
           echo "Code Coverage step is skipped on forks!"
           cargo build --verbose --all-features
           cargo test --verbose --all-features
         fi
-    - name: Upload coverage for Linux
-      if: ${{ secrets.COVERALLS_REPO_TOKEN }}
-      uses: actions/upload-artifact@v2
-      with:
-        name: coverage-linux
-        path: ./cargo/output-linux.lcov
   macos:
     runs-on: macos-latest
     steps:
@@ -78,26 +72,6 @@ jobs:
         rustup target add wasm32-unknown-unknown
         curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
         cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.88" --force
-        if [ -n "${{ secrets.COVERALLS_REPO_TOKEN }}" ]; then
-          cargo binstall --no-confirm cargo-tarpaulin --force
-          SAFARIDRIVER=$(which safaridriver) CHROMEDRIVER=$(which chromedriver) GECKODRIVER=$(which geckodriver) cargo tarpaulin --target wasm32-unknown-unknown --no-default-features --features="client, rt" --avoid-cfg-tarpaulin --tests --verbose --skip-clean --timeout 120 --output-dir ./cargo/output-macos.lcov --out Lcov
-        else
-          echo "Code Coverage step is skipped on forks!"
-          SAFARIDRIVER=$(which safaridriver) CHROMEDRIVER=$(which chromedriver) GECKODRIVER=$(which geckodriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"
-        fi
-    - name: Upload coverage for macOS
-      if: ${{ secrets.COVERALLS_REPO_TOKEN }}
-      uses: actions/upload-artifact@v2
-      with:
-        name: coverage-macos
-        path: ./cargo/output-macos.lcov
-        
-  upload-coverage:
-    needs: [linux, macos]
-    if: ${{ secrets.COVERALLS_REPO_TOKEN }}
-    runs-on: ubuntu-latest
-    steps:
-    - name: Download all workflow run artifacts
-      uses: actions/download-artifact@v2
-    - name: Upload coverage to Coveralls.io
-      uses: coverallsapp/github-action@v2
+        SAFARIDRIVER=$(which safaridriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"
+        GECKODRIVER=$(which geckodriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"
+        CHROMEDRIVER=$(which chromedriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "url",
+ "wasm-bindgen-test",
  "ws_stream_wasm",
 ]
 
@@ -250,6 +251,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-targets",
+]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1675,6 +1686,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2626,6 +2643,31 @@ name = "wasm-bindgen-shared"
 version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6433b7c56db97397842c46b67e11873eda263170afeb3a2dc74a7cb370fee0d"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "493fcbab756bb764fa37e6bee8cec2dd709eb4273d06d0c282a5e74275ded735"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
 
 [[package]]
 name = "web-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,6 @@ dependencies = [
  "lazy_static",
  "log",
  "native-tls",
- "pharos",
  "poem",
  "rand",
  "regex",
@@ -223,6 +222,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "url",
+ "wasm-bindgen",
  "wasm-bindgen-test",
  "ws_stream_wasm",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,9 +54,10 @@ sqlx = { version = "0.7.1", features = [
 ], optional = true }
 safina-timer = "0.1.11"
 rand = "0.8.5"
-# TODO: Remove the below 2 imports for production!
+# TODO: Remove the below 3 imports for production!
 ws_stream_wasm = "0.7.4"
 pharos = "0.5.3"
+wasm-bindgen-test = "0.3.38"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rustls = "0.21.8"
@@ -70,9 +71,8 @@ hostname = "0.3.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.11", features = ["js"] }
-tokio-tungstenite = { version = "0.20.1", default-features = false }
 ws_stream_wasm = "0.7.4"
-pharos = "0.5.3"
+wasm-bindgen-test = "0.3.38"
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,10 +54,6 @@ sqlx = { version = "0.7.1", features = [
 ], optional = true }
 safina-timer = "0.1.11"
 rand = "0.8.5"
-# TODO: Remove the below 3 imports for production!
-ws_stream_wasm = "0.7.4"
-pharos = "0.5.3"
-wasm-bindgen-test = "0.3.38"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rustls = "0.21.8"
@@ -72,8 +68,9 @@ hostname = "0.3.1"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.11", features = ["js"] }
 ws_stream_wasm = "0.7.4"
-wasm-bindgen-test = "0.3.38"
 
 
 [dev-dependencies]
 lazy_static = "1.4.0"
+wasm-bindgen-test = "0.3.38"
+wasm-bindgen = "0.2.88"

--- a/examples/gateway_observers.rs
+++ b/examples/gateway_observers.rs
@@ -6,7 +6,7 @@ use chorus::{
     types::{GatewayIdentifyPayload, GatewayReady},
 };
 use std::{sync::Arc, time::Duration};
-use tokio::{self, time::sleep};
+use tokio::{self};
 
 // This example creates a simple gateway connection and a basic observer struct
 
@@ -54,9 +54,10 @@ async fn main() {
     let mut identify = GatewayIdentifyPayload::common();
     identify.token = token;
     gateway.send_identify(identify).await;
+    safina_timer::start_timer_thread();
 
     // Do something on the main thread so we don't quit
     loop {
-        sleep(Duration::MAX).await;
+        safina_timer::sleep_for(Duration::MAX).await
     }
 }

--- a/examples/gateway_simple.rs
+++ b/examples/gateway_simple.rs
@@ -10,7 +10,7 @@ async fn main() {
     let websocket_url_spacebar = "wss://gateway.old.server.spacebar.chat/".to_string();
 
     // Initiate the gateway connection, starting a listener in one thread and a heartbeat handler in another
-    let gateway = Gateway::spawn(websocket_url_spacebar).await.unwrap();
+    let _ = Gateway::spawn(websocket_url_spacebar).await.unwrap();
 
     // At this point, we are connected to the server and are sending heartbeats, however we still haven't authenticated
 

--- a/examples/gateway_simple.rs
+++ b/examples/gateway_simple.rs
@@ -2,7 +2,6 @@ use std::time::Duration;
 
 use chorus::gateway::Gateway;
 use chorus::{self, types::GatewayIdentifyPayload};
-use tokio::time::sleep;
 
 /// This example creates a simple gateway connection and a session with an Identify event
 #[tokio::main(flavor = "current_thread")]
@@ -27,10 +26,10 @@ async fn main() {
     identify.token = token;
 
     // Send off the event
-    gateway.send_identify(identify).await;
+    safina_timer::start_timer_thread();
 
     // Do something on the main thread so we don't quit
     loop {
-        sleep(Duration::MAX).await;
+        safina_timer::sleep_for(Duration::MAX).await
     }
 }

--- a/src/gateway/backend_tungstenite.rs
+++ b/src/gateway/backend_tungstenite.rs
@@ -11,16 +11,17 @@ use super::GatewayMessage;
 use crate::errors::GatewayError;
 
 #[derive(Debug, Clone)]
-pub struct WebSocketBackend;
+pub struct TungsteniteBackend;
 
 // These could be made into inherent associated types when that's stabilized
-pub type WsSink = SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, tungstenite::Message>;
-pub type WsStream = SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>;
+pub type TungsteniteSink =
+    SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, tungstenite::Message>;
+pub type TungsteniteStream = SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>;
 
-impl WebSocketBackend {
+impl TungsteniteBackend {
     pub async fn connect(
         websocket_url: &str,
-    ) -> Result<(WsSink, WsStream), crate::errors::GatewayError> {
+    ) -> Result<(TungsteniteSink, TungsteniteStream), crate::errors::GatewayError> {
         let mut roots = rustls::RootCertStore::empty();
         for cert in rustls_native_certs::load_native_certs().expect("could not load platform certs")
         {

--- a/src/gateway/backends/mod.rs
+++ b/src/gateway/backends/mod.rs
@@ -1,9 +1,22 @@
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "client"))]
 pub mod tungstenite;
+#[cfg(all(not(target_arch = "wasm32"), feature = "client"))]
+pub use tungstenite::*;
+#[cfg(all(target_arch = "wasm32", feature = "client"))]
+pub mod wasm;
+#[cfg(all(target_arch = "wasm32", feature = "client"))]
+pub use wasm::*;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "client"))]
 pub type Sink = tungstenite::TungsteniteSink;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "client"))]
 pub type Stream = tungstenite::TungsteniteStream;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "client"))]
 pub type WebSocketBackend = tungstenite::TungsteniteBackend;
+
+#[cfg(all(target_arch = "wasm32", feature = "client"))]
+pub type Sink = wasm::WasmSink;
+#[cfg(all(target_arch = "wasm32", feature = "client"))]
+pub type Stream = wasm::WasmStream;
+#[cfg(all(target_arch = "wasm32", feature = "client"))]
+pub type WebSocketBackend = wasm::WasmBackend;

--- a/src/gateway/backends/mod.rs
+++ b/src/gateway/backends/mod.rs
@@ -2,6 +2,7 @@
 pub mod tungstenite;
 #[cfg(all(not(target_arch = "wasm32"), feature = "client"))]
 pub use tungstenite::*;
+
 #[cfg(all(target_arch = "wasm32", feature = "client"))]
 pub mod wasm;
 #[cfg(all(target_arch = "wasm32", feature = "client"))]

--- a/src/gateway/backends/mod.rs
+++ b/src/gateway/backends/mod.rs
@@ -1,0 +1,9 @@
+#[cfg(not(target_arch = "wasm32"))]
+pub mod tungstenite;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub type Sink = tungstenite::TungsteniteSink;
+#[cfg(not(target_arch = "wasm32"))]
+pub type Stream = tungstenite::TungsteniteStream;
+#[cfg(not(target_arch = "wasm32"))]
+pub type WebSocketBackend = tungstenite::TungsteniteBackend;

--- a/src/gateway/backends/tungstenite.rs
+++ b/src/gateway/backends/tungstenite.rs
@@ -7,8 +7,8 @@ use tokio_tungstenite::{
     connect_async_tls_with_config, tungstenite, Connector, MaybeTlsStream, WebSocketStream,
 };
 
-use super::GatewayMessage;
 use crate::errors::GatewayError;
+use crate::gateway::GatewayMessage;
 
 #[derive(Debug, Clone)]
 pub struct TungsteniteBackend;

--- a/src/gateway/backends/wasm.rs
+++ b/src/gateway/backends/wasm.rs
@@ -1,0 +1,46 @@
+use futures_util::{
+    stream::{SplitSink, SplitStream},
+    StreamExt,
+};
+
+use ws_stream_wasm::*;
+
+use crate::errors::GatewayError;
+use crate::gateway::GatewayMessage;
+
+#[derive(Debug, Clone)]
+pub struct WasmBackend;
+
+// These could be made into inherent associated types when that's stabilized
+pub type WasmSink = SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, tungstenite::Message>;
+pub type WasmStream = SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>;
+
+impl WasmBackend {
+    pub async fn connect(
+        websocket_url: &str,
+    ) -> Result<(WasmSink, WasmStream), crate::errors::GatewayError> {
+        let (websocket_stream, _) = match WsMeta::connect();
+        {
+            Ok(websocket_stream) => websocket_stream,
+            Err(e) => {
+                return Err(GatewayError::CannotConnect {
+                    error: e.to_string(),
+                })
+            }
+        };
+
+        Ok(websocket_stream.split())
+    }
+}
+
+impl From<GatewayMessage> for WsMessage {
+    fn from(message: GatewayMessage) -> Self {
+        Self::Text(message.0)
+    }
+}
+
+impl From<WsMessage> for GatewayMessage {
+    fn from(value: WsMessage) -> Self {
+        Self(value.to_string())
+    }
+}

--- a/src/gateway/gateway.rs
+++ b/src/gateway/gateway.rs
@@ -6,7 +6,7 @@ use tokio::task;
 
 use self::event::Events;
 use super::*;
-use super::{WsSink, WsStream};
+use super::{Sink, Stream};
 use crate::types::{
     self, AutoModerationRule, AutoModerationRuleUpdate, Channel, ChannelCreate, ChannelDelete,
     ChannelUpdate, Guild, GuildRoleCreate, GuildRoleUpdate, JsonField, RoleObject, SourceUrlField,
@@ -17,8 +17,8 @@ use crate::types::{
 pub struct Gateway {
     events: Arc<Mutex<Events>>,
     heartbeat_handler: HeartbeatHandler,
-    websocket_send: Arc<Mutex<WsSink>>,
-    websocket_receive: WsStream,
+    websocket_send: Arc<Mutex<Sink>>,
+    websocket_receive: Stream,
     kill_send: tokio::sync::broadcast::Sender<()>,
     store: Arc<Mutex<HashMap<Snowflake, Arc<RwLock<ObservableObject>>>>>,
     url: String,

--- a/src/gateway/handle.rs
+++ b/src/gateway/handle.rs
@@ -14,7 +14,7 @@ use crate::types::{self, Composite};
 pub struct GatewayHandle {
     pub url: String,
     pub events: Arc<Mutex<Events>>,
-    pub websocket_send: Arc<Mutex<WsSink>>,
+    pub websocket_send: Arc<Mutex<Sink>>,
     /// Tells gateway tasks to close
     pub(super) kill_send: tokio::sync::broadcast::Sender<()>,
     pub(crate) store: Arc<Mutex<HashMap<Snowflake, Arc<RwLock<ObservableObject>>>>>,

--- a/src/gateway/heartbeat.rs
+++ b/src/gateway/heartbeat.rs
@@ -27,7 +27,7 @@ pub(super) struct HeartbeatHandler {
 impl HeartbeatHandler {
     pub fn new(
         heartbeat_interval: Duration,
-        websocket_tx: Arc<Mutex<WsSink>>,
+        websocket_tx: Arc<Mutex<Sink>>,
         kill_rc: tokio::sync::broadcast::Receiver<()>,
     ) -> Self {
         let (send, receive) = tokio::sync::mpsc::channel(32);
@@ -49,7 +49,7 @@ impl HeartbeatHandler {
     /// Can be killed by the kill broadcast;
     /// If the websocket is closed, will die out next time it tries to send a heartbeat;
     pub async fn heartbeat_task(
-        websocket_tx: Arc<Mutex<WsSink>>,
+        websocket_tx: Arc<Mutex<Sink>>,
         heartbeat_interval: Duration,
         mut receive: Receiver<HeartbeatThreadCommunication>,
         mut kill_receive: tokio::sync::broadcast::Receiver<()>,

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -23,11 +23,11 @@ use std::sync::{Arc, RwLock};
 use tokio::sync::Mutex;
 
 #[cfg(not(target_arch = "wasm32"))]
-pub type WsSink = backend_tungstenite::WsSink;
+pub type Sink = backend_tungstenite::TungsteniteSink;
 #[cfg(not(target_arch = "wasm32"))]
-pub type WsStream = backend_tungstenite::WsStream;
+pub type Stream = backend_tungstenite::TungsteniteStream;
 #[cfg(not(target_arch = "wasm32"))]
-pub type WebSocketBackend = backend_tungstenite::WebSocketBackend;
+pub type WebSocketBackend = backend_tungstenite::TungsteniteBackend;
 
 // Gateway opcodes
 /// Opcode received when the server dispatches a [crate::types::WebSocketEvent]

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -1,13 +1,13 @@
 use async_trait::async_trait;
 
-#[cfg(not(target_arch = "wasm32"))]
-pub mod backend_tungstenite;
+pub mod backends;
 pub mod events;
 pub mod gateway;
 pub mod handle;
 pub mod heartbeat;
 pub mod message;
 
+pub use backends::*;
 pub use gateway::*;
 pub use handle::*;
 use heartbeat::*;
@@ -21,13 +21,6 @@ use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
 use tokio::sync::Mutex;
-
-#[cfg(not(target_arch = "wasm32"))]
-pub type Sink = backend_tungstenite::TungsteniteSink;
-#[cfg(not(target_arch = "wasm32"))]
-pub type Stream = backend_tungstenite::TungsteniteStream;
-#[cfg(not(target_arch = "wasm32"))]
-pub type WebSocketBackend = backend_tungstenite::TungsteniteBackend;
 
 // Gateway opcodes
 /// Opcode received when the server dispatches a [crate::types::WebSocketEvent]

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -1,0 +1,1 @@
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -1,1 +1,7 @@
+use wasm_bindgen_test::wasm_bindgen_test;
+
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+#[wasm_bindgen_test]
+fn pass() {
+    let _ = String::new();
+}


### PR DESCRIPTION
This PR is adding
- [x] wasm32 testing harness
- [x] wasm32 CI changes
- [x] successful build on wasm32
Combined coverage report uploading (treat wasm and regular test runs as one coverage report for coveralls.io) is sadly not possible yet, due to llvms profiler not supporting wasm