### PR TITLE
ignore unused imports for pub use

### DIFF
--- a/src/api/auth/mod.rs
+++ b/src/api/auth/mod.rs
@@ -4,7 +4,10 @@
 
 use std::sync::{Arc, RwLock};
 
+#[allow(unused_imports)]
 pub use login::*;
+
+#[allow(unused_imports)]
 pub use register::*;
 
 use crate::gateway::Gateway;

--- a/src/api/channels/mod.rs
+++ b/src/api/channels/mod.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#![allow(unused_imports)]
 pub use channels::*;
 pub use messages::*;
 pub use permissions::*;

--- a/src/api/guilds/mod.rs
+++ b/src/api/guilds/mod.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#![allow(unused_imports)]
 pub use guilds::*;
 pub use messages::*;
 pub use roles::*;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -3,6 +3,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //! All of the API's endpoints.
+
+#![allow(unused_imports)]
 pub use channels::messages::*;
 pub use guilds::*;
 pub use invites::*;

--- a/src/api/policies/instance/mod.rs
+++ b/src/api/policies/instance/mod.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#![allow(unused_imports)]
 pub use instance::*;
 
 pub mod instance;

--- a/src/api/users/mod.rs
+++ b/src/api/users/mod.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#![allow(unused_imports)]
 pub use channels::*;
 pub use guilds::*;
 pub use relationships::*;

--- a/src/types/interfaces/mod.rs
+++ b/src/types/interfaces/mod.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#![allow(unused_imports)]
 pub use activity::*;
 pub use connected_account::*;
 pub use guild_welcome_screen::*;

--- a/src/types/utils/mod.rs
+++ b/src/types/utils/mod.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#![allow(unused_imports)]
 pub use regexes::*;
 pub use rights::Rights;
 pub use snowflake::Snowflake;


### PR DESCRIPTION
Ignore the warnings given for `pub use ...`