### PR TITLE
Fix gateway heartbeat on WASM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,6 @@ dependencies = [
  "reqwest",
  "rustls",
  "rustls-native-certs",
- "safina-timer",
  "serde",
  "serde-aux",
  "serde_json",
@@ -1688,15 +1687,6 @@ name = "ryu"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
-
-[[package]]
-name = "safina-timer"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1081a264d1a3e81b75c4bcd5696094fb6ce470c2ded14cbd47bcb5229079b9df"
-dependencies = [
- "once_cell",
-]
 
 [[package]]
 name = "schannel"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "wasmtimer",
+ "web-sys",
  "ws_stream_wasm",
 ]
 
@@ -955,9 +956,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2590,9 +2591,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2600,9 +2601,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
 dependencies = [
  "bumpalo",
  "log",
@@ -2627,9 +2628,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2637,9 +2638,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2650,9 +2651,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 
 [[package]]
 name = "wasm-bindgen-test"
@@ -2695,9 +2696,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
+ "wasmtimer",
  "ws_stream_wasm",
 ]
 
@@ -2686,6 +2687,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "wasmtimer"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f656cd8858a5164932d8a90f936700860976ec21eb00e0fe2aa8cab13f6b4cf"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "wasmtimer",
- "web-sys",
  "ws_stream_wasm",
 ]
 
@@ -956,9 +955,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.67"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
+checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2591,9 +2590,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.90"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
+checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2601,9 +2600,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.90"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
+checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
 dependencies = [
  "bumpalo",
  "log",
@@ -2628,9 +2627,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.90"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
+checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2638,9 +2637,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.90"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
+checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2651,9 +2650,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.90"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
+checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "wasm-bindgen-test"
@@ -2696,9 +2695,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.67"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
+checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ getrandom = { version = "0.2.12", features = ["js"] }
 ws_stream_wasm = "0.7.4"
 wasm-bindgen-futures = "0.4.39"
 wasmtimer = "0.2.0"
+web-sys = "0.3.67"
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ sqlx = { version = "0.7.3", features = [
     "runtime-tokio-native-tls",
     "any",
 ], optional = true }
-safina-timer = "0.1.11"
 rand = "0.8.5"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -64,11 +63,13 @@ tokio-tungstenite = { version = "0.20.1", features = [
 ] }
 native-tls = "0.2.11"
 hostname = "0.3.1"
+safina-timer = "0.1.11"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.12", features = ["js"] }
 ws_stream_wasm = "0.7.4"
 wasm-bindgen-futures = "0.4.39"
+wasmtimer = "0.2.0"
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,6 @@ tokio-tungstenite = { version = "0.20.1", features = [
 ] }
 native-tls = "0.2.11"
 hostname = "0.3.1"
-safina-timer = "0.1.11"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.12", features = ["js"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,6 @@ getrandom = { version = "0.2.12", features = ["js"] }
 ws_stream_wasm = "0.7.4"
 wasm-bindgen-futures = "0.4.39"
 wasmtimer = "0.2.0"
-web-sys = "0.3.67"
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/examples/gateway_observers.rs
+++ b/examples/gateway_observers.rs
@@ -9,7 +9,7 @@ use std::{sync::Arc, time::Duration};
 use tokio::{self};
 
 #[cfg(not(target_arch = "wasm32"))]
-use safina_timer::sleep_for;
+use tokio::time::sleep;
 #[cfg(target_arch = "wasm32")]
 use wasmtimer::tokio::sleep;
 
@@ -60,14 +60,8 @@ async fn main() {
     identify.token = token;
     gateway.send_identify(identify).await;
 
-    #[cfg(not(target_arch = "wasm32"))]
-    safina_timer::start_timer_thread();
-
     // Do something on the main thread so we don't quit
     loop {
-        #[cfg(not(target_arch = "wasm32"))]
-        sleep_for(Duration::MAX).await;
-        #[cfg(target_arch = "wasm32")]
-        sleep(Duration::MAX).await;
+        sleep(Duration::from_secs(3600)).await;
     }
 }

--- a/examples/gateway_observers.rs
+++ b/examples/gateway_observers.rs
@@ -11,7 +11,7 @@ use tokio::{self};
 #[cfg(not(target_arch = "wasm32"))]
 use safina_timer::sleep_for;
 #[cfg(target_arch = "wasm32")]
-use wasmtimer::tokio::sleep_for;
+use wasmtimer::tokio::sleep;
 
 // This example creates a simple gateway connection and a basic observer struct
 
@@ -65,6 +65,9 @@ async fn main() {
 
     // Do something on the main thread so we don't quit
     loop {
-        sleep_for(Duration::MAX).await
+        #[cfg(not(target_arch = "wasm32"))]
+        sleep_for(Duration::MAX).await;
+        #[cfg(target_arch = "wasm32")]
+        sleep(Duration::MAX).await;
     }
 }

--- a/examples/gateway_observers.rs
+++ b/examples/gateway_observers.rs
@@ -8,6 +8,11 @@ use chorus::{
 use std::{sync::Arc, time::Duration};
 use tokio::{self};
 
+#[cfg(not(target_arch = "wasm32"))]
+use safina_timer::sleep_for;
+#[cfg(target_arch = "wasm32")]
+use wasmtimer::tokio::sleep_for;
+
 // This example creates a simple gateway connection and a basic observer struct
 
 // Due to certain limitations all observers must impl debug
@@ -54,10 +59,12 @@ async fn main() {
     let mut identify = GatewayIdentifyPayload::common();
     identify.token = token;
     gateway.send_identify(identify).await;
+
+    #[cfg(not(target_arch = "wasm32"))]
     safina_timer::start_timer_thread();
 
     // Do something on the main thread so we don't quit
     loop {
-        safina_timer::sleep_for(Duration::MAX).await
+        sleep_for(Duration::MAX).await
     }
 }

--- a/examples/gateway_simple.rs
+++ b/examples/gateway_simple.rs
@@ -3,6 +3,11 @@ use std::time::Duration;
 use chorus::gateway::Gateway;
 use chorus::{self, types::GatewayIdentifyPayload};
 
+#[cfg(not(target_arch = "wasm32"))]
+use safina_timer::sleep_for;
+#[cfg(target_arch = "wasm32")]
+use wasmtimer::tokio::sleep_for;
+
 /// This example creates a simple gateway connection and a session with an Identify event
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
@@ -10,7 +15,7 @@ async fn main() {
     let websocket_url_spacebar = "wss://gateway.old.server.spacebar.chat/".to_string();
 
     // Initiate the gateway connection, starting a listener in one thread and a heartbeat handler in another
-    let _ = Gateway::spawn(websocket_url_spacebar).await.unwrap();
+    let gateway = Gateway::spawn(websocket_url_spacebar).await.unwrap();
 
     // At this point, we are connected to the server and are sending heartbeats, however we still haven't authenticated
 
@@ -26,10 +31,13 @@ async fn main() {
     identify.token = token;
 
     // Send off the event
+    gateway.send_identify(identify).await; 
+    
+    #[cfg(not(target_arch = "wasm32"))]
     safina_timer::start_timer_thread();
 
     // Do something on the main thread so we don't quit
     loop {
-        safina_timer::sleep_for(Duration::MAX).await
+        sleep_for(Duration::MAX).await
     }
 }

--- a/examples/gateway_simple.rs
+++ b/examples/gateway_simple.rs
@@ -4,7 +4,7 @@ use chorus::gateway::Gateway;
 use chorus::{self, types::GatewayIdentifyPayload};
 
 #[cfg(not(target_arch = "wasm32"))]
-use safina_timer::sleep_for;
+use tokio::time::sleep;
 #[cfg(target_arch = "wasm32")]
 use wasmtimer::tokio::sleep;
 
@@ -33,14 +33,8 @@ async fn main() {
     // Send off the event
     gateway.send_identify(identify).await; 
     
-    #[cfg(not(target_arch = "wasm32"))]
-    safina_timer::start_timer_thread();
-
     // Do something on the main thread so we don't quit
     loop {
-        #[cfg(not(target_arch = "wasm32"))]
-        sleep_for(Duration::MAX).await;
-        #[cfg(target_arch = "wasm32")]
-        sleep(Duration::MAX).await;
+        sleep(Duration::from_secs(3600)).await;
     }
 }

--- a/examples/gateway_simple.rs
+++ b/examples/gateway_simple.rs
@@ -6,7 +6,7 @@ use chorus::{self, types::GatewayIdentifyPayload};
 #[cfg(not(target_arch = "wasm32"))]
 use safina_timer::sleep_for;
 #[cfg(target_arch = "wasm32")]
-use wasmtimer::tokio::sleep_for;
+use wasmtimer::tokio::sleep;
 
 /// This example creates a simple gateway connection and a session with an Identify event
 #[tokio::main(flavor = "current_thread")]
@@ -38,6 +38,9 @@ async fn main() {
 
     // Do something on the main thread so we don't quit
     loop {
-        sleep_for(Duration::MAX).await
+        #[cfg(not(target_arch = "wasm32"))]
+        sleep_for(Duration::MAX).await;
+        #[cfg(target_arch = "wasm32")]
+        sleep(Duration::MAX).await;
     }
 }

--- a/src/gateway/heartbeat.rs
+++ b/src/gateway/heartbeat.rs
@@ -73,6 +73,11 @@ impl HeartbeatHandler {
         let mut last_seq_number: Option<u64> = None;
          
         loop {
+            #[cfg(target_arch = "wasm32")]
+             web_sys::console::log_1(&String::from("Heartbeat works!").into());
+            
+             println!("Heartbeat works!");
+
             if kill_receive.try_recv().is_ok() {
                 trace!("GW: Closing heartbeat task");
                 break;

--- a/src/gateway/heartbeat.rs
+++ b/src/gateway/heartbeat.rs
@@ -1,9 +1,20 @@
 use futures_util::SinkExt;
 use log::*;
-use std::time::{self, Duration, Instant};
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant;
+#[cfg(target_arch = "wasm32")]
+use wasmtimer::std::Instant;
+
+#[cfg(not(target_arch = "wasm32"))]
+use safina_timer::sleep_until;
+#[cfg(target_arch = "wasm32")]
+use wasmtimer::tokio::sleep_until;
+
+use std::time::Duration;
+
 use tokio::sync::mpsc::{Receiver, Sender};
 
-use safina_timer::sleep_until;
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::task;
 
@@ -57,7 +68,7 @@ impl HeartbeatHandler {
         mut receive: Receiver<HeartbeatThreadCommunication>,
         mut kill_receive: tokio::sync::broadcast::Receiver<()>,
     ) {
-        let mut last_heartbeat_timestamp: Instant = time::Instant::now();
+        let mut last_heartbeat_timestamp: Instant = Instant::now();
         let mut last_heartbeat_acknowledged = true;
         let mut last_seq_number: Option<u64> = None;
 
@@ -123,7 +134,7 @@ impl HeartbeatHandler {
                     break;
                 }
 
-                last_heartbeat_timestamp = time::Instant::now();
+                last_heartbeat_timestamp = Instant::now();
                 last_heartbeat_acknowledged = false;
             }
         }

--- a/src/gateway/heartbeat.rs
+++ b/src/gateway/heartbeat.rs
@@ -2,12 +2,12 @@ use futures_util::SinkExt;
 use log::*;
 
 #[cfg(not(target_arch = "wasm32"))]
-use std::time::Instant;
+use tokio::time::Instant;
 #[cfg(target_arch = "wasm32")]
 use wasmtimer::std::Instant;
 
 #[cfg(not(target_arch = "wasm32"))]
-use safina_timer::sleep_until;
+use tokio::time::sleep_until;
 #[cfg(target_arch = "wasm32")]
 use wasmtimer::tokio::sleep_until;
 
@@ -72,9 +72,6 @@ impl HeartbeatHandler {
         let mut last_heartbeat_acknowledged = true;
         let mut last_seq_number: Option<u64> = None;
          
-        #[cfg(not(target_arch = "wasm32"))]
-        safina_timer::start_timer_thread();
-
         loop {
             if kill_receive.try_recv().is_ok() {
                 trace!("GW: Closing heartbeat task");

--- a/src/gateway/heartbeat.rs
+++ b/src/gateway/heartbeat.rs
@@ -71,7 +71,8 @@ impl HeartbeatHandler {
         let mut last_heartbeat_timestamp: Instant = Instant::now();
         let mut last_heartbeat_acknowledged = true;
         let mut last_seq_number: Option<u64> = None;
-
+         
+        #[cfg(not(target_arch = "wasm32"))]
         safina_timer::start_timer_thread();
 
         loop {

--- a/src/gateway/heartbeat.rs
+++ b/src/gateway/heartbeat.rs
@@ -73,11 +73,6 @@ impl HeartbeatHandler {
         let mut last_seq_number: Option<u64> = None;
          
         loop {
-            #[cfg(target_arch = "wasm32")]
-             web_sys::console::log_1(&String::from("Heartbeat works!").into());
-            
-             println!("Heartbeat works!");
-
             if kill_receive.try_recv().is_ok() {
                 trace!("GW: Closing heartbeat task");
                 break;

--- a/tests/gateway.rs
+++ b/tests/gateway.rs
@@ -32,7 +32,9 @@ async fn test_gateway_authenticate() {
     identify.token = bundle.user.token.clone();
 
     gateway.send_identify(identify).await;
-    common::teardown(bundle).await
+    common::teardown(bundle).await;
+
+    assert!(false);
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]

--- a/tests/gateway.rs
+++ b/tests/gateway.rs
@@ -32,9 +32,7 @@ async fn test_gateway_authenticate() {
     identify.token = bundle.user.token.clone();
 
     gateway.send_identify(identify).await;
-    common::teardown(bundle).await;
-
-    assert!(false);
+    common::teardown(bundle).await
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]


### PR DESCRIPTION
It turns out `std::time::Instant::now()` panics WASM (see #459) and breaks the heartbeat handler.

This pr attempts to fix that by replacing `std::time::Instant` with `wasmtimer::std::Instant` and `safina_timer::sleep_until` with `wasmtimer::tokio::sleep_until`.