### PR TITLE
Reuse gateway backends, don't duplicate them for voice gateway

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -93,7 +93,7 @@ custom_error! {
     DisallowedIntents = "You sent a disallowed intent. You may have tried to specify an intent that you have not enabled or are not approved for",
 
     // Errors when initiating a gateway connection
-    CannotConnect{error: String} = "Cannot connect due to a tungstenite error: {error}",
+    CannotConnect{error: String} = "Cannot connect due to a websocket error: {error}",
     NonHelloOnInitiate{opcode: u8} = "Received non hello on initial gateway connection ({opcode}), something is definitely wrong",
 
     // Other misc errors
@@ -124,7 +124,7 @@ custom_error! {
     UnknownEncryptionMode = "Server failed to decrypt data",
 
     // Errors when initiating a gateway connection
-    CannotConnect{error: String} = "Cannot connect due to a tungstenite error: {error}",
+    CannotConnect{error: String} = "Cannot connect due to a websocket error: {error}",
     NonHelloOnInitiate{opcode: u8} = "Received non hello on initial gateway connection ({opcode}), something is definitely wrong",
 
     // Other misc errors

--- a/src/gateway/backends/wasm.rs
+++ b/src/gateway/backends/wasm.rs
@@ -9,7 +9,6 @@ use futures_util::{
 
 use ws_stream_wasm::*;
 
-use crate::errors::GatewayError;
 use crate::gateway::GatewayMessage;
 
 #[derive(Debug, Clone)]
@@ -22,13 +21,8 @@ pub type WasmStream = SplitStream<WsStream>;
 impl WasmBackend {
     pub async fn connect(
         websocket_url: &str,
-    ) -> Result<(WasmSink, WasmStream), crate::errors::GatewayError> {
-        let (_, websocket_stream) = match WsMeta::connect(websocket_url, None).await {
-            Ok(stream) => Ok(stream),
-            Err(e) => Err(GatewayError::CannotConnect {
-                error: e.to_string(),
-            }),
-        }?;
+    ) -> Result<(WasmSink, WasmStream), ws_stream_wasm::WsErr> {
+        let (_, websocket_stream) = WsMeta::connect(websocket_url, None).await?;
 
         Ok(websocket_stream.split())
     }

--- a/src/gateway/gateway.rs
+++ b/src/gateway/gateway.rs
@@ -35,7 +35,14 @@ impl Gateway {
     #[allow(clippy::new_ret_no_self)]
     pub async fn spawn(websocket_url: String) -> Result<GatewayHandle, GatewayError> {
         let (websocket_send, mut websocket_receive) =
-            WebSocketBackend::connect(&websocket_url).await?;
+            match WebSocketBackend::connect(&websocket_url).await {
+                Ok(streams) => streams,
+                Err(e) => {
+                    return Err(GatewayError::CannotConnect {
+                        error: format!("{:?}", e),
+                    })
+                }
+            };
 
         let shared_websocket_send = Arc::new(Mutex::new(websocket_send));
 

--- a/src/voice/gateway/backends/mod.rs
+++ b/src/voice/gateway/backends/mod.rs
@@ -4,24 +4,7 @@
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "voice_gateway"))]
 pub mod tungstenite;
-#[cfg(all(not(target_arch = "wasm32"), feature = "voice_gateway"))]
-pub use tungstenite::*;
 
 #[cfg(all(target_arch = "wasm32", feature = "voice_gateway"))]
 pub mod wasm;
-#[cfg(all(target_arch = "wasm32", feature = "voice_gateway"))]
-pub use wasm::*;
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "voice_gateway"))]
-pub type Sink = tungstenite::TungsteniteSink;
-#[cfg(all(not(target_arch = "wasm32"), feature = "voice_gateway"))]
-pub type Stream = tungstenite::TungsteniteStream;
-#[cfg(all(not(target_arch = "wasm32"), feature = "voice_gateway"))]
-pub type WebSocketBackend = tungstenite::TungsteniteBackend;
-
-#[cfg(all(target_arch = "wasm32", feature = "voice_gateway"))]
-pub type Sink = wasm::WasmSink;
-#[cfg(all(target_arch = "wasm32", feature = "voice_gateway"))]
-pub type Stream = wasm::WasmStream;
-#[cfg(all(target_arch = "wasm32", feature = "voice_gateway"))]
-pub type WebSocketBackend = wasm::WasmBackend;

--- a/src/voice/gateway/backends/tungstenite.rs
+++ b/src/voice/gateway/backends/tungstenite.rs
@@ -2,76 +2,16 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use futures_util::{
-    stream::{SplitSink, SplitStream},
-    StreamExt,
-};
-use tokio::net::TcpStream;
-use tokio_tungstenite::{
-    connect_async_tls_with_config, tungstenite, Connector, MaybeTlsStream, WebSocketStream,
-};
+use crate::voice::gateway::VoiceGatewayMessage;
 
-use crate::{errors::VoiceGatewayError, voice::gateway::VoiceGatewayMessage};
-
-#[derive(Debug, Clone)]
-pub struct TungsteniteBackend;
-
-// These could be made into inherent associated types when that's stabilized
-pub type TungsteniteSink =
-    SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, tungstenite::Message>;
-pub type TungsteniteStream = SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>;
-
-impl TungsteniteBackend {
-    pub async fn connect(
-        websocket_url: &str,
-    ) -> Result<(TungsteniteSink, TungsteniteStream), crate::errors::VoiceGatewayError> {
-        let mut roots = rustls::RootCertStore::empty();
-        let certs = rustls_native_certs::load_native_certs();
-
-        if let Err(e) = certs {
-            log::error!("Failed to load platform native certs! {:?}", e);
-            return Err(VoiceGatewayError::CannotConnect {
-                error: format!("{:?}", e),
-            });
-        }
-
-        for cert in certs.unwrap() {
-            roots.add(&rustls::Certificate(cert.0)).unwrap();
-        }
-        let (websocket_stream, _) = match connect_async_tls_with_config(
-            websocket_url,
-            None,
-            false,
-            Some(Connector::Rustls(
-                rustls::ClientConfig::builder()
-                    .with_safe_defaults()
-                    .with_root_certificates(roots)
-                    .with_no_client_auth()
-                    .into(),
-            )),
-        )
-        .await
-        {
-            Ok(websocket_stream) => websocket_stream,
-            Err(e) => {
-                return Err(VoiceGatewayError::CannotConnect {
-                    error: e.to_string(),
-                })
-            }
-        };
-
-        Ok(websocket_stream.split())
-    }
-}
-
-impl From<VoiceGatewayMessage> for tungstenite::Message {
+impl From<VoiceGatewayMessage> for tokio_tungstenite::tungstenite::Message {
     fn from(message: VoiceGatewayMessage) -> Self {
         Self::Text(message.0)
     }
 }
 
-impl From<tungstenite::Message> for VoiceGatewayMessage {
-    fn from(value: tungstenite::Message) -> Self {
+impl From<tokio_tungstenite::tungstenite::Message> for VoiceGatewayMessage {
+    fn from(value: tokio_tungstenite::tungstenite::Message) -> Self {
         Self(value.to_string())
     }
 }

--- a/src/voice/gateway/backends/wasm.rs
+++ b/src/voice/gateway/backends/wasm.rs
@@ -2,35 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use futures_util::{
-    stream::{SplitSink, SplitStream},
-    StreamExt,
-};
-
-use ws_stream_wasm::*;
-
-use crate::errors::VoiceGatewayError;
+use ws_stream_wasm::WsMessage;
 use crate::voice::gateway::VoiceGatewayMessage;
-
-#[derive(Debug, Clone)]
-pub struct WasmBackend;
-
-// These could be made into inherent associated types when that's stabilized
-pub type WasmSink = SplitSink<WsStream, WsMessage>;
-pub type WasmStream = SplitStream<WsStream>;
-
-impl WasmBackend {
-    pub async fn connect(websocket_url: &str) -> Result<(WasmSink, WasmStream), VoiceGatewayError> {
-        let (_, websocket_stream) = match WsMeta::connect(websocket_url, None).await {
-            Ok(stream) => Ok(stream),
-            Err(e) => Err(VoiceGatewayError::CannotConnect {
-                error: e.to_string(),
-            }),
-        }?;
-
-        Ok(websocket_stream.split())
-    }
-}
 
 impl From<VoiceGatewayMessage> for WsMessage {
     fn from(message: VoiceGatewayMessage) -> Self {

--- a/src/voice/gateway/handle.rs
+++ b/src/voice/gateway/handle.rs
@@ -11,13 +11,16 @@ use futures_util::SinkExt;
 use serde_json::json;
 use tokio::sync::Mutex;
 
-use crate::types::{
-    SelectProtocol, Speaking, SsrcDefinition, VoiceGatewaySendPayload, VoiceIdentify,
-    VOICE_BACKEND_VERSION, VOICE_IDENTIFY, VOICE_SELECT_PROTOCOL, VOICE_SPEAKING,
-    VOICE_SSRC_DEFINITION,
+use crate::{
+    gateway::Sink,
+    types::{
+        SelectProtocol, Speaking, SsrcDefinition, VoiceGatewaySendPayload, VoiceIdentify,
+        VOICE_BACKEND_VERSION, VOICE_IDENTIFY, VOICE_SELECT_PROTOCOL, VOICE_SPEAKING,
+        VOICE_SSRC_DEFINITION,
+    },
 };
 
-use super::{events::VoiceEvents, Sink, VoiceGatewayMessage};
+use super::{events::VoiceEvents, VoiceGatewayMessage};
 
 /// Represents a handle to a Voice Gateway connection.
 /// Using this handle you can send Gateway Events directly.

--- a/src/voice/gateway/heartbeat.rs
+++ b/src/voice/gateway/heartbeat.rs
@@ -26,12 +26,10 @@ use tokio::sync::{
 use tokio::task;
 
 use crate::{
-    gateway::heartbeat::HEARTBEAT_ACK_TIMEOUT,
+    gateway::{heartbeat::HEARTBEAT_ACK_TIMEOUT, Sink},
     types::{VoiceGatewaySendPayload, VOICE_HEARTBEAT, VOICE_HEARTBEAT_ACK},
     voice::gateway::VoiceGatewayMessage,
 };
-
-use super::Sink;
 
 /// Handles sending heartbeats to the voice gateway in another thread
 #[allow(dead_code)] // FIXME: Remove this, once all fields of VoiceHeartbeatHandler are used


### PR DESCRIPTION
When I first implemented the voice gateway, I (pretty foolishly) just copy-pasted the code for the regular gateway backends, with some type changes. Now I've thought of a pretty easy to way to have the websocket backends implemented in just one place, so they aren't duplicated. ([also because there is potentially another type of gateway to implement](https://docs.discord.sex/remote-authentication/intro), and maintaining the same code three times would be a pain)