### PR TITLE
Get URLs from .well-known

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,5 @@
 //! Contains all the errors that can be returned by the library.
 use custom_error::custom_error;
-use url::Url;
 
 use crate::types::WebSocketEvent;
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,6 @@
 //! Contains all the errors that can be returned by the library.
 use custom_error::custom_error;
+use url::Url;
 
 use crate::types::WebSocketEvent;
 
@@ -42,6 +43,18 @@ custom_error! {
     InvalidResponse{error: String} = "The response is malformed and cannot be processed. Error: {error}",
     /// Invalid, insufficient or too many arguments provided.
     InvalidArguments{error: String} = "Invalid arguments were provided. Error: {error}"
+}
+
+impl From<reqwest::Error> for ChorusError {
+    fn from(value: reqwest::Error) -> Self {
+        ChorusError::RequestFailed {
+            url: match value.url() {
+                Some(url) => url.to_string(),
+                None => "None".to_string(),
+            },
+            error: value.to_string(),
+        }
+    }
 }
 
 custom_error! {

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -107,12 +107,12 @@ impl Instance {
         None
     }
 
-    /// Creates a new [`Instance`] by trying to get the [relevant instance urls](UrlBundle) from a root domain.
+    /// Creates a new [`Instance`] by trying to get the [relevant instance urls](UrlBundle) from a root url.
     /// Shorthand for `Instance::new(UrlBundle::from_root_domain(root_domain).await?)`.
     ///
     /// If `limited` is `true`, then Chorus will track and enforce rate limits for this instance.
-    pub async fn from_root_domain(root_domain: &str, limited: bool) -> ChorusResult<Instance> {
-        let urls = UrlBundle::from_root_domain(root_domain).await?;
+    pub async fn from_root_url(root_url: &str, limited: bool) -> ChorusResult<Instance> {
+        let urls = UrlBundle::from_root_url(root_url).await?;
         Instance::new(urls, limited).await
     }
 }

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -70,7 +70,7 @@ impl PartialEq for LimitsInformation {
 }
 
 impl Instance {
-    /// Creates a new [`Instance`] from the [relevant instance urls](UrlBundle), where `limited` is whether or not to automatically use rate limits.
+    /// Creates a new [`Instance`] from the [relevant instance urls](UrlBundle), where `limited` is whether Chorus will track and enforce rate limits for this instance.
     pub async fn new(urls: UrlBundle, limited: bool) -> ChorusResult<Instance> {
         let limits_information;
         if limited {
@@ -99,11 +99,21 @@ impl Instance {
         };
         Ok(instance)
     }
+
     pub(crate) fn clone_limits_if_some(&self) -> Option<HashMap<LimitType, Limit>> {
         if self.limits_information.is_some() {
             return Some(self.limits_information.as_ref().unwrap().ratelimits.clone());
         }
         None
+    }
+
+    /// Creates a new [`Instance`] by trying to get the [relevant instance urls](UrlBundle) from a root domain.
+    /// Shorthand for `Instance::new(UrlBundle::from_root_domain(root_domain).await?)`.
+    ///
+    /// If `limited` is `true`, then Chorus will track and enforce rate limits for this instance.
+    pub async fn from_root_domain(root_domain: &str, limited: bool) -> ChorusResult<Instance> {
+        let urls = UrlBundle::from_root_domain(root_domain).await?;
+        Instance::new(urls, limited).await
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,7 +189,7 @@ impl UrlBundle {
         url_string
     }
 
-    /// Performs a few HTTP requests to try and retrieve a `UrlBundle` from an instances' root domain.
+    /// Performs a few HTTP requests to try and retrieve a `UrlBundle` from an instances' root url.
     /// The method tries to retrieve the `UrlBundle` via these three strategies, in order:
     /// - GET: `$url/.well-known/spacebar` -> Retrieve UrlBundle via `$wellknownurl/api/policies/instance/domains`
     /// - GET: `$url/api/policies/instance/domains`
@@ -199,7 +199,7 @@ impl UrlBundle {
     /// stores the CDN and WSS URLs under the `$api/policies/instance/domains` endpoint. If all three
     /// of the above approaches fail, it is very likely that the instance is misconfigured, unreachable, or that
     /// a wrong URL was provided.
-    pub async fn from_root_domain(url: &str) -> ChorusResult<UrlBundle> {
+    pub async fn from_root_url(url: &str) -> ChorusResult<UrlBundle> {
         let parsed = UrlBundle::parse_url(url.to_string());
         let client = reqwest::Client::new();
         let request_wellknown = client

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@ This crate uses Semantic Versioning 2.0.0 as its versioning scheme. You can read
     clippy::new_without_default,
     clippy::useless_conversion
 )]
+#![warn(clippy::todo, clippy::unimplemented)]
 #[cfg(all(feature = "rt", feature = "rt_multi_thread"))]
 compile_error!("feature \"rt\" and feature \"rt_multi_thread\" cannot be enabled at the same time");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,13 +215,29 @@ impl UrlBundle {
             {
                 Ok(response_api)
             } else {
-                Err(ChorusError::RequestFailed { url: url.to_string(), error: "Could not retrieve UrlBundle from url after trying 3 different approaches. Check the provided Url and if the instance is reachable.".to_string() } )
+                Err(ChorusError::RequestFailed { url: url.to_string(), error: "Could not retrieve UrlBundle from url after trying 3 different approaches. Check the provided Url and make sure the instance is reachable.".to_string() } )
             }
         }
     }
 
     async fn from_api_url(url: &str) -> ChorusResult<UrlBundle> {
-        todo!()
+        let client = reqwest::Client::new();
+        let request = client
+            .get(url)
+            .header(http::header::ACCEPT, "application/json")
+            .build()?;
+        let response = client.execute(request).await?;
+        if let Ok(body) = response
+            .json::<types::types::domains_configuration::Domains>()
+            .await
+        {
+            Ok(UrlBundle::new(body.api_endpoint, body.gateway, body.cdn))
+        } else {
+            Err(ChorusError::RequestFailed {
+                url: url.to_string(),
+                error: "Could not retrieve a UrlBundle from the given url. Check the provided url and make sure the instance is reachable.".to_string(),
+            })
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,13 @@ This crate uses Semantic Versioning 2.0.0 as its versioning scheme. You can read
     clippy::new_without_default,
     clippy::useless_conversion
 )]
-#![warn(clippy::todo, clippy::unimplemented)]
+#![warn(
+    clippy::todo,
+    clippy::unimplemented,
+    clippy::dbg_macro,
+    clippy::print_stdout,
+    clippy::print_stderr
+)]
 #[cfg(all(feature = "rt", feature = "rt_multi_thread"))]
 compile_error!("feature \"rt\" and feature \"rt_multi_thread\" cannot be enabled at the same time");
 
@@ -206,16 +212,16 @@ impl UrlBundle {
             UrlBundle::from_api_url(&body).await
         } else {
             if let Ok(response_slash_api) =
-                UrlBundle::from_api_url(&format!("{}/api/policies/instance/domains", url)).await
+                UrlBundle::from_api_url(&format!("{}/api/policies/instance/domains", parsed)).await
             {
                 return Ok(response_slash_api);
             }
             if let Ok(response_api) =
-                UrlBundle::from_api_url(&format!("{}/policies/instance/domains", url)).await
+                UrlBundle::from_api_url(&format!("{}/policies/instance/domains", parsed)).await
             {
                 Ok(response_api)
             } else {
-                Err(ChorusError::RequestFailed { url: url.to_string(), error: "Could not retrieve UrlBundle from url after trying 3 different approaches. Check the provided Url and make sure the instance is reachable.".to_string() } )
+                Err(ChorusError::RequestFailed { url: parsed.to_string(), error: "Could not retrieve UrlBundle from url after trying 3 different approaches. Check the provided Url and make sure the instance is reachable.".to_string() } )
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,7 @@ compile_error!("feature \"rt\" and feature \"rt_multi_thread\" cannot be enabled
 
 use errors::ChorusResult;
 use serde::{Deserialize, Serialize};
+use types::types::domains_configuration::WellKnownResponse;
 use url::{ParseError, Url};
 
 use crate::errors::ChorusError;
@@ -221,11 +222,6 @@ impl UrlBundle {
     async fn from_api_url(url: &str) -> ChorusResult<UrlBundle> {
         todo!()
     }
-}
-
-#[derive(Deserialize)]
-struct WellKnownResponse {
-    pub(crate) api: String,
 }
 
 #[cfg(test)]

--- a/src/types/config/types/domains_configuration.rs
+++ b/src/types/config/types/domains_configuration.rs
@@ -1,0 +1,29 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Eq, PartialEq, Hash, Clone, Debug)]
+/// Represents the result of the `$rooturl/.well-known/spacebar` endpoint.
+///
+/// See <https://docs.spacebar.chat/setup/server/wellknown/> for more information.
+pub struct WellKnownResponse {
+    pub api: String,
+}
+
+#[derive(Deserialize, Serialize, Eq, PartialEq, Hash, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+/// Represents the result of the `$api/policies/instance/domains` endpoint.
+pub struct Domains {
+    pub cdn: String,
+    pub gateway: String,
+    pub api_endpoint: String,
+    pub default_api_version: String,
+}
+
+impl std::fmt::Display for Domains {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{{\n\tCDN URL: {},\n\tGateway URL: {},\n\tAPI Endpoint: {},\n\tDefault API Version: {}\n}}",
+            self.cdn, self.gateway, self.api_endpoint, self.default_api_version
+        )
+    }
+}

--- a/src/types/config/types/mod.rs
+++ b/src/types/config/types/mod.rs
@@ -1,6 +1,7 @@
 pub mod api_configuration;
 pub mod cdn_configuration;
 pub mod defaults_configuration;
+pub mod domains_configuration;
 pub mod email_configuration;
 pub mod endpoint_configuration;
 pub mod external_tokens_configuration;

--- a/tests/urlbundle.rs
+++ b/tests/urlbundle.rs
@@ -11,9 +11,9 @@ wasm_bindgen_test_configure!(run_in_browser);
 async fn test_parse_url() {
     // TODO: Currently only tests two of the three branches in UrlBundle::from_root_domain.
     let url = url::Url::parse("http://localhost:3001/").unwrap();
-    UrlBundle::from_root_domain(url.as_str()).await.unwrap();
+    UrlBundle::from_root_url(url.as_str()).await.unwrap();
     let url = url::Url::parse("http://localhost:3001/api/").unwrap();
-    UrlBundle::from_root_domain(url.as_str()).await.unwrap();
+    UrlBundle::from_root_url(url.as_str()).await.unwrap();
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]

--- a/tests/urlbundle.rs
+++ b/tests/urlbundle.rs
@@ -1,4 +1,6 @@
+use chorus::types::types::domains_configuration::WellKnownResponse;
 use chorus::UrlBundle;
+use serde_json::json;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::*;
 #[cfg(target_arch = "wasm32")]
@@ -7,6 +9,18 @@ wasm_bindgen_test_configure!(run_in_browser);
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
 async fn test_parse_url() {
+    // TODO: Currently only tests two of the three branches in UrlBundle::from_root_domain.
     let url = url::Url::parse("http://localhost:3001/").unwrap();
     UrlBundle::from_root_domain(url.as_str()).await.unwrap();
+    let url = url::Url::parse("http://localhost:3001/api/").unwrap();
+    UrlBundle::from_root_domain(url.as_str()).await.unwrap();
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+async fn test_parse_wellknown() {
+    let json = json!({
+        "api": "http://localhost:3001/api/v9"
+    });
+    let _well_known: WellKnownResponse = serde_json::from_value(json).unwrap();
 }

--- a/tests/urlbundle.rs
+++ b/tests/urlbundle.rs
@@ -1,0 +1,12 @@
+use chorus::UrlBundle;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_test::*;
+#[cfg(target_arch = "wasm32")]
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+async fn test_parse_url() {
+    let url = url::Url::parse("http://localhost:3001/").unwrap();
+    UrlBundle::from_root_domain(url.as_str()).await.unwrap();
+}


### PR DESCRIPTION
Closes #449.

+ `Instance::from_root_url(root_url: &str, limited: bool)`:  Creates a new Instance by trying to get the relevant instance urls (UrlBundle) from a root url. Shorthand for `Instance::new(UrlBundle::from_root_domain(root_domain).await?)`
+ `UrlBundle::from_root_url(url: &str)`: Performs a few HTTP requests to try and retrieve a UrlBundle from an instance's root URL. The method tries to retrieve the UrlBundle via these three strategies, in order:
    - GET: $url/.well-known/spacebar -> Retrieve UrlBundle via $wellknownurl/api/policies/instance/domains
    - GET: $url/api/policies/instance/domains
    - GET: $url/policies/instance/domains
    
    The URL stored at .well-known/spacebar is the instance's API endpoint. The API stores the CDN and WSS URLs under the $api/policies/instance/domains endpoint. If all three of the above approaches fail, it is very likely that the instance is misconfigured, unreachable, or that a wrong URL was provided.
+ Add clippy warnings for: `clippy::todo,
    clippy::unimplemented,
    clippy::dbg_macro,
    clippy::print_stdout,
    clippy::print_stderr`