### PR TITLE
Bump chorus macros to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,9 +264,7 @@ dependencies = [
 
 [[package]]
 name = "chorus-macros"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de4221700bc486c6e6bc261fdea478936d33067a06325895f5d2a8cde5917272"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ thiserror = "1.0.56"
 jsonwebtoken = "8.3.0"
 log = "0.4.20"
 async-trait = "0.1.77"
-chorus-macros = { path = "./chorus-macros" }
+chorus-macros = { path = "./chorus-macros", version = "0.4.0" } # Note: version here is used when releasing. Make sure to update and republish when code in macros is changed!
 sqlx = { version = "0.7.3", features = [
     "mysql",
     "sqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ thiserror = "1.0.56"
 jsonwebtoken = "8.3.0"
 log = "0.4.20"
 async-trait = "0.1.77"
-chorus-macros = { path = "./chorus-macros", version = "0.4.0" } # Note: version here is used when releasing. Make sure to update and republish when code in macros is changed!
+chorus-macros = { path = "./chorus-macros", version = "0" } # Note: version here is used when releasing. This will use the latest release. Make sure to republish the crate when code in macros is changed!
 sqlx = { version = "0.7.3", features = [
     "mysql",
     "sqlite",

--- a/chorus-macros/Cargo.lock
+++ b/chorus-macros/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "chorus-macros"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "quote",

--- a/chorus-macros/Cargo.toml
+++ b/chorus-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chorus-macros"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MPL-2.0"
 description = "Macros for the chorus crate."


### PR DESCRIPTION
- Bumps chorus macros to 0.4.0, followup to #505
- Makes builds within the repo use the local path and published releases use a set version of the macros crate