### PR TITLE
Bump actions/setup-node in GHA workflow to v4

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Clone spacebar server
       run: |
         git clone https://github.com/bitfl0wer/server.git
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
           node-version: 18
           cache: 'npm'
@@ -52,7 +52,7 @@ jobs:
   #   - name: Clone spacebar server
   #     run: |
   #       git clone https://github.com/bitfl0wer/server.git
-  #   - uses: actions/setup-node@v3
+  #   - uses: actions/setup-node@v4
   #     with:
   #         node-version: 18
   #         cache: 'npm'
@@ -80,7 +80,7 @@ jobs:
     - name: Clone spacebar server
       run: |
         git clone https://github.com/bitfl0wer/server.git
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
           node-version: 18
           cache: 'npm'
@@ -108,7 +108,7 @@ jobs:
     - name: Clone spacebar server
       run: |
         git clone https://github.com/bitfl0wer/server.git
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
           node-version: 18
           cache: 'npm'


### PR DESCRIPTION
This pull request updates [`actions/setup-node`](https://github.com/actions/setup-node) to v4.

Still using the older version of the action will generate warnings in CI runs, for example in https://github.com/polyphony-chat/chorus/actions/runs/7647051423:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/setup-node@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

The PR will get rid of those warnings.