### PR TITLE
Move Shared<T> to types/mod.rs, bump some dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,9 +716,9 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1753,9 +1753,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.10"
+version = "0.21.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+checksum = "7fecbfb7b1444f477b345853b1fce097a2c6fb637b2bfb87e6bc5db0f043fae4"
 dependencies = [
  "log",
  "ring 0.17.7",

--- a/src/gateway/handle.rs
+++ b/src/gateway/handle.rs
@@ -8,7 +8,7 @@ use log::*;
 use std::fmt::Debug;
 
 use super::{events::Events, *};
-use crate::types::{self, Composite};
+use crate::types::{self, Composite, Shared};
 
 /// Represents a handle to a Gateway connection. A Gateway connection will create observable
 /// [`GatewayEvents`](GatewayEvent), which you can subscribe to. Gateway events include all currently

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -133,10 +133,3 @@ impl<T: WebSocketEvent> GatewayEvent<T> {
     }
 }
 
-/// A type alias for [`Arc<RwLock<T>>`], used to make the public facing API concerned with
-/// Composite structs more ergonomic.
-/// ## Note
-///
-/// While `T` does not have to implement `Composite` to be used with `Shared`,
-/// the primary use of `Shared` is with types that implement `Composite`.
-pub type Shared<T> = Arc<RwLock<T>>;

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -13,11 +13,11 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 
 use crate::errors::ChorusResult;
-use crate::gateway::{Gateway, GatewayHandle, Shared};
+use crate::gateway::{Gateway, GatewayHandle};
 use crate::ratelimiter::ChorusRequest;
 use crate::types::types::subconfigs::limits::rates::RateLimits;
 use crate::types::{
-    GeneralConfiguration, Limit, LimitType, LimitsConfiguration, User, UserSettings,
+    GeneralConfiguration, Limit, LimitType, LimitsConfiguration, Shared, User, UserSettings,
 };
 use crate::UrlBundle;
 

--- a/src/types/entities/application.rs
+++ b/src/types/entities/application.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::gateway::Shared;
+use crate::types::Shared;
 use crate::types::utils::Snowflake;
 use crate::types::{Team, User};
 

--- a/src/types/entities/audit_log.rs
+++ b/src/types/entities/audit_log.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::gateway::Shared;
+use crate::types::Shared;
 use crate::types::utils::Snowflake;
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]

--- a/src/types/entities/auto_moderation.rs
+++ b/src/types/entities/auto_moderation.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use crate::gateway::Shared;
+use crate::types::Shared;
 #[cfg(feature = "client")]
 use crate::gateway::Updateable;
 

--- a/src/types/entities/channel.rs
+++ b/src/types/entities/channel.rs
@@ -8,7 +8,7 @@ use serde_aux::prelude::deserialize_string_from_number;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use std::fmt::Debug;
 
-use crate::gateway::Shared;
+use crate::types::Shared;
 use crate::types::{
     entities::{GuildMember, User},
     utils::Snowflake,

--- a/src/types/entities/emoji.rs
+++ b/src/types/entities/emoji.rs
@@ -6,7 +6,7 @@ use std::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 
-use crate::gateway::Shared;
+use crate::types::Shared;
 use crate::types::entities::User;
 use crate::types::Snowflake;
 

--- a/src/types/entities/guild.rs
+++ b/src/types/entities/guild.rs
@@ -9,7 +9,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::gateway::Shared;
+use crate::types::Shared;
 use crate::types::types::guild_configuration::GuildFeaturesList;
 use crate::types::{
     entities::{Channel, Emoji, RoleObject, Sticker, User, VoiceState, Webhook},

--- a/src/types/entities/guild_member.rs
+++ b/src/types/entities/guild_member.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::gateway::Shared;
+use crate::types::Shared;
 use crate::types::{entities::PublicUser, Snowflake};
 
 #[derive(Debug, Deserialize, Default, Serialize, Clone)]

--- a/src/types/entities/integration.rs
+++ b/src/types/entities/integration.rs
@@ -5,8 +5,8 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::gateway::Shared;
 use crate::types::{
+    Shared,
     entities::{Application, User},
     utils::Snowflake,
 };

--- a/src/types/entities/invite.rs
+++ b/src/types/entities/invite.rs
@@ -5,8 +5,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::gateway::Shared;
-use crate::types::{Snowflake, WelcomeScreenObject};
+use crate::types::{Snowflake, WelcomeScreenObject, Shared};
 
 use super::guild::GuildScheduledEvent;
 use super::{Application, Channel, GuildMember, NSFWLevel, User};

--- a/src/types/entities/message.rs
+++ b/src/types/entities/message.rs
@@ -4,8 +4,8 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::gateway::Shared;
 use crate::types::{
+    Shared,
     entities::{
         Application, Attachment, Channel, Emoji, GuildMember, PublicUser, RoleSubscriptionData,
         Sticker, StickerItem, User,

--- a/src/types/entities/mod.rs
+++ b/src/types/entities/mod.rs
@@ -27,7 +27,9 @@ pub use user_settings::*;
 pub use voice_state::*;
 pub use webhook::*;
 
-use crate::gateway::Shared;
+use crate::types::Shared;
+use std::sync::{Arc, RwLock};
+
 #[cfg(feature = "client")]
 use crate::gateway::Updateable;
 
@@ -39,8 +41,6 @@ use async_trait::async_trait;
 
 #[cfg(feature = "client")]
 use std::fmt::Debug;
-#[cfg(feature = "client")]
-use std::sync::{Arc, RwLock};
 
 mod application;
 mod attachment;

--- a/src/types/entities/relationship.rs
+++ b/src/types/entities/relationship.rs
@@ -6,8 +6,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::gateway::Shared;
-use crate::types::Snowflake;
+use crate::types::{Shared, Snowflake};
 
 use super::PublicUser;
 

--- a/src/types/entities/sticker.rs
+++ b/src/types/entities/sticker.rs
@@ -4,8 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::gateway::Shared;
-use crate::types::{entities::User, utils::Snowflake};
+use crate::types::{entities::User, utils::Snowflake, Shared};
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]

--- a/src/types/entities/team.rs
+++ b/src/types/entities/team.rs
@@ -4,9 +4,9 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::gateway::Shared;
 use crate::types::entities::User;
 use crate::types::Snowflake;
+use crate::types::Shared;
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]

--- a/src/types/entities/template.rs
+++ b/src/types/entities/template.rs
@@ -5,8 +5,8 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::gateway::Shared;
 use crate::types::{
+    Shared,
     entities::{Guild, User},
     utils::Snowflake,
 };

--- a/src/types/entities/user_settings.rs
+++ b/src/types/entities/user_settings.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, RwLock};
 use chrono::{serde::ts_milliseconds_option, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::gateway::Shared;
+use crate::types::Shared;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]

--- a/src/types/entities/voice_state.rs
+++ b/src/types/entities/voice_state.rs
@@ -5,7 +5,8 @@
 #[cfg(feature = "client")]
 use chorus_macros::Composite;
 
-use crate::gateway::Shared;
+use crate::types::Shared;
+
 #[cfg(feature = "client")]
 use crate::types::Composite;
 
@@ -51,6 +52,7 @@ pub struct VoiceState {
     pub id: Option<Snowflake>, // Only exists on Spacebar
 }
 
+#[cfg(feature = "client")]
 impl Updateable for VoiceState {
     #[cfg(not(tarpaulin_include))]
     fn id(&self) -> Snowflake {

--- a/src/types/entities/webhook.rs
+++ b/src/types/entities/webhook.rs
@@ -6,7 +6,8 @@ use std::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 
-use crate::gateway::Shared;
+use crate::types::Shared;
+
 #[cfg(feature = "client")]
 use crate::gateway::Updateable;
 

--- a/src/types/events/channel.rs
+++ b/src/types/events/channel.rs
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use crate::types::events::WebSocketEvent;
-use crate::types::IntoShared;
 use crate::types::{entities::Channel, JsonField, Snowflake, SourceUrlField};
 use chorus_macros::{JsonField, SourceUrlField};
 use chrono::{DateTime, Utc};
@@ -13,7 +12,10 @@ use serde::{Deserialize, Serialize};
 use super::UpdateMessage;
 
 #[cfg(feature = "client")]
-use crate::gateway::Shared;
+use crate::types::Shared;
+
+#[cfg(feature = "client")]
+use crate::types::IntoShared;
 
 #[cfg(feature = "client")]
 use crate::types::Guild;

--- a/src/types/events/guild.rs
+++ b/src/types/events/guild.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::types::entities::{Guild, PublicUser, UnavailableGuild};
 use crate::types::events::WebSocketEvent;
 use crate::types::{
-    AuditLogEntry, Emoji, GuildMember, GuildScheduledEvent, IntoShared, JsonField, RoleObject,
+    AuditLogEntry, Emoji, GuildMember, GuildScheduledEvent, JsonField, RoleObject,
     Snowflake, SourceUrlField, Sticker,
 };
 
@@ -18,7 +18,9 @@ use super::PresenceUpdate;
 #[cfg(feature = "client")]
 use super::UpdateMessage;
 #[cfg(feature = "client")]
-use crate::gateway::Shared;
+use crate::types::Shared;
+#[cfg(feature = "client")]
+use crate::types::IntoShared;
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone, SourceUrlField, JsonField)]
 /// See <https://discord.com/developers/docs/topics/gateway-events#guild-create>;

--- a/src/types/events/mod.rs
+++ b/src/types/events/mod.rs
@@ -46,7 +46,7 @@ use serde_json::{from_str, from_value, to_value, Value};
 use std::collections::HashMap;
 
 #[cfg(feature = "client")]
-use crate::gateway::Shared;
+use crate::types::Shared;
 use std::fmt::Debug;
 
 #[cfg(feature = "client")]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -4,6 +4,8 @@
 
 //! All the types, entities, events and interfaces of the Spacebar API.
 
+use std::sync::{Arc, RwLock};
+
 pub use config::*;
 pub use entities::*;
 pub use errors::*;
@@ -19,3 +21,11 @@ mod events;
 mod interfaces;
 mod schema;
 mod utils;
+
+/// A type alias for [`Arc<RwLock<T>>`], used to make the public facing API concerned with
+/// Composite structs more ergonomic.
+/// ## Note
+///
+/// While `T` does not have to implement `Composite` to be used with `Shared`,
+/// the primary use of `Shared` is with types that implement `Composite`.
+pub type Shared<T> = Arc<RwLock<T>>;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use chorus::gateway::{Gateway, Shared};
+use chorus::gateway::{Gateway};
 use chorus::types::IntoShared;
 use chorus::{
     instance::{ChorusUser, Instance},
@@ -11,6 +11,7 @@ use chorus::{
         RoleCreateModifySchema, RoleObject,
     },
     UrlBundle,
+    Shared,
 };
 
 #[allow(dead_code)]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,16 +2,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use chorus::gateway::{Gateway};
+use chorus::gateway::Gateway;
 use chorus::types::IntoShared;
 use chorus::{
     instance::{ChorusUser, Instance},
     types::{
         Channel, ChannelCreateSchema, Guild, GuildCreateSchema, RegisterSchema,
-        RoleCreateModifySchema, RoleObject,
+        RoleCreateModifySchema, RoleObject, Shared
     },
     UrlBundle,
-    Shared,
 };
 
 #[allow(dead_code)]


### PR DESCRIPTION
This pr includes various fixes:
- bump rustls to 0.21.11, to fix an (although n/a to chorus) [security vulnerability](https://github.com/advisories/GHSA-6g7w-8wpp-frhj)
- bump h2 to 0.3.26 to fix another (although n/a to chorus) [security vulnerability](https://github.com/advisories/GHSA-q6cp-qfwq-4gcv)
- move type alias `Shared<T>` from `src/gateway/mod.rs` (feature locked behind `client`) to `src/types/mod.rs`, to fix compiler errors when building without the `client` feature:
```
error[E0432]: unresolved import `crate::gateway`
  --> src/types/entities/mod.rs:30:12
   |
30 | use crate::gateway::Shared;
   |            ^^^^^^^ could not find `gateway` in the crate root

error[E0432]: unresolved import `crate::gateway`
  --> src/types/entities/application.rs:10:12
   |
10 | use crate::gateway::Shared;
   |            ^^^^^^^ could not find `gateway` in the crate root

error[E0432]: unresolved import `crate::gateway`
 --> src/types/entities/audit_log.rs:7:12
  |
7 | use crate::gateway::Shared;
  |            ^^^^^^^ could not find `gateway` in the crate root
...
  ```