### PR TITLE
add WebSocketEvent macro derive, bump chorus-macros to 0.3.0

### DIFF
--- a/chorus-macros/Cargo.lock
+++ b/chorus-macros/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "chorus-macros"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "quote",

--- a/chorus-macros/Cargo.toml
+++ b/chorus-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chorus-macros"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "AGPL-3.0"
 description = "Macros for the chorus crate."

--- a/chorus-macros/Cargo.toml
+++ b/chorus-macros/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "chorus-macros"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
-license = "AGPL-3.0"
+license = "MPL-2.0"
 description = "Macros for the chorus crate."
 
 [lib]

--- a/chorus-macros/src/lib.rs
+++ b/chorus-macros/src/lib.rs
@@ -6,6 +6,18 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, Data, DeriveInput, Field, Fields, FieldsNamed};
 
+#[proc_macro_derive(WebSocketEvent)]
+pub fn websocket_event_macro_derive(input: TokenStream) -> TokenStream {
+    let ast: syn::DeriveInput = syn::parse(input).unwrap();
+
+    let name = &ast.ident;
+
+    quote! {
+        impl WebSocketEvent for #name {}
+    }
+    .into()
+}
+
 #[proc_macro_derive(Updateable)]
 pub fn updateable_macro_derive(input: TokenStream) -> TokenStream {
     let ast: syn::DeriveInput = syn::parse(input).unwrap();


### PR DESCRIPTION
Added #486 and bumped version of chorus-macros, can't perform the change in chorus yet though, since macros needs to be published first