### PR TITLE
Move contribution guidelines to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+
+# Contributing
+
+**Please refer to the [contribution guidelines](https://github.com/polyphony-chat/.github/blob/main/CONTRIBUTION_GUIDELINES.md) and [our Code of Conduct](https://github.com/polyphony-chat/.github/blob/main/CODE_OF_CONDUCT.md) before making a contribution.**
+
+Chorus is currently missing voice support and a lot of API endpoints, many of which should be trivial to implement,
+ever since [we streamlined the process of doing so](https://github.com/polyphony-chat/chorus/discussions/401).
+
+If you'd like to contribute new functionality, check out [The 'Meta'-issues.](https://github.com/polyphony-chat/chorus/issues?q=is%3Aissue+label%3A%22Type%3A+Meta%22+) They contain a comprehensive list of all features which are yet missing for full Discord.com compatibility.
+Please feel free to open an Issue with the idea you have, or a Pull Request. 

--- a/README.md
+++ b/README.md
@@ -134,11 +134,7 @@ This crate uses Semantic Versioning 2.0.0 as its versioning scheme. You can read
 
 ## Contributing
 
-Chorus is currently missing voice support and a lot of API endpoints, many of which should be trivial to implement,
-ever since [we streamlined the process of doing so](https://github.com/polyphony-chat/chorus/discussions/401).
-
-If you'd like to contribute new functionality, check out [The 'Meta'-issues.](https://github.com/polyphony-chat/chorus/issues?q=is%3Aissue+label%3A%22Type%3A+Meta%22+) They contain a comprehensive list of all features which are yet missing for full Discord.com compatibility.
-Please feel free to open an Issue with the idea you have, or a Pull Request. Please keep our [contribution guidelines](https://github.com/polyphony-chat/.github/blob/main/CONTRIBUTION_GUIDELINES.md) in mind. Your contribution might not be accepted if it violates these guidelines or [our Code of Conduct](https://github.com/polyphony-chat/.github/blob/main/CODE_OF_CONDUCT.md).
+See [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 <details>
   <summary>Progress Tracker/Roadmap</summary>


### PR DESCRIPTION
Moves the contribution guidelines from README.md to CONTRIBUTING.md, as per @striezel's suggestion.