### PR TITLE
Add custom deserializer for PermissionOverwriteType

### DIFF
--- a/src/types/entities/channel.rs
+++ b/src/types/entities/channel.rs
@@ -5,13 +5,14 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use std::fmt::{Debug, Formatter};
+use std::fmt::Debug;
 use std::str::FromStr;
 
 use crate::types::{
     PermissionFlags, Shared,
     entities::{GuildMember, User},
     utils::Snowflake,
+    serde::string_or_u64
 };
 
 #[cfg(feature = "client")]
@@ -25,8 +26,7 @@ use crate::gateway::Updateable;
 
 #[cfg(feature = "client")]
 use chorus_macros::{observe_option_vec, Composite, Updateable};
-use serde::de::{Error, Visitor};
-use crate::types::serde::string_or_u64;
+
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]

--- a/src/types/entities/channel.rs
+++ b/src/types/entities/channel.rs
@@ -5,7 +5,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use std::fmt::Debug;
+use std::fmt::{Debug, Formatter};
 use std::str::FromStr;
 
 use crate::types::{
@@ -26,6 +26,7 @@ use crate::gateway::Updateable;
 
 #[cfg(feature = "client")]
 use chorus_macros::{observe_option_vec, Composite, Updateable};
+use serde::de::{Error, Visitor};
 
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
@@ -177,18 +178,49 @@ impl From<u8> for PermissionOverwriteType {
 }
 
 impl FromStr for PermissionOverwriteType {
-    type Err = std::num::ParseIntError;
+    type Err = serde::de::value::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        s.parse::<u8>().map(PermissionOverwriteType::from)
+        match s {
+            "role" => Ok(PermissionOverwriteType::Role),
+            "member" => Ok(PermissionOverwriteType::Member),
+            _ => Err(Self::Err::custom("invalid permission overwrite type")),
+        }
+    }
+}
+
+struct PermissionOverwriteTypeVisitor;
+
+impl<'de> Visitor<'de> for PermissionOverwriteTypeVisitor {
+    type Value = PermissionOverwriteType;
+
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+        formatter.write_str("a valid permission overwrite type")
+    }
+
+    fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: Error {
+        Ok(PermissionOverwriteType::from(v))
+    }
+
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: Error {
+        self.visit_u8(v as u8)
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: Error {
+        PermissionOverwriteType::from_str(v)
+            .map_err(E::custom)
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: Error {
+        self.visit_str(v.as_str())
     }
 }
 
 impl<'de> Deserialize<'de> for PermissionOverwriteType {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
-        let raw = string_or_u64(deserializer)?;
+        let val = deserializer.deserialize_any(PermissionOverwriteTypeVisitor)?;
 
-        Ok(PermissionOverwriteType::from(raw as u8))
+        Ok(val)
     }
 }
 


### PR DESCRIPTION
This simply add's a custom Deserialize impl for PermissionOverwriteType to allow deserialization from both ints and strings.