### PR TITLE
Coverage, change register/login

### DIFF
--- a/examples/login.rs
+++ b/examples/login.rs
@@ -9,7 +9,7 @@ async fn main() {
         "wss://example.com/".to_string(),
         "https://example.com/cdn".to_string(),
     );
-    let instance = Instance::new(bundle, true)
+    let mut instance = Instance::new(bundle, true)
         .await
         .expect("Failed to connect to the Spacebar server");
     // Assume, you already have an account created on this instance. Registering an account works

--- a/src/api/auth/login.rs
+++ b/src/api/auth/login.rs
@@ -14,7 +14,7 @@ impl Instance {
     ///
     /// # Reference
     /// See <https://docs.spacebar.chat/routes/#post-/auth/login/>
-    pub async fn login_account(mut self, login_schema: LoginSchema) -> ChorusResult<ChorusUser> {
+    pub async fn login_account(&mut self, login_schema: LoginSchema) -> ChorusResult<ChorusUser> {
         let endpoint_url = self.urls.api.clone() + "/auth/login";
         let chorus_request = ChorusRequest {
             request: Client::new()

--- a/src/api/auth/register.rs
+++ b/src/api/auth/register.rs
@@ -19,7 +19,7 @@ impl Instance {
     /// # Reference
     /// See <https://docs.spacebar.chat/routes/#post-/auth/register/>
     pub async fn register_account(
-        mut self,
+        &mut self,
         register_schema: RegisterSchema,
     ) -> ChorusResult<ChorusUser> {
         let endpoint_url = self.urls.api.clone() + "/auth/register";
@@ -43,7 +43,7 @@ impl Instance {
             self.limits_information.as_mut().unwrap().ratelimits = shell.limits.unwrap();
         }
         let user_object = self.get_user(token.clone(), None).await.unwrap();
-        let settings = ChorusUser::get_settings(&token, &self.urls.api.clone(), &mut self).await?;
+        let settings = ChorusUser::get_settings(&token, &self.urls.api.clone(), self).await?;
         let mut identify = GatewayIdentifyPayload::common();
         let gateway: GatewayHandle = Gateway::spawn(self.urls.wss.clone()).await.unwrap();
         identify.token = token.clone();

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -20,3 +20,36 @@ async fn test_registration() {
     bundle.instance.clone().register_account(reg).await.unwrap();
     common::teardown(bundle).await;
 }
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+async fn test_login_with_token() {
+    let mut bundle = common::setup().await;
+
+    let token = &bundle.user.token;
+    let other_user = bundle
+        .instance
+        .login_with_token(token.clone())
+        .await
+        .unwrap();
+    assert_eq!(
+        bundle.user.object.read().unwrap().id,
+        other_user.object.read().unwrap().id
+    );
+    assert_eq!(bundle.user.token, other_user.token);
+
+    common::teardown(bundle).await;
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+async fn test_login_with_invalid_token() {
+    let mut bundle = common::setup().await;
+
+    let token = "invalid token lalalalala".to_string();
+    let other_user = bundle.instance.login_with_token(token.clone()).await;
+
+    assert!(other_user.is_err());
+
+    common::teardown(bundle).await;
+}

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -1,4 +1,6 @@
-use chorus::types::RegisterSchema;
+use std::borrow::BorrowMut;
+
+use chorus::types::{LoginSchema, RegisterSchema};
 // PRETTYFYME: Move common wasm setup to common.rs
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::*;
@@ -10,14 +12,59 @@ mod common;
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
 async fn test_registration() {
-    let bundle = common::setup().await;
+    let mut bundle = common::setup().await;
     let reg = RegisterSchema {
         username: "Hiiii".into(),
         date_of_birth: Some("2000-01-01".to_string()),
         consent: true,
         ..Default::default()
     };
-    bundle.instance.clone().register_account(reg).await.unwrap();
+    bundle.instance.register_account(reg).await.unwrap();
+    common::teardown(bundle).await;
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+async fn test_login() {
+    let mut bundle = common::setup().await;
+    let reg = RegisterSchema {
+        username: "Hiiii".into(),
+        email: Some("testuser1@integrationtesting.xyz".into()),
+        password: Some("Correct-Horse-Battery-Staple1".into()),
+        date_of_birth: Some("2000-01-01".to_string()),
+        consent: true,
+        ..Default::default()
+    };
+    bundle.instance.register_account(reg).await.unwrap();
+    let login = LoginSchema {
+        login: "testuser1@integrationtesting.xyz".into(),
+        password: "Correct-Horse-Battery-Staple1".into(),
+        ..Default::default()
+    };
+    bundle.instance.login_account(login).await.unwrap();
+    common::teardown(bundle).await;
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+async fn test_wrong_login() {
+    let mut bundle = common::setup().await;
+    let reg = RegisterSchema {
+        username: "Hiiii".into(),
+        email: Some("testuser2@integrationtesting.xyz".into()),
+        password: Some("Correct-Horse-Battery-Staple1".into()),
+        date_of_birth: Some("2000-01-01".to_string()),
+        consent: true,
+        ..Default::default()
+    };
+    bundle.instance.register_account(reg).await.unwrap();
+    let login = LoginSchema {
+        login: "testuser2@integrationtesting.xyz".into(),
+        password: "Correct-Horse-Battery-Staple2".into(),
+        ..Default::default()
+    };
+    let res = bundle.instance.login_account(login).await;
+    assert!(res.is_err());
     common::teardown(bundle).await;
 }
 


### PR DESCRIPTION
Register and login, for some reason, required ownership of the `Instance` object. This was not necessary and has been changed in this PR. The PR also includes some extra tests, like logging in, logging in with a token, etc.