### PR TITLE
Ci improvements

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -35,10 +35,11 @@ jobs:
       with:
         cache-all-crates: "true"
         prefix-key: "linux"
+    - name: Install cargo binstall
+      run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
     - name: Build, Test and Publish Coverage
       run: |
         if [ -n "${{ secrets.COVERALLS_REPO_TOKEN }}" ]; then
-          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
           cargo binstall --no-confirm cargo-tarpaulin --force
           cargo tarpaulin --all-features --avoid-cfg-tarpaulin --tests --verbose --skip-clean --coveralls ${{ secrets.COVERALLS_REPO_TOKEN }} --timeout 120
         else
@@ -46,6 +47,10 @@ jobs:
           cargo build --verbose --all-features
           cargo test --verbose --all-features
         fi
+    - name: Check all feature configurations
+      run: |
+        cargo binstall --no-confirm cargo-all-features --force
+        cargo check-all-features
   # wasm-safari:
   #   runs-on: macos-latest
   #   steps:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -75,7 +75,7 @@ jobs:
   #       cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.88" --force
   #       SAFARIDRIVER=$(which safaridriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt" --no-fail-fast
   wasm-gecko:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v4
@@ -93,9 +93,6 @@ jobs:
         npm run setup
         npm run start &
       working-directory: ./server
-    - uses: browser-actions/setup-geckodriver@latest
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
     - uses: Swatinem/rust-cache@v2 
       with:
         cache-all-crates: "true"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -101,7 +101,7 @@ jobs:
       run: |
         rustup target add wasm32-unknown-unknown
         curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-        cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.88" --force
+        cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.92" --force
         GECKODRIVER=$(which geckodriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt, voice_gateway"
   wasm-chrome:
     runs-on: macos-latest
@@ -130,5 +130,5 @@ jobs:
       run: |
         rustup target add wasm32-unknown-unknown
         curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-        cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.88" --force
+        cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.92" --force
         CHROMEDRIVER=$(which chromedriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt, voice_gateway"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -35,11 +35,10 @@ jobs:
       with:
         cache-all-crates: "true"
         prefix-key: "linux"
-    - name: Install cargo binstall
-      run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
     - name: Build, Test and Publish Coverage
       run: |
         if [ -n "${{ secrets.COVERALLS_REPO_TOKEN }}" ]; then
+          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
           cargo binstall --no-confirm cargo-tarpaulin --force
           cargo tarpaulin --all-features --avoid-cfg-tarpaulin --tests --verbose --skip-clean --coveralls ${{ secrets.COVERALLS_REPO_TOKEN }} --timeout 120
         else
@@ -47,10 +46,26 @@ jobs:
           cargo build --verbose --all-features
           cargo test --verbose --all-features
         fi
-    - name: Check all feature configurations
+    - name: Check common non-default feature configurations
       run: |
-        cargo binstall --no-confirm cargo-all-features --force
-        cargo check-all-features
+        echo "No features:"
+        cargo check --features="" --no-default-features
+        echo "Only client:"
+        cargo check --features="client" --no-default-features
+        echo "Only backend:"
+        cargo check --features="backend" --no-default-features
+        echo "Only voice:"
+        cargo check --features="voice" --no-default-features
+        echo "Only voice gateway:"
+        cargo check --features="voice_gateway" --no-default-features
+        echo "Backend + client:"
+        cargo check --features="backend, client" --no-default-features
+        echo "Backend + voice:"
+        cargo check --features="backend, voice" --no-default-features
+        echo "Backend + voice gateway:"
+        cargo check --features="backend, voice_gateway" --no-default-features
+        echo "Client + voice gateway:"
+        cargo check --features="client, voice_gateway" --no-default-features 
   # wasm-safari:
   #   runs-on: macos-latest
   #   steps:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -102,6 +102,7 @@ jobs:
         rustup target add wasm32-unknown-unknown
         curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
         cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.92" --force
+        echo $(which geckodriver)
         GECKODRIVER=$(which geckodriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt, voice_gateway"
   wasm-chrome:
     runs-on: macos-latest

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -93,6 +93,9 @@ jobs:
         npm run setup
         npm run start &
       working-directory: ./server
+    - uses: browser-actions/setup-geckodriver@latest
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
     - uses: Swatinem/rust-cache@v2 
       with:
         cache-all-crates: "true"
@@ -102,7 +105,6 @@ jobs:
         rustup target add wasm32-unknown-unknown
         curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
         cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.92" --force
-        echo Chromedriver path: $(which geckodriver)
         GECKODRIVER=$(which geckodriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt, voice_gateway"
   wasm-chrome:
     runs-on: macos-latest

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -102,7 +102,7 @@ jobs:
         rustup target add wasm32-unknown-unknown
         curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
         cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.92" --force
-        echo $(which geckodriver)
+        echo Chromedriver path: $(which geckodriver)
         GECKODRIVER=$(which geckodriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt, voice_gateway"
   wasm-chrome:
     runs-on: macos-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2727,9 +2727,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2737,9 +2737,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
@@ -2764,9 +2764,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2774,9 +2774,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2787,9 +2787,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasm-bindgen-test"

--- a/semver_release_checks.yml
+++ b/semver_release_checks.yml
@@ -1,0 +1,18 @@
+name: Semver release checks
+
+on:
+  pull_request:
+    branches: ["main"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  semver-checks:
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4 
+      - uses: obi1kenobi/cargo-semver-checks-action@v2


### PR DESCRIPTION
Changes:
- add an experimental check for semver compliance on pull requests to main (which are usually releases)
- 'fix' `wasm-gecko` by changing it to run on `ubuntu-latest`, since geckodriver no longer supports arm64 macos
- Cargo check a few common non-default feature configuration, sort of doing #497 (mostly so we don't give symfonia build errors)
- bump `wasm-bindgen` to `0.2.92`