### PR TITLE
Fix broken luna.gitlab.io links

### DIFF
--- a/src/api/users/relationships.rs
+++ b/src/api/users/relationships.rs
@@ -19,7 +19,7 @@ impl ChorusUser {
     /// Retrieves a list of mutual friends between the authenticated user and a given user.
     ///
     /// # Reference
-    /// See <https://luna.gitlab.io/discord-unofficial-docs/relationships.html#get-users-peer-id-relationships>
+    /// See <https://luna.gitlab.io/discord-unofficial-docs/docs/relationships.html#get-userspeer_idrelationships>
     pub async fn get_mutual_relationships(
         &mut self,
         user_id: Snowflake,
@@ -41,7 +41,7 @@ impl ChorusUser {
     /// Retrieves the user's relationships.
     ///
     /// # Reference
-    /// See <https://luna.gitlab.io/discord-unofficial-docs/relationships.html#get-users-me-relationships>
+    /// See <https://luna.gitlab.io/discord-unofficial-docs/docs/relationships.html#get-usersmerelationships>
     pub async fn get_relationships(&mut self) -> ChorusResult<Vec<types::Relationship>> {
         let url = format!(
             "{}/users/@me/relationships",
@@ -59,7 +59,7 @@ impl ChorusUser {
     /// Sends a friend request to a user.
     ///
     /// # Reference
-    /// See <https://luna.gitlab.io/discord-unofficial-docs/relationships.html#post-users-me-relationships>
+    /// See <https://luna.gitlab.io/discord-unofficial-docs/docs/relationships.html#post-usersmerelationships>
     pub async fn send_friend_request(
         &mut self,
         schema: FriendRequestSendSchema,
@@ -136,7 +136,7 @@ impl ChorusUser {
     /// Removes the relationship between the authenticated user and a given user.
     ///
     /// # Reference
-    /// See <https://luna.gitlab.io/discord-unofficial-docs/relationships.html#delete-users-me-relationships-peer-id>
+    /// See <https://luna.gitlab.io/discord-unofficial-docs/docs/relationships.html#delete-usersmerelationshipspeer_id>
     pub async fn remove_relationship(&mut self, user_id: Snowflake) -> ChorusResult<()> {
         let url = format!(
             "{}/users/@me/relationships/{}",

--- a/src/api/users/users.rs
+++ b/src/api/users/users.rs
@@ -117,7 +117,7 @@ impl User {
     /// Gets the user's settings.
     ///
     /// # Reference
-    /// See <https://luna.gitlab.io/discord-unofficial-docs/user_settings.html#get-users-me-settings>
+    /// See <https://luna.gitlab.io/discord-unofficial-docs/docs/user_settings.html#get-usersmesettings>
     pub async fn get_settings(
         token: &String,
         url_api: &String,

--- a/src/types/events/lazy_request.rs
+++ b/src/types/events/lazy_request.rs
@@ -17,7 +17,7 @@ use super::WebSocketEvent;
 /// Sent by the official client when switching to a guild or channel;
 /// After this, you should receive message updates
 ///
-/// See <https://luna.gitlab.io/discord-unofficial-docs/lazy_guilds.html#op-14-lazy-request>
+/// See <https://luna.gitlab.io/discord-unofficial-docs/docs/lazy_guilds#op-14-lazy-request>
 ///
 /// {"op":14,"d":{"guild_id":"848582562217590824","typing":true,"activities":true,"threads":true}}
 pub struct LazyRequest {


### PR DESCRIPTION
At some point luna.gitlab.io updated their url structure and now all existing links return a 404. This pr updates the links in our documentation to properly point to the right new urls.