### PR TITLE
Derives

### DIFF
--- a/src/api/channels/reactions.rs
+++ b/src/api/channels/reactions.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 /// Useful metadata for working with [`types::Reaction`], bundled together nicely.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy, Hash, PartialOrd, Ord)]
 pub struct ReactionMeta {
     pub message_id: types::Snowflake,
     pub channel_id: types::Snowflake,

--- a/src/gateway/backends/tungstenite.rs
+++ b/src/gateway/backends/tungstenite.rs
@@ -14,7 +14,7 @@ use tokio_tungstenite::{
 
 use crate::gateway::{GatewayMessage, RawGatewayMessage};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct TungsteniteBackend;
 
 // These could be made into inherent associated types when that's stabilized

--- a/src/gateway/handle.rs
+++ b/src/gateway/handle.rs
@@ -154,7 +154,7 @@ impl GatewayHandle {
 
     /// Sends a call sync to the server
     pub async fn send_call_sync(&self, to_send: types::CallSync) {
-        let to_send_value = serde_json::to_value(&to_send).unwrap();
+        let to_send_value = serde_json::to_value(to_send).unwrap();
 
         trace!("GW: Sending Call Sync..");
 

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use async_trait::async_trait;
 
 pub mod backends;
 pub mod events;
@@ -20,7 +19,7 @@ pub use message::*;
 pub use options::*;
 
 use crate::errors::GatewayError;
-use crate::types::{Snowflake, WebSocketEvent};
+use crate::types::{Snowflake};
 
 use std::any::Any;
 use std::collections::HashMap;

--- a/src/gateway/options.rs
+++ b/src/gateway/options.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Debug, Default)]
+#[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Debug, Default, Copy)]
 /// Options passed when initializing the gateway connection.
 ///
 /// E.g. compression
@@ -17,8 +17,8 @@
 ///
 /// See <https://docs.discord.sex/topics/gateway#connections>
 pub struct GatewayOptions {
-   pub encoding: GatewayEncoding,
-   pub transport_compression: GatewayTransportCompression,
+    pub encoding: GatewayEncoding,
+    pub transport_compression: GatewayTransportCompression,
 }
 
 impl GatewayOptions {
@@ -26,11 +26,10 @@ impl GatewayOptions {
     ///
     /// Returns the new url
     pub(crate) fn add_to_url(&self, url: String) -> String {
-        
         let mut url = url;
 
         let mut parameters = Vec::with_capacity(2);
-        
+
         let encoding = self.encoding.to_url_parameter();
         parameters.push(encoding);
 
@@ -54,8 +53,7 @@ impl GatewayOptions {
             if !has_parameters {
                 url = format!("{}?{}", url, parameter);
                 has_parameters = true;
-            }
-            else {
+            } else {
                 url = format!("{}&{}", url, parameter);
             }
         }
@@ -78,15 +76,15 @@ pub enum GatewayTransportCompression {
 
 impl GatewayTransportCompression {
     /// Returns the option as a url parameter.
-    /// 
+    ///
     /// If set to [GatewayTransportCompression::None] returns [None].
     ///
     /// If set to anything else, returns a string like "compress=zlib-stream"
     pub(crate) fn to_url_parameter(self) -> Option<String> {
-       match self {
-            Self::None =>  None,
-            Self::ZLibStream => Some(String::from("compress=zlib-stream"))
-       } 
+        match self {
+            Self::None => None,
+            Self::ZLibStream => Some(String::from("compress=zlib-stream")),
+        }
     }
 }
 
@@ -102,17 +100,17 @@ pub enum GatewayEncoding {
     /// Should be lighter and faster than json.
     ///
     /// !! Chorus does not implement ETF yet !!
-    ETF
+    ETF,
 }
 
 impl GatewayEncoding {
     /// Returns the option as a url parameter.
-    /// 
+    ///
     /// Returns a string like "encoding=json"
     pub(crate) fn to_url_parameter(self) -> String {
-       match self {
-           Self::Json => String::from("encoding=json"),
-           Self::ETF => String::from("encoding=etf")
-       } 
+        match self {
+            Self::Json => String::from("encoding=json"),
+            Self::ETF => String::from("encoding=etf"),
+        }
     }
 }

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -35,24 +35,6 @@ pub struct Instance {
     pub gateway_options: GatewayOptions,
 }
 
-impl PartialEq for Instance {
-    fn eq(&self, other: &Self) -> bool {
-        self.urls == other.urls
-            && self.instance_info == other.instance_info
-            && self.limits_information == other.limits_information
-    }
-}
-
-impl std::hash::Hash for Instance {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.urls.hash(state);
-        self.instance_info.hash(state);
-        if let Some(inf) = &self.limits_information {
-            inf.hash(state);
-        }
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, Default, Eq)]
 pub struct LimitsInformation {
     pub ratelimits: HashMap<LimitType, Limit>,
@@ -69,6 +51,7 @@ impl std::hash::Hash for LimitsInformation {
     }
 }
 
+#[cfg(not(tarpaulin_include))]
 impl PartialEq for LimitsInformation {
     fn eq(&self, other: &Self) -> bool {
         self.ratelimits.iter().eq(other.ratelimits.iter())
@@ -173,14 +156,6 @@ pub struct ChorusUser {
     pub settings: Shared<UserSettings>,
     pub object: Shared<User>,
     pub gateway: GatewayHandle,
-}
-
-impl PartialEq for ChorusUser {
-    fn eq(&self, other: &Self) -> bool {
-        self.token == other.token
-            && self.limits == other.limits
-            && self.gateway.url == other.gateway.url
-    }
 }
 
 impl ChorusUser {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,6 @@ This crate uses Semantic Versioning 2.0.0 as its versioning scheme. You can read
 )]
 #![allow(clippy::module_inception)]
 #![deny(
-    missing_debug_implementations,
     clippy::extra_unused_lifetimes,
     clippy::from_over_into,
     clippy::needless_borrow,
@@ -110,7 +109,9 @@ This crate uses Semantic Versioning 2.0.0 as its versioning scheme. You can read
     clippy::unimplemented,
     clippy::dbg_macro,
     clippy::print_stdout,
-    clippy::print_stderr
+    clippy::print_stderr,
+    missing_debug_implementations,
+    missing_copy_implementations
 )]
 #[cfg(all(feature = "rt", feature = "rt_multi_thread"))]
 compile_error!("feature \"rt\" and feature \"rt_multi_thread\" cannot be enabled at the same time");

--- a/src/types/config/types/defaults_configuration.rs
+++ b/src/types/config/types/defaults_configuration.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::config::types::subconfigs::defaults::{guild::GuildDefaults, user::UserDefaults};
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, Copy)]
 #[serde(rename_all = "camelCase")]
 pub struct DefaultsConfiguration {
     pub guild: GuildDefaults,

--- a/src/types/config/types/login_configuration.rs
+++ b/src/types/config/types/login_configuration.rs
@@ -4,7 +4,9 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, Copy, Hash, PartialOrd, Ord,
+)]
 #[serde(rename_all = "camelCase")]
 pub struct LoginConfiguration {
     pub require_captcha: bool,

--- a/src/types/config/types/metrics_configuration.rs
+++ b/src/types/config/types/metrics_configuration.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Ord, PartialOrd, Copy, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct MetricsConfiguration {
     pub timeout: u64,

--- a/src/types/config/types/password_reset_configuration.rs
+++ b/src/types/config/types/password_reset_configuration.rs
@@ -4,7 +4,9 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, Copy, Hash, PartialOrd, Ord,
+)]
 #[serde(rename_all = "camelCase")]
 pub struct PasswordResetConfiguration {
     pub require_captcha: bool,

--- a/src/types/config/types/subconfigs/defaults/guild.rs
+++ b/src/types/config/types/subconfigs/defaults/guild.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::{ExplicitContentFilterLevel, MessageNotificationLevel};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, Hash, PartialOrd, Ord)]
 #[serde(rename_all = "camelCase")]
 pub struct GuildDefaults {
     pub max_presences: u64,

--- a/src/types/config/types/subconfigs/defaults/user.rs
+++ b/src/types/config/types/subconfigs/defaults/user.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, Hash, PartialOrd, Ord)]
 #[serde(rename_all = "camelCase")]
 pub struct UserDefaults {
     pub premium: bool,

--- a/src/types/config/types/subconfigs/guild/discovery.rs
+++ b/src/types/config/types/subconfigs/guild/discovery.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, PartialOrd, Ord, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct DiscoverConfiguration {
     pub show_all_guilds: bool,

--- a/src/types/config/types/subconfigs/limits/channel.rs
+++ b/src/types/config/types/subconfigs/limits/channel.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, PartialOrd, Ord)]
 #[serde(rename_all = "camelCase")]
 pub struct ChannelLimits {
     pub max_pins: u16,

--- a/src/types/config/types/subconfigs/limits/global.rs
+++ b/src/types/config/types/subconfigs/limits/global.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, PartialOrd, Ord, Hash)]
 pub struct GlobalRateLimit {
     pub limit: u16,
     pub window: u64,
@@ -21,7 +21,7 @@ impl Default for GlobalRateLimit {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, PartialOrd, Ord, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct GlobalRateLimits {
     pub register: GlobalRateLimit,

--- a/src/types/config/types/subconfigs/limits/guild.rs
+++ b/src/types/config/types/subconfigs/limits/guild.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, Hash, PartialOrd, Ord)]
 #[serde(rename_all = "camelCase")]
 pub struct GuildLimits {
     pub max_roles: u16,

--- a/src/types/config/types/subconfigs/limits/message.rs
+++ b/src/types/config/types/subconfigs/limits/message.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, PartialOrd, Ord, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct MessageLimits {
     pub max_characters: u32,

--- a/src/types/config/types/subconfigs/limits/ratelimits/auth.rs
+++ b/src/types/config/types/subconfigs/limits/ratelimits/auth.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::config::types::subconfigs::limits::ratelimits::RateLimitOptions;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, PartialOrd, Ord, Hash)]
 pub struct AuthRateLimit {
     pub login: RateLimitOptions,
     pub register: RateLimitOptions,

--- a/src/types/config/types/subconfigs/limits/ratelimits/mod.rs
+++ b/src/types/config/types/subconfigs/limits/ratelimits/mod.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 pub mod auth;
 pub mod route;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash, PartialOrd, Ord, Copy)]
 #[serde(rename_all = "camelCase")]
 pub struct RateLimitOptions {
     pub bot: Option<u64>,

--- a/src/types/config/types/subconfigs/limits/ratelimits/route.rs
+++ b/src/types/config/types/subconfigs/limits/ratelimits/route.rs
@@ -8,7 +8,7 @@ use crate::types::config::types::subconfigs::limits::ratelimits::{
     auth::AuthRateLimit, RateLimitOptions,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash, Copy, PartialOrd, Ord)]
 pub struct RouteRateLimit {
     pub guild: RateLimitOptions,
     pub webhook: RateLimitOptions,

--- a/src/types/config/types/subconfigs/limits/rates.rs
+++ b/src/types/config/types/subconfigs/limits/rates.rs
@@ -50,14 +50,14 @@ impl Default for RateLimits {
 impl RateLimits {
     pub fn to_hash_map(&self) -> HashMap<LimitType, RateLimitOptions> {
         let mut map = HashMap::new();
-        map.insert(LimitType::AuthLogin, self.routes.auth.login.clone());
-        map.insert(LimitType::AuthRegister, self.routes.auth.register.clone());
-        map.insert(LimitType::ChannelBaseline, self.routes.channel.clone());
-        map.insert(LimitType::Error, self.error.clone());
-        map.insert(LimitType::Global, self.global.clone());
-        map.insert(LimitType::Ip, self.ip.clone());
-        map.insert(LimitType::WebhookBaseline, self.routes.webhook.clone());
-        map.insert(LimitType::GuildBaseline, self.routes.guild.clone());
+        map.insert(LimitType::AuthLogin, self.routes.auth.login);
+        map.insert(LimitType::AuthRegister, self.routes.auth.register);
+        map.insert(LimitType::ChannelBaseline, self.routes.channel);
+        map.insert(LimitType::Error, self.error);
+        map.insert(LimitType::Global, self.global);
+        map.insert(LimitType::Ip, self.ip);
+        map.insert(LimitType::WebhookBaseline, self.routes.webhook);
+        map.insert(LimitType::GuildBaseline, self.routes.guild);
         map
     }
 }

--- a/src/types/config/types/subconfigs/limits/user.rs
+++ b/src/types/config/types/subconfigs/limits/user.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord, Copy, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct UserLimits {
     pub max_guilds: u64,

--- a/src/types/config/types/subconfigs/region/mod.rs
+++ b/src/types/config/types/subconfigs/region/mod.rs
@@ -4,13 +4,13 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, PartialOrd, Copy)]
 pub struct LatLong {
     pub latitude: f64,
     pub longitude: f64,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, PartialOrd)]
 pub struct Region {
     pub id: String,
     pub name: String,

--- a/src/types/config/types/subconfigs/register/date_of_birth.rs
+++ b/src/types/config/types/subconfigs/register/date_of_birth.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, PartialOrd, Ord, Hash)]
 pub struct DateOfBirthConfiguration {
     pub required: bool,
     pub minimum: u8,

--- a/src/types/config/types/subconfigs/register/password.rs
+++ b/src/types/config/types/subconfigs/register/password.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, PartialOrd, Ord, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct PasswordConfiguration {
     pub required: bool,

--- a/src/types/config/types/subconfigs/security/twofactor.rs
+++ b/src/types/config/types/subconfigs/security/twofactor.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, Hash, PartialOrd, Ord)]
 #[serde(rename_all = "camelCase")]
 pub struct TwoFactorConfiguration {
     pub generate_backup_codes: bool,

--- a/src/types/config/types/template_configuration.rs
+++ b/src/types/config/types/template_configuration.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, PartialOrd, Ord, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct TemplateConfiguration {
     pub enabled: bool,

--- a/src/types/entities/application.rs
+++ b/src/types/entities/application.rs
@@ -11,6 +11,7 @@ use crate::types::utils::Snowflake;
 use crate::types::Shared;
 use crate::types::{Team, User};
 
+#[allow(unused_imports)]
 use super::{arc_rwlock_ptr_eq, option_arc_rwlock_ptr_eq};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -87,11 +88,33 @@ impl PartialEq for Application {
             && self.discovery_eligibility_flags == other.discovery_eligibility_flags
             && self.tags == other.tags
             && self.cover_image == other.cover_image
-            && option_arc_rwlock_ptr_eq(&self.install_params, &other.install_params)
+            && compare_install_params(&self.install_params, &other.install_params)
             && self.terms_of_service_url == other.terms_of_service_url
             && self.privacy_policy_url == other.privacy_policy_url
             && self.team == other.team
     }
+}
+
+#[cfg(not(tarpaulin_include))]
+#[cfg(feature = "sqlx")]
+fn compare_install_params(
+    a: &Option<sqlx::types::Json<InstallParams>>,
+    b: &Option<sqlx::types::Json<InstallParams>>,
+) -> bool {
+    match (a, b) {
+        (Some(a), Some(b)) => a.encode_to_string() == b.encode_to_string(),
+        (None, None) => true,
+        _ => false,
+    }
+}
+
+#[cfg(not(tarpaulin_include))]
+#[cfg(not(feature = "sqlx"))]
+fn compare_install_params(
+    a: &Option<Shared<InstallParams>>,
+    b: &Option<Shared<InstallParams>>,
+) -> bool {
+    option_arc_rwlock_ptr_eq(a, b)
 }
 
 impl Default for Application {

--- a/src/types/entities/application.rs
+++ b/src/types/entities/application.rs
@@ -7,9 +7,11 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::types::Shared;
 use crate::types::utils::Snowflake;
+use crate::types::Shared;
 use crate::types::{Team, User};
+
+use super::{arc_rwlock_ptr_eq, option_arc_rwlock_ptr_eq};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
@@ -57,6 +59,39 @@ pub struct Application {
     pub privacy_policy_url: Option<String>,
     #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub team: Option<Team>,
+}
+
+#[cfg(not(tarpaulin_include))]
+impl PartialEq for Application {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+            && self.name == other.name
+            && self.icon == other.icon
+            && self.description == other.description
+            && self.summary == other.summary
+            && self.r#type == other.r#type
+            && self.hook == other.hook
+            && self.bot_public == other.bot_public
+            && self.bot_require_code_grant == other.bot_require_code_grant
+            && self.verify_key == other.verify_key
+            && arc_rwlock_ptr_eq(&self.owner, &other.owner)
+            && self.flags == other.flags
+            && self.redirect_uris == other.redirect_uris
+            && self.rpc_application_state == other.rpc_application_state
+            && self.store_application_state == other.store_application_state
+            && self.verification_state == other.verification_state
+            && self.interactions_endpoint_url == other.interactions_endpoint_url
+            && self.integration_public == other.integration_public
+            && self.integration_require_code_grant == other.integration_require_code_grant
+            && self.discoverability_state == other.discoverability_state
+            && self.discovery_eligibility_flags == other.discovery_eligibility_flags
+            && self.tags == other.tags
+            && self.cover_image == other.cover_image
+            && option_arc_rwlock_ptr_eq(&self.install_params, &other.install_params)
+            && self.terms_of_service_url == other.terms_of_service_url
+            && self.privacy_policy_url == other.privacy_policy_url
+            && self.team == other.team
+    }
 }
 
 impl Default for Application {
@@ -207,7 +242,9 @@ pub struct GuildApplicationCommandPermissions {
     pub permissions: Vec<Shared<ApplicationCommandPermission>>,
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Debug, Default, Clone, PartialEq, Serialize, Deserialize, Copy, Eq, Hash, PartialOrd, Ord,
+)]
 /// See <https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permissions-structure>
 pub struct ApplicationCommandPermission {
     pub id: Snowflake,
@@ -217,7 +254,19 @@ pub struct ApplicationCommandPermission {
     pub permission: bool,
 }
 
-#[derive(Serialize_repr, Deserialize_repr, Debug, Default, Clone, PartialEq, Eq, Hash)]
+#[derive(
+    Serialize_repr,
+    Deserialize_repr,
+    Debug,
+    Default,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    Copy,
+    PartialOrd,
+    Ord,
+)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[repr(u8)]
 /// See <https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permission-type>

--- a/src/types/entities/auto_moderation.rs
+++ b/src/types/entities/auto_moderation.rs
@@ -2,9 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use crate::types::Shared;
 #[cfg(feature = "client")]
 use crate::gateway::Updateable;
+use crate::types::Shared;
 
 #[cfg(feature = "client")]
 use chorus_macros::Updateable;
@@ -31,7 +31,7 @@ pub struct AutoModerationRule {
     pub exempt_channels: Vec<Snowflake>,
 }
 
-#[derive(Serialize_repr, Deserialize_repr, Debug, Clone, Default)]
+#[derive(Serialize_repr, Deserialize_repr, Debug, Clone, Default, Copy)]
 #[repr(u8)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// See <https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-event-types>
@@ -40,7 +40,9 @@ pub enum AutoModerationRuleEventType {
     MessageSend = 1,
 }
 
-#[derive(Serialize_repr, Deserialize_repr, Debug, Clone, Default)]
+#[derive(
+    Serialize_repr, Deserialize_repr, Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Copy,
+)]
 #[repr(u8)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// See <https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-types>
@@ -52,7 +54,7 @@ pub enum AutoModerationRuleTriggerType {
     MentionSpam = 5,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(untagged)]
 /// See <https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-metadata>
 pub enum AutoModerationRuleTriggerMetadata {
@@ -63,7 +65,7 @@ pub enum AutoModerationRuleTriggerMetadata {
     None,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord)]
 /// See <https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-metadata>
 pub struct AutoModerationRuleTriggerMetadataForKeyword {
     pub keyword_filter: Vec<String>,
@@ -71,14 +73,14 @@ pub struct AutoModerationRuleTriggerMetadataForKeyword {
     pub allow_list: Vec<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord)]
 /// See <https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-metadata>
 pub struct AutoModerationRuleTriggerMetadataForKeywordPreset {
     pub presets: Vec<AutoModerationRuleKeywordPresetType>,
     pub allow_list: Vec<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Copy)]
 /// See <https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-metadata>
 pub struct AutoModerationRuleTriggerMetadataForMentionSpam {
     /// Max 50
@@ -86,7 +88,9 @@ pub struct AutoModerationRuleTriggerMetadataForMentionSpam {
     pub mention_raid_protection_enabled: bool,
 }
 
-#[derive(Serialize_repr, Deserialize_repr, Debug, Clone, Default)]
+#[derive(
+    Serialize_repr, Deserialize_repr, Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Copy,
+)]
 #[repr(u8)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// See <https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-preset-types>
@@ -105,7 +109,9 @@ pub struct AutoModerationAction {
     pub metadata: Option<Shared<AutoModerationActionMetadata>>,
 }
 
-#[derive(Serialize_repr, Deserialize_repr, Debug, Clone, Default)]
+#[derive(
+    Serialize_repr, Deserialize_repr, Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Copy, Hash
+)]
 #[repr(u8)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// See <https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-action-object-action-types>
@@ -116,7 +122,7 @@ pub enum AutoModerationActionType {
     Timeout = 3,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(untagged)]
 /// See <https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-action-object-action-metadata>
 pub enum AutoModerationActionMetadata {
@@ -127,19 +133,19 @@ pub enum AutoModerationActionMetadata {
     None,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord)]
 /// See <https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-action-object-action-metadata>
 pub struct AutoModerationActionMetadataForBlockMessage {
     pub custom_message: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Copy)]
 /// See <https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-action-object-action-metadata>
 pub struct AutoModerationActionMetadataForSendAlertMessage {
     pub channel_id: Snowflake,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Copy)]
 /// See <https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-action-object-action-metadata>
 pub struct AutoModerationActionMetadataForTimeout {
     /// Max 2419200

--- a/src/types/entities/channel.rs
+++ b/src/types/entities/channel.rs
@@ -5,7 +5,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use sqlx::types::Json;
 use std::fmt::{Debug, Formatter};
 use std::str::FromStr;
 
@@ -27,6 +26,9 @@ use crate::gateway::Updateable;
 #[cfg(feature = "client")]
 use chorus_macros::{observe_option_vec, Composite, Updateable};
 use serde::de::{Error, Visitor};
+
+#[cfg(feature = "sqlx")]
+use sqlx::types::Json;
 
 use super::{option_arc_rwlock_ptr_eq, option_vec_arc_rwlock_ptr_eq};
 

--- a/src/types/entities/channel.rs
+++ b/src/types/entities/channel.rs
@@ -9,10 +9,9 @@ use std::fmt::{Debug, Formatter};
 use std::str::FromStr;
 
 use crate::types::{
-    PermissionFlags, Shared,
     entities::{GuildMember, User},
     utils::Snowflake,
-    serde::string_or_u64
+    PermissionFlags, Shared,
 };
 
 #[cfg(feature = "client")]
@@ -28,6 +27,7 @@ use crate::gateway::Updateable;
 use chorus_macros::{observe_option_vec, Composite, Updateable};
 use serde::de::{Error, Visitor};
 
+use super::{option_arc_rwlock_ptr_eq, option_vec_arc_rwlock_ptr_eq};
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
@@ -97,14 +97,21 @@ pub struct Channel {
     pub video_quality_mode: Option<i32>,
 }
 
+#[cfg(not(tarpaulin_include))]
 impl PartialEq for Channel {
     fn eq(&self, other: &Self) -> bool {
         self.application_id == other.application_id
+            && self.applied_tags == other.applied_tags
+            && self.applied_tags == other.applied_tags
+            && self.available_tags == other.available_tags
+            && self.available_tags == other.available_tags
             && self.bitrate == other.bitrate
             && self.channel_type == other.channel_type
             && self.created_at == other.created_at
             && self.default_auto_archive_duration == other.default_auto_archive_duration
             && self.default_forum_layout == other.default_forum_layout
+            && self.default_reaction_emoji == other.default_reaction_emoji
+            && self.default_reaction_emoji == other.default_reaction_emoji
             && self.default_sort_order == other.default_sort_order
             && self.default_thread_rate_limit_per_user == other.default_thread_rate_limit_per_user
             && self.flags == other.flags
@@ -114,16 +121,23 @@ impl PartialEq for Channel {
             && self.last_message_id == other.last_message_id
             && self.last_pin_timestamp == other.last_pin_timestamp
             && self.managed == other.managed
+            && self.member == other.member
             && self.member_count == other.member_count
             && self.message_count == other.message_count
             && self.name == other.name
             && self.nsfw == other.nsfw
             && self.owner_id == other.owner_id
             && self.parent_id == other.parent_id
+            && option_vec_arc_rwlock_ptr_eq(
+                &self.permission_overwrites,
+                &other.permission_overwrites,
+            )
             && self.permissions == other.permissions
             && self.position == other.position
             && self.rate_limit_per_user == other.rate_limit_per_user
+            && option_vec_arc_rwlock_ptr_eq(&self.recipients, &other.recipients)
             && self.rtc_region == other.rtc_region
+            && self.thread_metadata == other.thread_metadata
             && self.topic == other.topic
             && self.total_message_sent == other.total_message_sent
             && self.user_limit == other.user_limit
@@ -131,7 +145,7 @@ impl PartialEq for Channel {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// A tag that can be applied to a thread in a [ChannelType::GuildForum] or [ChannelType::GuildMedia] channel.
 ///
 /// # Reference
@@ -158,8 +172,7 @@ pub struct PermissionOverwrite {
     pub deny: PermissionFlags,
 }
 
-
-#[derive(Debug, Serialize_repr, Clone, PartialEq, Eq, PartialOrd)]
+#[derive(Debug, Serialize_repr, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 #[repr(u8)]
 /// # Reference
 ///
@@ -200,33 +213,47 @@ impl<'de> Visitor<'de> for PermissionOverwriteTypeVisitor {
         formatter.write_str("a valid permission overwrite type")
     }
 
-    fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: Error {
+    fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
         Ok(PermissionOverwriteType::from(v))
     }
 
-    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: Error {
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
         self.visit_u8(v as u8)
     }
 
-    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: Error {
-        PermissionOverwriteType::from_str(v)
-            .map_err(E::custom)
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        PermissionOverwriteType::from_str(v).map_err(E::custom)
     }
 
-    fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: Error {
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
         self.visit_str(v.as_str())
     }
 }
 
 impl<'de> Deserialize<'de> for PermissionOverwriteType {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
         let val = deserializer.deserialize_any(PermissionOverwriteTypeVisitor)?;
 
         Ok(val)
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 /// # Reference
 /// See <https://discord-userdoccers.vercel.app/resources/channel#thread-metadata-object>
 pub struct ThreadMetadata {
@@ -247,6 +274,17 @@ pub struct ThreadMember {
     pub join_timestamp: Option<DateTime<Utc>>,
     pub flags: Option<u64>,
     pub member: Option<Shared<GuildMember>>,
+}
+
+#[cfg(not(tarpaulin_include))]
+impl PartialEq for ThreadMember {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+            && self.user_id == other.user_id
+            && self.join_timestamp == other.join_timestamp
+            && self.flags == other.flags
+            && option_arc_rwlock_ptr_eq(&self.member, &other.member)
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, PartialOrd)]
@@ -329,11 +367,10 @@ pub enum ChannelType {
     Unhandled = 255,
 }
 
-
 /// # Reference
 /// See <https://docs.discord.sex/resources/message#followed-channel-object>
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Copy, Hash, PartialOrd, Ord)]
 pub struct FollowedChannel {
     pub channel_id: Snowflake,
-    pub webhook_id: Snowflake
+    pub webhook_id: Snowflake,
 }

--- a/src/types/entities/channel.rs
+++ b/src/types/entities/channel.rs
@@ -162,7 +162,7 @@ fn compare_permission_overwrites(
 
 #[cfg(not(tarpaulin_include))]
 #[cfg(not(feature = "sqlx"))]
-fn compare_permission_overrides(
+fn compare_permission_overwrites(
     a: &Option<Vec<Shared<PermissionOverwrite>>>,
     b: &Option<Vec<Shared<PermissionOverwrite>>>,
 ) -> bool {

--- a/src/types/entities/channel.rs
+++ b/src/types/entities/channel.rs
@@ -5,6 +5,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
+use sqlx::types::Json;
 use std::fmt::{Debug, Formatter};
 use std::str::FromStr;
 
@@ -98,6 +99,7 @@ pub struct Channel {
 }
 
 #[cfg(not(tarpaulin_include))]
+#[allow(clippy::nonminimal_bool)]
 impl PartialEq for Channel {
     fn eq(&self, other: &Self) -> bool {
         self.application_id == other.application_id
@@ -128,7 +130,7 @@ impl PartialEq for Channel {
             && self.nsfw == other.nsfw
             && self.owner_id == other.owner_id
             && self.parent_id == other.parent_id
-            && option_vec_arc_rwlock_ptr_eq(
+            && compare_permission_overwrites(
                 &self.permission_overwrites,
                 &other.permission_overwrites,
             )
@@ -143,6 +145,28 @@ impl PartialEq for Channel {
             && self.user_limit == other.user_limit
             && self.video_quality_mode == other.video_quality_mode
     }
+}
+
+#[cfg(not(tarpaulin_include))]
+#[cfg(feature = "sqlx")]
+fn compare_permission_overwrites(
+    a: &Option<Json<Vec<PermissionOverwrite>>>,
+    b: &Option<Json<Vec<PermissionOverwrite>>>,
+) -> bool {
+    match (a, b) {
+        (Some(a), Some(b)) => a.encode_to_string() == b.encode_to_string(),
+        (None, None) => true,
+        _ => false,
+    }
+}
+
+#[cfg(not(tarpaulin_include))]
+#[cfg(not(feature = "sqlx"))]
+fn compare_permission_overrides(
+    a: &Option<Vec<Shared<PermissionOverwrite>>>,
+    b: &Option<Vec<Shared<PermissionOverwrite>>>,
+) -> bool {
+    option_vec_arc_rwlock_ptr_eq(a, b)
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/types/entities/emoji.rs
+++ b/src/types/entities/emoji.rs
@@ -45,6 +45,7 @@ pub struct Emoji {
 }
 
 #[cfg(not(tarpaulin_include))]
+#[allow(clippy::nonminimal_bool)]
 impl PartialEq for Emoji {
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id
@@ -62,7 +63,7 @@ impl PartialEq for Emoji {
 impl From<PartialEmoji> for Emoji {
     fn from(value: PartialEmoji) -> Self {
         Self {
-            id: value.id.unwrap_or_default(), // TODO: this should be handled differently
+            id: value.id.unwrap_or_default(), // TODO: Make this method an impl to TryFrom<> instead
             name: Some(value.name),
             roles: None,
             user: None,

--- a/src/types/entities/emoji.rs
+++ b/src/types/entities/emoji.rs
@@ -6,9 +6,9 @@ use std::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 
-use crate::types::{PartialEmoji, Shared};
 use crate::types::entities::User;
 use crate::types::Snowflake;
+use crate::types::{PartialEmoji, Shared};
 
 #[cfg(feature = "client")]
 use crate::gateway::GatewayHandle;
@@ -21,6 +21,8 @@ use crate::gateway::Updateable;
 
 #[cfg(feature = "client")]
 use chorus_macros::{Composite, Updateable};
+
+use super::option_arc_rwlock_ptr_eq;
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[cfg_attr(feature = "client", derive(Updateable, Composite))]
@@ -42,28 +44,18 @@ pub struct Emoji {
     pub available: Option<bool>,
 }
 
-impl std::hash::Hash for Emoji {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.id.hash(state);
-        self.name.hash(state);
-        self.roles.hash(state);
-        self.roles.hash(state);
-        self.require_colons.hash(state);
-        self.managed.hash(state);
-        self.animated.hash(state);
-        self.available.hash(state);
-    }
-}
-
+#[cfg(not(tarpaulin_include))]
 impl PartialEq for Emoji {
     fn eq(&self, other: &Self) -> bool {
-        !(self.id != other.id
-            || self.name != other.name
-            || self.roles != other.roles
-            || self.require_colons != other.require_colons
-            || self.managed != other.managed
-            || self.animated != other.animated
-            || self.available != other.available)
+        self.id == other.id
+            && self.name == other.name
+            && self.roles == other.roles
+            && self.roles == other.roles
+            && option_arc_rwlock_ptr_eq(&self.user, &other.user)
+            && self.require_colons == other.require_colons
+            && self.managed == other.managed
+            && self.animated == other.animated
+            && self.available == other.available
     }
 }
 

--- a/src/types/entities/guild.rs
+++ b/src/types/entities/guild.rs
@@ -3,21 +3,22 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use std::fmt::Debug;
+use std::hash::Hash;
 
 use bitflags::bitflags;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-use crate::types::Shared;
 use crate::types::types::guild_configuration::GuildFeaturesList;
+use crate::types::Shared;
 use crate::types::{
     entities::{Channel, Emoji, RoleObject, Sticker, User, VoiceState, Webhook},
     interfaces::WelcomeScreenObject,
     utils::Snowflake,
 };
 
-use super::PublicUser;
+use super::{option_arc_rwlock_ptr_eq, vec_arc_rwlock_ptr_eq, PublicUser};
 
 #[cfg(feature = "client")]
 use crate::gateway::Updateable;
@@ -126,59 +127,8 @@ pub struct Guild {
     pub widget_enabled: Option<bool>,
 }
 
-impl std::hash::Hash for Guild {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.afk_channel_id.hash(state);
-        self.afk_timeout.hash(state);
-        self.application_id.hash(state);
-        self.approximate_member_count.hash(state);
-        self.approximate_presence_count.hash(state);
-        self.banner.hash(state);
-        self.bans.hash(state);
-        self.default_message_notifications.hash(state);
-        self.description.hash(state);
-        self.discovery_splash.hash(state);
-        self.explicit_content_filter.hash(state);
-        self.features.hash(state);
-        self.icon.hash(state);
-        self.icon_hash.hash(state);
-        self.id.hash(state);
-        self.invites.hash(state);
-        self.joined_at.hash(state);
-        self.large.hash(state);
-        self.max_members.hash(state);
-        self.max_presences.hash(state);
-        self.max_stage_video_channel_users.hash(state);
-        self.max_video_channel_users.hash(state);
-        self.mfa_level.hash(state);
-        self.name.hash(state);
-        self.nsfw_level.hash(state);
-        self.owner.hash(state);
-        self.owner_id.hash(state);
-        self.permissions.hash(state);
-        self.preferred_locale.hash(state);
-        self.premium_progress_bar_enabled.hash(state);
-        self.premium_subscription_count.hash(state);
-        self.premium_tier.hash(state);
-        self.primary_category_id.hash(state);
-        self.public_updates_channel_id.hash(state);
-        self.region.hash(state);
-        self.rules_channel.hash(state);
-        self.rules_channel_id.hash(state);
-        self.splash.hash(state);
-        self.stickers.hash(state);
-        self.system_channel_flags.hash(state);
-        self.system_channel_id.hash(state);
-        self.vanity_url_code.hash(state);
-        self.verification_level.hash(state);
-        self.welcome_screen.hash(state);
-        self.welcome_screen.hash(state);
-        self.widget_channel_id.hash(state);
-        self.widget_enabled.hash(state);
-    }
-}
-
-impl std::cmp::PartialEq for Guild {
+#[cfg(not(tarpaulin_include))]
+impl PartialEq for Guild {
     fn eq(&self, other: &Self) -> bool {
         self.afk_channel_id == other.afk_channel_id
             && self.afk_timeout == other.afk_timeout
@@ -187,14 +137,17 @@ impl std::cmp::PartialEq for Guild {
             && self.approximate_presence_count == other.approximate_presence_count
             && self.banner == other.banner
             && self.bans == other.bans
+            && vec_arc_rwlock_ptr_eq(&self.channels, &other.channels)
             && self.default_message_notifications == other.default_message_notifications
             && self.description == other.description
             && self.discovery_splash == other.discovery_splash
+            && vec_arc_rwlock_ptr_eq(&self.emojis, &other.emojis)
             && self.explicit_content_filter == other.explicit_content_filter
             && self.features == other.features
             && self.icon == other.icon
             && self.icon_hash == other.icon_hash
             && self.id == other.id
+            && self.invites == other.invites
             && self.joined_at == other.joined_at
             && self.large == other.large
             && self.max_members == other.max_members
@@ -214,6 +167,7 @@ impl std::cmp::PartialEq for Guild {
             && self.primary_category_id == other.primary_category_id
             && self.public_updates_channel_id == other.public_updates_channel_id
             && self.region == other.region
+            && vec_arc_rwlock_ptr_eq(&self.roles, &other.roles)
             && self.rules_channel == other.rules_channel
             && self.rules_channel_id == other.rules_channel_id
             && self.splash == other.splash
@@ -222,6 +176,8 @@ impl std::cmp::PartialEq for Guild {
             && self.system_channel_id == other.system_channel_id
             && self.vanity_url_code == other.vanity_url_code
             && self.verification_level == other.verification_level
+            && vec_arc_rwlock_ptr_eq(&self.voice_states, &other.voice_states)
+            && vec_arc_rwlock_ptr_eq(&self.webhooks, &other.webhooks)
             && self.welcome_screen == other.welcome_screen
             && self.welcome_screen == other.welcome_screen
             && self.widget_channel_id == other.widget_channel_id
@@ -261,32 +217,36 @@ pub struct GuildInvite {
     pub vanity_url: Option<bool>,
 }
 
-impl std::hash::Hash for GuildInvite {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.code.hash(state);
-        self.temporary.hash(state);
-        self.uses.hash(state);
-        self.max_uses.hash(state);
-        self.max_age.hash(state);
-        self.created_at.hash(state);
-        self.expires_at.hash(state);
-        self.guild_id.hash(state);
-        self.channel_id.hash(state);
-        self.inviter_id.hash(state);
-        self.target_user_id.hash(state);
-        self.target_user.hash(state);
-        self.target_user_type.hash(state);
-        self.vanity_url.hash(state);
+#[cfg(not(tarpaulin_include))]
+impl PartialEq for GuildInvite {
+    fn eq(&self, other: &Self) -> bool {
+        self.code == other.code
+            && self.temporary == other.temporary
+            && self.uses == other.uses
+            && self.max_uses == other.max_uses
+            && self.max_age == other.max_age
+            && self.created_at == other.created_at
+            && self.expires_at == other.expires_at
+            && self.guild_id == other.guild_id
+            && option_arc_rwlock_ptr_eq(&self.guild, &other.guild)
+            && self.channel_id == other.channel_id
+            && option_arc_rwlock_ptr_eq(&self.channel, &other.channel)
+            && self.inviter_id == other.inviter_id
+            && option_arc_rwlock_ptr_eq(&self.inviter, &other.inviter)
+            && self.target_user_id == other.target_user_id
+            && self.target_user == other.target_user
+            && self.target_user_type == other.target_user_type
+            && self.vanity_url == other.vanity_url
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Hash)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Hash, Eq, PartialOrd, Ord, Copy)]
 pub struct UnavailableGuild {
     pub id: Snowflake,
     pub unavailable: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 pub struct GuildCreateResponse {
     pub id: Snowflake,
 }
@@ -312,7 +272,29 @@ pub struct GuildScheduledEvent {
     pub image: Option<String>,
 }
 
-#[derive(Serialize_repr, Deserialize_repr, Debug, Default, Clone)]
+#[cfg(not(tarpaulin_include))]
+impl PartialEq for GuildScheduledEvent {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+            && self.guild_id == other.guild_id
+            && self.channel_id == other.channel_id
+            && self.creator_id == other.creator_id
+            && self.name == other.name
+            && self.description == other.description
+            && self.scheduled_start_time == other.scheduled_start_time
+            && self.scheduled_end_time == other.scheduled_end_time
+            && self.privacy_level == other.privacy_level
+            && self.status == other.status
+            && self.entity_type == other.entity_type
+            && self.entity_id == other.entity_id
+            && self.entity_metadata == other.entity_metadata
+            && option_arc_rwlock_ptr_eq(&self.creator, &other.creator)
+            && self.user_count == other.user_count
+            && self.image == other.image
+    }
+}
+
+#[derive(Serialize_repr, Deserialize_repr, Debug, Default, Clone, PartialEq, Copy)]
 #[repr(u8)]
 /// See <https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-privacy-level>
 pub enum GuildScheduledEventPrivacyLevel {
@@ -320,7 +302,7 @@ pub enum GuildScheduledEventPrivacyLevel {
     GuildOnly = 2,
 }
 
-#[derive(Serialize_repr, Deserialize_repr, Debug, Default, Clone)]
+#[derive(Serialize_repr, Deserialize_repr, Debug, Default, Clone, PartialEq, Copy)]
 #[repr(u8)]
 /// See <https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-status>
 pub enum GuildScheduledEventStatus {
@@ -331,7 +313,19 @@ pub enum GuildScheduledEventStatus {
     Canceled = 4,
 }
 
-#[derive(Serialize_repr, Deserialize_repr, Debug, Default, Clone)]
+#[derive(
+    Serialize_repr,
+    Deserialize_repr,
+    Debug,
+    Default,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Copy,
+    Hash,
+)]
 #[repr(u8)]
 /// See <https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-types>
 pub enum GuildScheduledEventEntityType {
@@ -341,7 +335,7 @@ pub enum GuildScheduledEventEntityType {
     External = 3,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// See <https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-metadata>
 pub struct GuildScheduledEventEntityMetadata {
     pub location: Option<String>,
@@ -356,7 +350,19 @@ pub struct VoiceRegion {
     custom: bool,
 }
 
-#[derive(Serialize_repr, Deserialize_repr, Debug, Default, Clone, Eq, PartialEq, Hash, Copy)]
+#[derive(
+    Serialize_repr,
+    Deserialize_repr,
+    Debug,
+    Default,
+    Clone,
+    Eq,
+    PartialEq,
+    Hash,
+    Copy,
+    PartialOrd,
+    Ord,
+)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[repr(u8)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -367,7 +373,19 @@ pub enum MessageNotificationLevel {
     OnlyMentions = 1,
 }
 
-#[derive(Serialize_repr, Deserialize_repr, Debug, Default, Clone, Eq, PartialEq, Hash, Copy)]
+#[derive(
+    Serialize_repr,
+    Deserialize_repr,
+    Debug,
+    Default,
+    Clone,
+    Eq,
+    PartialEq,
+    Hash,
+    Copy,
+    PartialOrd,
+    Ord,
+)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[repr(u8)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -379,7 +397,19 @@ pub enum ExplicitContentFilterLevel {
     AllMembers = 2,
 }
 
-#[derive(Serialize_repr, Deserialize_repr, Debug, Default, Clone, Eq, PartialEq, Hash, Copy)]
+#[derive(
+    Serialize_repr,
+    Deserialize_repr,
+    Debug,
+    Default,
+    Clone,
+    Eq,
+    PartialEq,
+    Hash,
+    Copy,
+    PartialOrd,
+    Ord,
+)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[repr(u8)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -393,7 +423,19 @@ pub enum VerificationLevel {
     VeryHigh = 4,
 }
 
-#[derive(Serialize_repr, Deserialize_repr, Debug, Default, Clone, Eq, PartialEq, Hash, Copy)]
+#[derive(
+    Serialize_repr,
+    Deserialize_repr,
+    Debug,
+    Default,
+    Clone,
+    Eq,
+    PartialEq,
+    Hash,
+    Copy,
+    PartialOrd,
+    Ord,
+)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[repr(u8)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -404,7 +446,19 @@ pub enum MFALevel {
     Elevated = 1,
 }
 
-#[derive(Serialize_repr, Deserialize_repr, Debug, Default, Clone, Eq, PartialEq, Hash, Copy)]
+#[derive(
+    Serialize_repr,
+    Deserialize_repr,
+    Debug,
+    Default,
+    Clone,
+    Eq,
+    PartialEq,
+    Hash,
+    Copy,
+    PartialOrd,
+    Ord,
+)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[repr(u8)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -417,7 +471,19 @@ pub enum NSFWLevel {
     AgeRestricted = 3,
 }
 
-#[derive(Serialize_repr, Deserialize_repr, Debug, Default, Clone, Eq, PartialEq, Hash, Copy)]
+#[derive(
+    Serialize_repr,
+    Deserialize_repr,
+    Debug,
+    Default,
+    Clone,
+    Eq,
+    PartialEq,
+    Hash,
+    Copy,
+    PartialOrd,
+    Ord,
+)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[repr(u8)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]

--- a/src/types/entities/guild_member.rs
+++ b/src/types/entities/guild_member.rs
@@ -5,8 +5,10 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::types::{GuildMemberFlags, PermissionFlags, Shared};
 use crate::types::{entities::PublicUser, Snowflake};
+use crate::types::{GuildMemberFlags, PermissionFlags, Shared};
+
+use super::option_arc_rwlock_ptr_eq;
 
 #[derive(Debug, Deserialize, Default, Serialize, Clone)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
@@ -30,4 +32,22 @@ pub struct GuildMember {
     #[serde(default)]
     pub permissions: PermissionFlags,
     pub communication_disabled_until: Option<DateTime<Utc>>,
+}
+
+#[cfg(not(tarpaulin_include))]
+impl PartialEq for GuildMember {
+    fn eq(&self, other: &Self) -> bool {
+        self.nick == other.nick
+            && self.avatar == other.avatar
+            && self.roles == other.roles
+            && self.joined_at == other.joined_at
+            && self.premium_since == other.premium_since
+            && self.deaf == other.deaf
+            && self.mute == other.mute
+            && self.flags == other.flags
+            && self.pending == other.pending
+            && self.permissions == other.permissions
+            && self.communication_disabled_until == other.communication_disabled_until
+            && option_arc_rwlock_ptr_eq(&self.user, &other.user)
+    }
 }

--- a/src/types/entities/integration.rs
+++ b/src/types/entities/integration.rs
@@ -6,9 +6,9 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::types::{
-    Shared,
     entities::{Application, User},
     utils::Snowflake,
+    Shared,
 };
 
 #[derive(Default, Debug, Deserialize, Serialize, Clone)]
@@ -44,7 +44,9 @@ pub struct IntegrationAccount {
     pub name: String,
 }
 
-#[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(
+    Debug, Default, Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord, Copy, Hash,
+)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[cfg_attr(feature = "sqlx", sqlx(rename_all = "snake_case"))]

--- a/src/types/entities/mod.rs
+++ b/src/types/entities/mod.rs
@@ -141,3 +141,42 @@ impl<T: Sized> IntoShared for T {
         Arc::new(RwLock::new(self))
     }
 }
+
+/// Internal function to compare two `Arc<RwLock<T>>`s by comparing their pointers.
+pub(crate) fn arc_rwlock_ptr_eq<T>(a: &Arc<RwLock<T>>, b: &Arc<RwLock<T>>) -> bool {
+    Arc::ptr_eq(a, b)
+}
+
+/// Internal function to compare two `Vec<Arc<RwLock<T>>>`s by comparing their pointers.
+pub(crate) fn vec_arc_rwlock_ptr_eq<T>(a: &Vec<Arc<RwLock<T>>>, b: &Vec<Arc<RwLock<T>>>) -> bool {
+    for (a, b) in a.iter().zip(b.iter()) {
+        if !arc_rwlock_ptr_eq(a, b) {
+            return false;
+        }
+    }
+    true
+}
+
+/// Internal function to compare two `Option<Arc<RwLock<T>>>`s by comparing their pointers.
+pub(crate) fn option_arc_rwlock_ptr_eq<T>(
+    a: &Option<Arc<RwLock<T>>>,
+    b: &Option<Arc<RwLock<T>>>,
+) -> bool {
+    match (a, b) {
+        (Some(a), Some(b)) => arc_rwlock_ptr_eq(a, b),
+        (None, None) => true,
+        _ => false,
+    }
+}
+
+/// Internal function to compare two `Option<Vec<Arc<RwLock<T>>>>`s by comparing their pointers.
+pub(crate) fn option_vec_arc_rwlock_ptr_eq<T>(
+    a: &Option<Vec<Arc<RwLock<T>>>>,
+    b: &Option<Vec<Arc<RwLock<T>>>>,
+) -> bool {
+    match (a, b) {
+        (Some(a), Some(b)) => vec_arc_rwlock_ptr_eq(a, b),
+        (None, None) => true,
+        _ => false,
+    }
+}

--- a/src/types/entities/mod.rs
+++ b/src/types/entities/mod.rs
@@ -142,13 +142,21 @@ impl<T: Sized> IntoShared for T {
     }
 }
 
-/// Internal function to compare two `Arc<RwLock<T>>`s by comparing their pointers.
-pub(crate) fn arc_rwlock_ptr_eq<T>(a: &Arc<RwLock<T>>, b: &Arc<RwLock<T>>) -> bool {
-    Arc::ptr_eq(a, b)
+/// Internal function to compare two `Shared<T>`s by comparing their pointers.
+#[cfg_attr(not(feature = "client"), allow(unused_variables))]
+pub(crate) fn arc_rwlock_ptr_eq<T>(a: &Shared<T>, b: &Shared<T>) -> bool {
+    #[cfg(feature = "client")]
+    {
+        Shared::ptr_eq(a, b)
+    }
+    #[cfg(not(feature = "client"))]
+    {
+        true
+    }
 }
 
-/// Internal function to compare two `Vec<Arc<RwLock<T>>>`s by comparing their pointers.
-pub(crate) fn vec_arc_rwlock_ptr_eq<T>(a: &Vec<Arc<RwLock<T>>>, b: &Vec<Arc<RwLock<T>>>) -> bool {
+/// Internal function to compare two `Vec<Shared<T>>`s by comparing their pointers.
+pub(crate) fn vec_arc_rwlock_ptr_eq<T>(a: &[Shared<T>], b: &[Shared<T>]) -> bool {
     for (a, b) in a.iter().zip(b.iter()) {
         if !arc_rwlock_ptr_eq(a, b) {
             return false;
@@ -157,11 +165,8 @@ pub(crate) fn vec_arc_rwlock_ptr_eq<T>(a: &Vec<Arc<RwLock<T>>>, b: &Vec<Arc<RwLo
     true
 }
 
-/// Internal function to compare two `Option<Arc<RwLock<T>>>`s by comparing their pointers.
-pub(crate) fn option_arc_rwlock_ptr_eq<T>(
-    a: &Option<Arc<RwLock<T>>>,
-    b: &Option<Arc<RwLock<T>>>,
-) -> bool {
+/// Internal function to compare two `Option<Shared<T>>`s by comparing their pointers.
+pub(crate) fn option_arc_rwlock_ptr_eq<T>(a: &Option<Shared<T>>, b: &Option<Shared<T>>) -> bool {
     match (a, b) {
         (Some(a), Some(b)) => arc_rwlock_ptr_eq(a, b),
         (None, None) => true,
@@ -169,10 +174,10 @@ pub(crate) fn option_arc_rwlock_ptr_eq<T>(
     }
 }
 
-/// Internal function to compare two `Option<Vec<Arc<RwLock<T>>>>`s by comparing their pointers.
+/// Internal function to compare two `Option<Vec<Shared<T>>>`s by comparing their pointers.
 pub(crate) fn option_vec_arc_rwlock_ptr_eq<T>(
-    a: &Option<Vec<Arc<RwLock<T>>>>,
-    b: &Option<Vec<Arc<RwLock<T>>>>,
+    a: &Option<Vec<Shared<T>>>,
+    b: &Option<Vec<Shared<T>>>,
 ) -> bool {
     match (a, b) {
         (Some(a), Some(b)) => vec_arc_rwlock_ptr_eq(a, b),

--- a/src/types/entities/ratelimits.rs
+++ b/src/types/entities/ratelimits.rs
@@ -11,7 +11,9 @@ use crate::types::Snowflake;
 /// The different types of ratelimits that can be applied to a request. Includes "Baseline"-variants
 /// for when the Snowflake is not yet known.
 /// See <https://discord.com/developers/docs/topics/rate-limits#rate-limits> for more information.
-#[derive(Clone, Copy, Eq, PartialEq, Debug, Default, Hash, Serialize, Deserialize)]
+#[derive(
+    Clone, Copy, Eq, PartialEq, Debug, Default, Hash, Serialize, Deserialize, PartialOrd, Ord,
+)]
 pub enum LimitType {
     AuthRegister,
     AuthLogin,
@@ -29,7 +31,7 @@ pub enum LimitType {
 
 /// A struct that represents the current ratelimits, either instance-wide or user-wide.
 /// See <https://discord.com/developers/docs/topics/rate-limits#rate-limits> for more information.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Copy, PartialOrd, Ord)]
 pub struct Limit {
     pub bucket: LimitType,
     pub limit: u64,

--- a/src/types/entities/relationship.rs
+++ b/src/types/entities/relationship.rs
@@ -8,7 +8,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::types::{Shared, Snowflake};
 
-use super::PublicUser;
+use super::{arc_rwlock_ptr_eq, PublicUser};
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 /// See <https://discord-userdoccers.vercel.app/resources/user#relationship-structure>
@@ -21,16 +21,30 @@ pub struct Relationship {
     pub since: Option<DateTime<Utc>>,
 }
 
+#[cfg(not(tarpaulin_include))]
 impl PartialEq for Relationship {
     fn eq(&self, other: &Self) -> bool {
         self.id == other.id
             && self.relationship_type == other.relationship_type
-            && self.since == other.since
             && self.nickname == other.nickname
+            && arc_rwlock_ptr_eq(&self.user, &other.user)
+            && self.since == other.since
     }
 }
 
-#[derive(Serialize_repr, Deserialize_repr, Debug, Clone, Default, Eq, PartialEq)]
+#[derive(
+    Serialize_repr,
+    Deserialize_repr,
+    Debug,
+    Clone,
+    Default,
+    Eq,
+    PartialEq,
+    PartialOrd,
+    Ord,
+    Copy,
+    Hash,
+)]
 #[repr(u8)]
 /// See <https://discord-userdoccers.vercel.app/resources/user#relationship-type>
 pub enum RelationshipType {

--- a/src/types/entities/role.rs
+++ b/src/types/entities/role.rs
@@ -51,7 +51,7 @@ pub struct RoleSubscriptionData {
     pub is_renewal: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq, Hash, Copy, PartialOrd, Ord)]
 /// See <https://discord.com/developers/docs/topics/permissions#role-object-role-tags-structure>
 pub struct RoleTags {
     #[serde(default)]

--- a/src/types/entities/stage_instance.rs
+++ b/src/types/entities/stage_instance.rs
@@ -21,7 +21,7 @@ pub struct StageInstance {
     pub guild_scheduled_event_id: Option<Snowflake>,
 }
 
-#[derive(Serialize_repr, Deserialize_repr, Debug, Clone, Default)]
+#[derive(Serialize_repr, Deserialize_repr, Debug, Clone, Default, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(u8)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// See <https://discord.com/developers/docs/resources/stage-instance#stage-instance-object-privacy-level>

--- a/src/types/entities/team.rs
+++ b/src/types/entities/team.rs
@@ -5,8 +5,10 @@
 use serde::{Deserialize, Serialize};
 
 use crate::types::entities::User;
-use crate::types::Snowflake;
 use crate::types::Shared;
+use crate::types::Snowflake;
+
+use super::arc_rwlock_ptr_eq;
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
@@ -19,10 +21,31 @@ pub struct Team {
     pub owner_user_id: Snowflake,
 }
 
+#[cfg(not(tarpaulin_include))]
+impl PartialEq for Team {
+    fn eq(&self, other: &Self) -> bool {
+        self.icon == other.icon
+            && self.id == other.id
+            && self.members == other.members
+            && self.name == other.name
+            && self.owner_user_id == other.owner_user_id
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct TeamMember {
     pub membership_state: u8,
     pub permissions: Vec<String>,
     pub team_id: Snowflake,
     pub user: Shared<User>,
+}
+
+#[cfg(not(tarpaulin_include))]
+impl PartialEq for TeamMember {
+    fn eq(&self, other: &Self) -> bool {
+        self.membership_state == other.membership_state
+            && self.permissions == other.permissions
+            && self.team_id == other.team_id
+            && arc_rwlock_ptr_eq(&self.user, &other.user)
+    }
 }

--- a/src/types/entities/user_settings.rs
+++ b/src/types/entities/user_settings.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::types::Shared;
 use serde_aux::field_attributes::deserialize_option_number_from_string;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default, Copy, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[serde(rename_all = "lowercase")]
 pub enum UserStatus {
@@ -26,7 +26,7 @@ impl std::fmt::Display for UserStatus {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default, Copy, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[serde(rename_all = "lowercase")]
 pub enum UserTheme {
@@ -136,7 +136,7 @@ pub struct CustomStatus {
     pub text: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, PartialOrd, Ord, Hash)]
 pub struct FriendSourceFlags {
     pub all: bool,
 }

--- a/src/types/entities/voice_state.rs
+++ b/src/types/entities/voice_state.rs
@@ -25,6 +25,8 @@ use crate::types::{
     utils::Snowflake,
 };
 
+use super::option_arc_rwlock_ptr_eq;
+
 /// The VoiceState struct. Note, that Discord does not have an `id` field for this, whereas Spacebar
 /// does.
 ///
@@ -52,6 +54,28 @@ pub struct VoiceState {
     pub suppress: bool,
     pub request_to_speak_timestamp: Option<DateTime<Utc>>,
     pub id: Option<Snowflake>, // Only exists on Spacebar
+}
+
+#[cfg(not(tarpaulin_include))]
+impl PartialEq for VoiceState {
+    fn eq(&self, other: &Self) -> bool {
+        self.guild_id == other.guild_id
+            && self.guild == other.guild
+            && self.channel_id == other.channel_id
+            && self.user_id == other.user_id
+            && option_arc_rwlock_ptr_eq(&self.member, &other.member)
+            && self.session_id == other.session_id
+            && self.token == other.token
+            && self.deaf == other.deaf
+            && self.mute == other.mute
+            && self.self_deaf == other.self_deaf
+            && self.self_mute == other.self_mute
+            && self.self_stream == other.self_stream
+            && self.self_video == other.self_video
+            && self.suppress == other.suppress
+            && self.request_to_speak_timestamp == other.request_to_speak_timestamp
+            && self.id == other.id
+    }
 }
 
 #[cfg(feature = "client")]

--- a/src/types/entities/webhook.rs
+++ b/src/types/entities/webhook.rs
@@ -25,6 +25,8 @@ use crate::types::{
     utils::Snowflake,
 };
 
+use super::option_arc_rwlock_ptr_eq;
+
 /// See <https://docs.spacebar.chat/routes/#cmp--schemas-webhook>
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[cfg_attr(feature = "client", derive(Updateable, Composite))]
@@ -36,7 +38,7 @@ pub struct Webhook {
     pub name: String,
     pub avatar: String,
     pub token: String,
-    pub guild_id: Snowflake, 
+    pub guild_id: Snowflake,
     pub channel_id: Snowflake,
     pub application_id: Option<Snowflake>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -49,7 +51,26 @@ pub struct Webhook {
     pub url: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default, Clone, Copy)]
+#[cfg(not(tarpaulin_include))]
+impl PartialEq for Webhook {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+            && self.webhook_type == other.webhook_type
+            && self.name == other.name
+            && self.avatar == other.avatar
+            && self.token == other.token
+            && self.guild_id == other.guild_id
+            && self.channel_id == other.channel_id
+            && self.application_id == other.application_id
+            && option_arc_rwlock_ptr_eq(&self.user, &other.user)
+            && option_arc_rwlock_ptr_eq(&self.source_guild, &other.source_guild)
+            && self.url == other.url
+    }
+}
+
+#[derive(
+    Serialize, Deserialize, Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 #[repr(u8)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 pub enum WebhookType {

--- a/src/types/errors.rs
+++ b/src/types/errors.rs
@@ -21,18 +21,18 @@ pub enum Error {
 
     #[error(transparent)]
     Guild(#[from] GuildError),
-    
+
     #[error("Invalid flags value: {0}")]
-    InvalidFlags(u64)
+    InvalidFlags(u64),
 }
 
-#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, PartialEq, Eq, thiserror::Error, Copy, Clone)]
 pub enum GuildError {
     #[error("Invalid Guild Feature")]
     InvalidGuildFeature,
 }
 
-#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, PartialEq, Eq, thiserror::Error, Copy, Clone)]
 pub enum FieldFormatError {
     #[error("Password must be between 1 and 72 characters.")]
     PasswordError,

--- a/src/types/events/call.rs
+++ b/src/types/events/call.rs
@@ -39,7 +39,19 @@ pub struct CallUpdate {
     pub channel_id: Snowflake,
 }
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq, Eq, WebSocketEvent)]
+#[derive(
+    Debug,
+    Deserialize,
+    Serialize,
+    Default,
+    Clone,
+    PartialEq,
+    Eq,
+    WebSocketEvent,
+    Copy,
+    PartialOrd,
+    Ord,
+)]
 /// Officially Undocumented;
 /// Deletes a ringing call;
 /// Ex: {"t":"CALL_DELETE","s":8,"op":0,"d":{"channel_id":"837609115475771392"}}
@@ -47,7 +59,19 @@ pub struct CallDelete {
     pub channel_id: Snowflake,
 }
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq, Eq, WebSocketEvent)]
+#[derive(
+    Debug,
+    Deserialize,
+    Serialize,
+    Default,
+    Clone,
+    PartialEq,
+    Eq,
+    WebSocketEvent,
+    Copy,
+    PartialOrd,
+    Ord,
+)]
 /// Officially Undocumented;
 /// See <https://unofficial-discord-docs.vercel.app/gateway/op13>;
 ///
@@ -55,4 +79,3 @@ pub struct CallDelete {
 pub struct CallSync {
     pub channel_id: Snowflake,
 }
-

--- a/src/types/events/channel.rs
+++ b/src/types/events/channel.rs
@@ -20,7 +20,7 @@ use crate::types::IntoShared;
 #[cfg(feature = "client")]
 use crate::types::Guild;
 
-#[derive(Debug, Default, Deserialize, Serialize, WebSocketEvent)]
+#[derive(Debug, Default, Deserialize, Serialize, WebSocketEvent, Copy, PartialEq, Clone, Eq, Hash, PartialOrd, Ord)]
 /// See <https://discord.com/developers/docs/topics/gateway-events#channel-pins-update>
 pub struct ChannelPinsUpdate {
     pub guild_id: Option<Snowflake>,
@@ -86,7 +86,7 @@ pub struct ChannelUnreadUpdate {
     pub guild_id: Snowflake,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 /// Contains very few fields from [Channel]
 /// See also [ChannelUnreadUpdate]
 pub struct ChannelUnreadUpdateObject {

--- a/src/types/events/guild.rs
+++ b/src/types/events/guild.rs
@@ -9,8 +9,8 @@ use serde::{Deserialize, Serialize};
 use crate::types::entities::{Guild, PublicUser, UnavailableGuild};
 use crate::types::events::WebSocketEvent;
 use crate::types::{
-    AuditLogEntry, Emoji, GuildMember, GuildScheduledEvent, JsonField, RoleObject,
-    Snowflake, SourceUrlField, Sticker,
+    AuditLogEntry, Emoji, GuildMember, GuildScheduledEvent, JsonField, RoleObject, Snowflake,
+    SourceUrlField, Sticker,
 };
 
 use super::PresenceUpdate;
@@ -18,11 +18,21 @@ use super::PresenceUpdate;
 #[cfg(feature = "client")]
 use super::UpdateMessage;
 #[cfg(feature = "client")]
-use crate::types::Shared;
-#[cfg(feature = "client")]
 use crate::types::IntoShared;
+#[cfg(feature = "client")]
+use crate::types::Shared;
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone, SourceUrlField, JsonField, WebSocketEvent)]
+#[derive(
+    Debug,
+    Deserialize,
+    Serialize,
+    Default,
+    Clone,
+    SourceUrlField,
+    JsonField,
+    WebSocketEvent,
+    PartialEq,
+)]
 /// See <https://discord.com/developers/docs/topics/gateway-events#guild-create>;
 /// Received to give data about a guild;
 // This one is particularly painful, it can be a Guild object with an extra field or an unavailable guild object
@@ -49,7 +59,7 @@ impl UpdateMessage<Guild> for GuildCreate {
     fn update(&mut self, _: Shared<Guild>) {}
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum GuildCreateDataOption {
     UnavailableGuild(UnavailableGuild),
@@ -62,7 +72,31 @@ impl Default for GuildCreateDataOption {
     }
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent)]
+#[derive(Debug, Clone, PartialEq)]
+pub enum GuildEvents {
+    Create(GuildCreate),
+    Update(GuildUpdate),
+    Delete(GuildDelete),
+    BanAdd(GuildBanAdd),
+    BanRemove(GuildBanRemove),
+    EmojisUpdate(GuildEmojisUpdate),
+    StickersUpdate(GuildStickersUpdate),
+    IntegrationsUpdate(GuildIntegrationsUpdate),
+    MemberAdd(GuildMemberAdd),
+    MemberRemove(GuildMemberRemove),
+    MemberUpdate(GuildMemberUpdate),
+    MembersChunk(GuildMembersChunk),
+    RoleCreate(GuildRoleCreate),
+    RoleUpdate(GuildRoleUpdate),
+    RoleDelete(GuildRoleDelete),
+    ScheduledEventCreate(GuildScheduledEventCreate),
+    ScheduledEventUpdate(GuildScheduledEventUpdate),
+    ScheduledEventDelete(GuildScheduledEventDelete),
+    ScheduledEventUserAdd(GuildScheduledEventUserAdd),
+    ScheduledEventUserRemove(GuildScheduledEventUserRemove),
+    AuditLogEntryCreate(GuildAuditLogEntryCreate),
+}
+#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent, PartialEq)]
 /// See <https://discord.com/developers/docs/topics/gateway-events#guild-ban-add-guild-ban-add-event-fields>;
 /// Received to give info about a user being banned from a guild;
 pub struct GuildBanAdd {
@@ -70,7 +104,7 @@ pub struct GuildBanAdd {
     pub user: PublicUser,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent, PartialEq)]
 /// See <https://discord.com/developers/docs/topics/gateway-events#guild-ban-remove>;
 /// Received to give info about a user being unbanned from a guild;
 pub struct GuildBanRemove {
@@ -78,7 +112,17 @@ pub struct GuildBanRemove {
     pub user: PublicUser,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone, SourceUrlField, JsonField, WebSocketEvent)]
+#[derive(
+    Debug,
+    Default,
+    Deserialize,
+    Serialize,
+    Clone,
+    SourceUrlField,
+    JsonField,
+    WebSocketEvent,
+    PartialEq,
+)]
 /// See <https://discord.com/developers/docs/topics/gateway-events#guild-update>;
 /// Received to give info about a guild being updated;
 pub struct GuildUpdate {
@@ -98,7 +142,17 @@ impl UpdateMessage<Guild> for GuildUpdate {
     }
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone, SourceUrlField, JsonField, WebSocketEvent)]
+#[derive(
+    Debug,
+    Default,
+    Deserialize,
+    Serialize,
+    Clone,
+    SourceUrlField,
+    JsonField,
+    WebSocketEvent,
+    PartialEq,
+)]
 /// See <https://discord.com/developers/docs/topics/gateway-events#guild-delete>;
 /// Received to tell the client about a guild being deleted;
 pub struct GuildDelete {
@@ -119,7 +173,7 @@ impl UpdateMessage<Guild> for GuildDelete {
     fn update(&mut self, _: Shared<Guild>) {}
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent, PartialEq)]
 /// See <https://discord.com/developers/docs/topics/gateway-events#guild-audit-log-entry-create>;
 /// Received to the client about an audit log entry being added;
 pub struct GuildAuditLogEntryCreate {
@@ -127,7 +181,7 @@ pub struct GuildAuditLogEntryCreate {
     pub entry: AuditLogEntry,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent, PartialEq)]
 /// See <https://discord.com/developers/docs/topics/gateway-events#guild-emojis-update>;
 /// Received to tell the client about a change to a guild's emoji list;
 pub struct GuildEmojisUpdate {
@@ -135,7 +189,7 @@ pub struct GuildEmojisUpdate {
     pub emojis: Vec<Emoji>,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent, PartialEq)]
 /// See <https://discord.com/developers/docs/topics/gateway-events#guild-stickers-update>;
 /// Received to tell the client about a change to a guild's sticker list;
 pub struct GuildStickersUpdate {
@@ -143,13 +197,13 @@ pub struct GuildStickersUpdate {
     pub stickers: Vec<Sticker>,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent, PartialEq, Copy, Eq, Hash, PartialOrd, Ord)]
 /// See <https://discord.com/developers/docs/topics/gateway-events#guild-integrations-update>
 pub struct GuildIntegrationsUpdate {
     pub guild_id: Snowflake,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent, PartialEq)]
 /// See <https://discord.com/developers/docs/topics/gateway-events#guild-member-add>;
 /// Received to tell the client about a user joining a guild;
 pub struct GuildMemberAdd {
@@ -158,7 +212,7 @@ pub struct GuildMemberAdd {
     pub guild_id: Snowflake,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent, PartialEq)]
 /// See <https://discord.com/developers/docs/topics/gateway-events#guild-member-remove>;
 /// Received to tell the client about a user leaving a guild;
 pub struct GuildMemberRemove {
@@ -166,7 +220,7 @@ pub struct GuildMemberRemove {
     pub user: PublicUser,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent, PartialEq)]
 /// See <https://discord.com/developers/docs/topics/gateway-events#guild-member-update>
 pub struct GuildMemberUpdate {
     pub guild_id: Snowflake,
@@ -182,7 +236,7 @@ pub struct GuildMemberUpdate {
     pub communication_disabled_until: Option<DateTime<Utc>>,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent, PartialEq)]
 /// See <https://discord.com/developers/docs/topics/gateway-events#guild-members-chunk>
 pub struct GuildMembersChunk {
     pub guild_id: Snowflake,
@@ -194,7 +248,17 @@ pub struct GuildMembersChunk {
     pub nonce: Option<String>,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone, JsonField, SourceUrlField, WebSocketEvent)]
+#[derive(
+    Debug,
+    Default,
+    Deserialize,
+    Serialize,
+    Clone,
+    JsonField,
+    SourceUrlField,
+    WebSocketEvent,
+    PartialEq,
+)]
 /// See <https://discord.com/developers/docs/topics/gateway-events#guild-role-create>
 pub struct GuildRoleCreate {
     pub guild_id: Snowflake,
@@ -214,13 +278,21 @@ impl UpdateMessage<Guild> for GuildRoleCreate {
 
     fn update(&mut self, object_to_update: Shared<Guild>) {
         let mut object_to_update = object_to_update.write().unwrap();
-        object_to_update
-            .roles
-            .push(self.role.clone().into_shared());
+        object_to_update.roles.push(self.role.clone().into_shared());
     }
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone, JsonField, SourceUrlField, WebSocketEvent)]
+#[derive(
+    Debug,
+    Default,
+    Deserialize,
+    Serialize,
+    Clone,
+    JsonField,
+    SourceUrlField,
+    WebSocketEvent,
+    PartialEq,
+)]
 /// See <https://discord.com/developers/docs/topics/gateway-events#guild-role-update>
 pub struct GuildRoleUpdate {
     pub guild_id: Snowflake,
@@ -244,35 +316,35 @@ impl UpdateMessage<RoleObject> for GuildRoleUpdate {
     }
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 /// See <https://discord.com/developers/docs/topics/gateway-events#guild-role-delete>
 pub struct GuildRoleDelete {
     pub guild_id: Snowflake,
     pub role_id: Snowflake,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent, PartialEq)]
 /// See <https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-create>
 pub struct GuildScheduledEventCreate {
     #[serde(flatten)]
     pub event: GuildScheduledEvent,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent, PartialEq)]
 /// See <https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-update>
 pub struct GuildScheduledEventUpdate {
     #[serde(flatten)]
     pub event: GuildScheduledEvent,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent, PartialEq)]
 /// See <https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-delete>
 pub struct GuildScheduledEventDelete {
     #[serde(flatten)]
     pub event: GuildScheduledEvent,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent, PartialEq, Copy, Eq, Hash, PartialOrd, Ord)]
 /// See <https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-user-add>
 pub struct GuildScheduledEventUserAdd {
     pub guild_scheduled_event_id: Snowflake,
@@ -280,7 +352,7 @@ pub struct GuildScheduledEventUserAdd {
     pub guild_id: Snowflake,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent, PartialEq, Copy, Eq, Hash, PartialOrd, Ord)]
 /// See <https://discord.com/developers/docs/topics/gateway-events#guild-scheduled-event-user-remove>
 pub struct GuildScheduledEventUserRemove {
     pub guild_scheduled_event_id: Snowflake,

--- a/src/types/events/heartbeat.rs
+++ b/src/types/events/heartbeat.rs
@@ -5,13 +5,13 @@
 use crate::types::events::WebSocketEvent;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Default, Deserialize, Serialize, WebSocketEvent)]
+#[derive(Debug, Default, Deserialize, Serialize, WebSocketEvent, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct GatewayHeartbeat {
     pub op: u8,
     pub d: Option<u64>,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct GatewayHeartbeatAck {
     pub op: i32,
 }

--- a/src/types/events/hello.rs
+++ b/src/types/events/hello.rs
@@ -7,13 +7,13 @@ use chorus_macros::WebSocketEvent;
 use serde::{Deserialize, Serialize};
 
 /// Received on gateway init, tells the client how often to send heartbeats;
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq, WebSocketEvent)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq, WebSocketEvent, Copy, Hash, PartialOrd, Ord)]
 pub struct GatewayHello {
     pub op: i32,
     pub d: HelloData,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq, Copy, WebSocketEvent)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq, Copy, WebSocketEvent, Hash, PartialOrd, Ord)]
 /// Contains info on how often the client should send heartbeats to the server;
 pub struct HelloData {
     /// How often a client should send heartbeats, in milliseconds

--- a/src/types/events/integration.rs
+++ b/src/types/events/integration.rs
@@ -23,7 +23,7 @@ pub struct IntegrationUpdate {
     pub guild_id: Snowflake,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone, WebSocketEvent, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 /// See <https://discord.com/developers/docs/topics/gateway-events#integration-delete>
 pub struct IntegrationDelete {
     pub id: Snowflake,

--- a/src/types/events/invalid_session.rs
+++ b/src/types/events/invalid_session.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use super::WebSocketEvent;
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone, WebSocketEvent)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone, WebSocketEvent, PartialEq, Eq, Hash, PartialOrd, Ord, Copy)]
 /// Your session is now invalid.
 ///
 /// Either reauthenticate and reidentify or resume if possible.

--- a/src/types/events/message.rs
+++ b/src/types/events/message.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::{
     entities::{Emoji, GuildMember, Message, PublicUser},
-    Snowflake, WebSocketEvent
+    Snowflake, WebSocketEvent,
 };
 
 use chorus_macros::WebSocketEvent;
@@ -51,7 +51,20 @@ pub struct MessageUpdate {
     pub mentions: Option<Vec<MessageCreateUser>>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default, Clone, WebSocketEvent)]
+#[derive(
+    Debug,
+    Serialize,
+    Deserialize,
+    Default,
+    Clone,
+    WebSocketEvent,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+)]
 /// # Reference
 /// See <https://discord.com/developers/docs/topics/gateway-events#message-delete>
 pub struct MessageDelete {
@@ -60,7 +73,19 @@ pub struct MessageDelete {
     pub guild_id: Option<Snowflake>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default, Clone, WebSocketEvent)]
+#[derive(
+    Debug,
+    Serialize,
+    Deserialize,
+    Default,
+    Clone,
+    WebSocketEvent,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+)]
 /// # Reference
 /// See <https://discord.com/developers/docs/topics/gateway-events#message-delete-bulk>
 pub struct MessageDeleteBulk {
@@ -92,7 +117,20 @@ pub struct MessageReactionRemove {
     pub emoji: Emoji,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default, Clone, WebSocketEvent)]
+#[derive(
+    Debug,
+    Serialize,
+    Deserialize,
+    Default,
+    Clone,
+    WebSocketEvent,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+)]
 /// # Reference
 /// See <https://discord.com/developers/docs/topics/gateway-events#message-reaction-remove-all>
 pub struct MessageReactionRemoveAll {
@@ -131,4 +169,3 @@ pub struct MessageACK {
     pub flags: Option<serde_json::Value>,
     pub channel_id: Snowflake,
 }
-

--- a/src/types/events/reconnect.rs
+++ b/src/types/events/reconnect.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use super::WebSocketEvent;
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone, WebSocketEvent)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone, WebSocketEvent, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 /// "The reconnect event is dispatched when a client should reconnect to the Gateway (and resume their existing session, if they have one). This event usually occurs during deploys to migrate sessions gracefully off old hosts"
 ///
 /// # Reference

--- a/src/types/events/relationship.rs
+++ b/src/types/events/relationship.rs
@@ -13,7 +13,7 @@ pub struct RelationshipAdd {
     pub should_notify: bool,
 }
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone, WebSocketEvent)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone, WebSocketEvent, PartialEq, Eq, Hash, PartialOrd, Ord, Copy)]
 /// See <https://github.com/spacebarchat/server/issues/203>
 pub struct RelationshipRemove {
     pub id: Snowflake,

--- a/src/types/events/voice_gateway/speaking.rs
+++ b/src/types/events/voice_gateway/speaking.rs
@@ -13,7 +13,7 @@ use chorus_macros::WebSocketEvent;
 /// Essentially, what allows us to send UDP data and lights up the green circle around your avatar.
 ///
 /// See <https://discord-userdoccers.vercel.app/topics/voice-connections#speaking-structure>
-#[derive(Debug, Deserialize, Serialize, Clone, Default, WebSocketEvent)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, WebSocketEvent, PartialEq, Eq, Hash, PartialOrd, Ord, Copy)]
 pub struct Speaking {
     /// Data about the audio we're transmitting.
     ///

--- a/src/types/events/webhooks.rs
+++ b/src/types/events/webhooks.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::types::{Snowflake, WebSocketEvent};
 use chorus_macros::WebSocketEvent;
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone, WebSocketEvent)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone, WebSocketEvent, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 /// See <https://discord.com/developers/docs/topics/gateway-events#webhooks-update>
 pub struct WebhooksUpdate {
     pub guild_id: Snowflake,

--- a/src/types/interfaces/interaction.rs
+++ b/src/types/interfaces/interaction.rs
@@ -20,7 +20,7 @@ pub struct Interaction {
     pub version: i32,
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize, Eq, PartialOrd, Ord, Hash, Copy)]
 pub enum InteractionType {
     #[default]
     SelfCommand = 0,
@@ -28,7 +28,7 @@ pub enum InteractionType {
     ApplicationCommand = 2,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Copy, Eq, Hash, PartialOrd, Ord)]
 pub enum InteractionResponseType {
     SelfCommandResponse = 0,
     Pong = 1,
@@ -38,7 +38,7 @@ pub enum InteractionResponseType {
     AcknowledgeWithSource = 5,
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize, Eq, Hash, PartialOrd, Ord)]
 pub struct InteractionApplicationCommandCallbackData {
     pub tts: bool,
     pub content: String,

--- a/src/types/schema/apierror.rs
+++ b/src/types/schema/apierror.rs
@@ -6,7 +6,7 @@
 use poem::{http::StatusCode, IntoResponse, Response};
 use serde_json::{json, Value};
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum APIError {
     #[error(transparent)]
     Auth(#[from] AuthError),
@@ -20,7 +20,7 @@ impl APIError {
     }
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum AuthError {
     #[error("INVALID_LOGIN")]
     InvalidLogin,

--- a/src/types/schema/audit_log.rs
+++ b/src/types/schema/audit_log.rs
@@ -1,5 +1,8 @@
+use crate::types::{
+    ApplicationCommand, AuditLogActionType, AuditLogEntry, AutoModerationRule, Channel,
+    GuildScheduledEvent, Integration, Snowflake, User, Webhook,
+};
 use serde::{Deserialize, Serialize};
-use crate::types::{ApplicationCommand, AuditLogActionType, AuditLogEntry, AutoModerationRule, Channel, GuildScheduledEvent, Integration, Snowflake, User, Webhook};
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct AuditLogObject {
@@ -13,11 +16,13 @@ pub struct AuditLogObject {
     pub webhooks: Vec<Webhook>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(
+    Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Default,
+)]
 pub struct GetAuditLogsQuery {
     pub before: Option<Snowflake>,
     pub after: Option<Snowflake>,
     pub limit: Option<u8>,
     pub user_id: Option<Snowflake>,
-    pub action_type: Option<AuditLogActionType>
+    pub action_type: Option<AuditLogActionType>,
 }

--- a/src/types/schema/channel.rs
+++ b/src/types/schema/channel.rs
@@ -169,7 +169,7 @@ pub struct AddChannelRecipientSchema {
 }
 
 /// See <https://discord-userdoccers.vercel.app/resources/channel#add-channel-recipient>
-#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialOrd, Ord, PartialEq, Eq, Copy, Hash)]
 pub struct ModifyChannelPositionsSchema {
     pub id: Snowflake,
     pub position: Option<u32>,
@@ -178,7 +178,7 @@ pub struct ModifyChannelPositionsSchema {
 }
 
 /// See <https://docs.discord.sex/resources/channel#follow-channel>
-#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialOrd, Ord, PartialEq, Eq, Copy, Hash)]
 pub struct AddFollowingChannelSchema {
     pub webhook_channel_id: Snowflake,
 }

--- a/src/types/schema/message.rs
+++ b/src/types/schema/message.rs
@@ -7,7 +7,9 @@ use serde::{Deserialize, Serialize};
 use crate::types::entities::{
     AllowedMention, Component, Embed, MessageReference, PartialDiscordFileAttachment,
 };
-use crate::types::{Attachment, EmbedType, Message, MessageFlags, MessageType, ReactionType, Snowflake};
+use crate::types::{
+    Attachment, EmbedType, Message, MessageFlags, MessageType, ReactionType, Snowflake,
+};
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
@@ -25,7 +27,7 @@ pub struct MessageSendSchema {
     pub attachments: Option<Vec<PartialDiscordFileAttachment>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum MessageSearchEndpoint {
     GuildChannel(Snowflake),
     Channel(Snowflake),
@@ -102,7 +104,7 @@ impl std::default::Default for MessageSearchQuery {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, PartialOrd, Ord, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum AuthorType {
     User,
@@ -116,7 +118,7 @@ pub enum AuthorType {
     NotWebhook,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, PartialOrd, Ord, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum HasType {
     Image,
@@ -148,15 +150,19 @@ pub enum HasType {
     NotSnapshot,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq, PartialOrd, Ord, Copy, Hash,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum SortType {
     #[default]
     Timestamp,
-    Relevance
+    Relevance,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq, PartialOrd, Ord, Copy, Hash,
+)]
 pub enum SortOrder {
     #[default]
     #[serde(rename = "desc")]
@@ -198,10 +204,10 @@ pub struct MessageModifySchema {
     pub attachments: Option<Vec<Attachment>>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, PartialOrd)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, PartialOrd, Copy, Eq, Hash, Ord)]
 pub struct ReactionQuerySchema {
     pub after: Option<Snowflake>,
     pub limit: Option<u32>,
     #[serde(rename = "type")]
-    pub reaction_type: Option<ReactionType>
+    pub reaction_type: Option<ReactionType>,
 }

--- a/src/types/schema/role.rs
+++ b/src/types/schema/role.rs
@@ -2,10 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use serde::{Deserialize, Serialize};
 use crate::types::{PermissionFlags, Snowflake};
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 /// Represents the schema which needs to be sent to create or modify a Role.
 /// See: [https://docs.spacebar.chat/routes/#cmp--schemas-rolemodifyschema](https://docs.spacebar.chat/routes/#cmp--schemas-rolemodifyschema)
@@ -20,7 +20,7 @@ pub struct RoleCreateModifySchema {
     pub position: Option<i32>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[serde(rename_all = "snake_case")]
 /// Represents the schema which needs to be sent to update a roles' position.
 /// See: [https://docs.spacebar.chat/routes/#cmp--schemas-rolepositionupdateschema](https://docs.spacebar.chat/routes/#cmp--schemas-rolepositionupdateschema)

--- a/src/types/schema/voice_state.rs
+++ b/src/types/schema/voice_state.rs
@@ -1,8 +1,8 @@
+use crate::types::Snowflake;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use crate::types::Snowflake;
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, PartialOrd)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, PartialOrd, Copy)]
 /// # Reference:
 /// See <https://docs.discord.sex/resources/voice#json-params>
 pub struct VoiceStateUpdateSchema {

--- a/src/voice/udp/backends/tokio.rs
+++ b/src/voice/udp/backends/tokio.rs
@@ -6,7 +6,7 @@ use std::net::SocketAddr;
 
 use crate::errors::VoiceUdpError;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct TokioBackend;
 
 pub type TokioSocket = tokio::net::UdpSocket;

--- a/tests/channels.rs
+++ b/tests/channels.rs
@@ -168,8 +168,7 @@ async fn create_dm() {
         dm_channel
             .recipients
             .as_ref()
-            .unwrap()
-            .get(0)
+            .unwrap().first()
             .unwrap()
             .read()
             .unwrap()
@@ -242,8 +241,7 @@ async fn remove_add_person_from_to_dm() {
         dm_channel
             .recipients
             .as_ref()
-            .unwrap()
-            .get(0)
+            .unwrap().first()
             .unwrap()
             .read()
             .unwrap()

--- a/tests/gateway.rs
+++ b/tests/gateway.rs
@@ -206,7 +206,7 @@ async fn test_recursive_self_updating_structs() {
     let guild = bundle.user.gateway.observe(bundle.guild.clone()).await;
     let inner_guild = guild.read().unwrap().clone();
     let guild_roles = inner_guild.roles;
-    let guild_role_inner = guild_roles.get(0).unwrap().read().unwrap().clone();
+    let guild_role_inner = guild_roles.first().unwrap().read().unwrap().clone();
     assert_eq!(guild_role_inner.name, "yippieee".to_string());
     common::teardown(bundle).await;
 }

--- a/tests/messages.rs
+++ b/tests/messages.rs
@@ -114,7 +114,7 @@ async fn search_messages() {
         .await
         .unwrap();
     assert!(!query_result.is_empty());
-    assert_eq!(query_result.get(0).unwrap().id, message.id);
+    assert_eq!(query_result.first().unwrap().id, message.id);
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
@@ -139,8 +139,7 @@ async fn test_stickies() {
     assert_eq!(
         Message::get_sticky(channel.id, &mut bundle.user)
             .await
-            .unwrap()
-            .get(0)
+            .unwrap().first()
             .unwrap()
             .id,
         message.id

--- a/tests/relationships.rs
+++ b/tests/relationships.rs
@@ -50,7 +50,7 @@ async fn test_get_relationships() {
         .unwrap();
     let relationships = user.get_relationships().await.unwrap();
     assert_eq!(
-        relationships.get(0).unwrap().id,
+        relationships.first().unwrap().id,
         other_user.object.read().unwrap().id
     );
     common::teardown(bundle).await
@@ -71,20 +71,20 @@ async fn test_modify_relationship_friends() {
         .unwrap();
     let relationships = user.get_relationships().await.unwrap();
     assert_eq!(
-        relationships.get(0).unwrap().id,
+        relationships.first().unwrap().id,
         other_user.object.read().unwrap().id
     );
     assert_eq!(
-        relationships.get(0).unwrap().relationship_type,
+        relationships.first().unwrap().relationship_type,
         RelationshipType::Incoming
     );
     let relationships = other_user.get_relationships().await.unwrap();
     assert_eq!(
-        relationships.get(0).unwrap().id,
+        relationships.first().unwrap().id,
         user.object.read().unwrap().id
     );
     assert_eq!(
-        relationships.get(0).unwrap().relationship_type,
+        relationships.first().unwrap().relationship_type,
         RelationshipType::Outgoing
     );
     let _ = user
@@ -95,7 +95,7 @@ async fn test_modify_relationship_friends() {
             .get_relationships()
             .await
             .unwrap()
-            .get(0)
+            .first()
             .unwrap()
             .relationship_type,
         RelationshipType::Friends
@@ -124,11 +124,11 @@ async fn test_modify_relationship_block() {
     assert_eq!(relationships, Vec::<Relationship>::new());
     let relationships = other_user.get_relationships().await.unwrap();
     assert_eq!(
-        relationships.get(0).unwrap().id,
+        relationships.first().unwrap().id,
         user.object.read().unwrap().id
     );
     assert_eq!(
-        relationships.get(0).unwrap().relationship_type,
+        relationships.first().unwrap().relationship_type,
         RelationshipType::Blocked
     );
     other_user.remove_relationship(user_id).await.unwrap();

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -953,45 +953,7 @@ mod entities {
     }
 
     mod guild {
-        use std::hash::{Hash, Hasher};
-
-        use chorus::types::{Guild, GuildInvite};
-
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-        #[cfg_attr(not(target_arch = "wasm32"), test)]
-        fn guild_hash() {
-            let id: u64 = 1;
-            let mut guild1 = Guild::default();
-            let mut guild2 = Guild::default();
-            guild1.id = id.into();
-            guild2.id = id.into();
-            let mut hasher1 = std::collections::hash_map::DefaultHasher::new();
-            guild1.hash(&mut hasher1);
-
-            let mut hasher2 = std::collections::hash_map::DefaultHasher::new();
-            guild2.hash(&mut hasher2);
-
-            assert_eq!(hasher1.finish(), hasher2.finish());
-        }
-
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-        #[cfg_attr(not(target_arch = "wasm32"), test)]
-        fn guild_invite_hash() {
-            let id: u64 = 1;
-            let mut invite1 = GuildInvite::default();
-            let mut invite2 = GuildInvite::default();
-            invite1.channel_id = id.into();
-            invite2.channel_id = id.into();
-            invite1.guild_id = id.into();
-            invite2.guild_id = id.into();
-            let mut hasher1 = std::collections::hash_map::DefaultHasher::new();
-            invite1.hash(&mut hasher1);
-
-            let mut hasher2 = std::collections::hash_map::DefaultHasher::new();
-            invite2.hash(&mut hasher2);
-
-            assert_eq!(hasher1.finish(), hasher2.finish());
-        }
+        use chorus::types::Guild;
 
         #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
         #[cfg_attr(not(target_arch = "wasm32"), test)]
@@ -1003,38 +965,6 @@ mod entities {
             guild2.id = id.into();
 
             assert_eq!(guild1, guild2);
-        }
-    }
-
-    mod relationship {
-        use chorus::types::{IntoShared, Relationship, User};
-
-        #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-        #[cfg_attr(not(target_arch = "wasm32"), test)]
-        fn relationship_partial_eq() {
-            let user = User::default();
-            // These 2 users are different, because they do not have the same Snowflake "id".
-            let user_2 = User::default();
-            let relationship_1 = Relationship {
-                id: 32_u64.into(),
-                relationship_type: chorus::types::RelationshipType::Friends,
-                nickname: Some("Xenia".to_string()),
-                user: user.into_public_user().into_shared(),
-                since: None,
-            };
-
-            let relationship_2 = Relationship {
-                id: 32_u64.into(),
-                relationship_type: chorus::types::RelationshipType::Friends,
-                nickname: Some("Xenia".to_string()),
-                user: user_2.into_public_user().into_shared(),
-                since: None,
-            };
-
-            // This should succeed, even though the two users' IDs are different. This is because
-            // `User` is only `PartialEq`, and the actual user object is not checked, since the
-            // `RwLock` would have to be locked.
-            assert_eq!(relationship_1, relationship_2);
         }
     }
 


### PR DESCRIPTION
Adds about one billion (+- a few hundred million) missing derives for all sorts of types.

The biggest change in this PR is, how structs holding a property `Shared<T>` types implement `PartialEq`. In previous versions of this crate, if a `Shared<T>` was part of a struct, this or these properties would be ignored in == comparisons. This is because `Shared<T>` is defined as `Arc<RwLock<T>>` - meaning you'd have to lock the `RwLock` to make a comparison. From now on, instead of ignoring these properties or locking the inner `RwLock`, the pointer values of the `Arc<T>`'s get compared. This is a cheap and exact way of ensuring `Eq` for types, which have an inner `Shared<T>`.