### PR TITLE
Use cargo nextest

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2,153 +2,130 @@ name: Build and Test
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main", "dev" ]
+    branches: ["main", "dev"]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   linux:
-
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    
     steps:
-    - uses: actions/checkout@v4
-    - name: Clone spacebar server
-      run: |
-        git clone https://github.com/bitfl0wer/server.git
-    - uses: actions/setup-node@v4
-      with:
+      - uses: actions/checkout@v4
+      - name: Clone spacebar server
+        run: |
+          git clone https://github.com/bitfl0wer/server.git
+      - uses: actions/setup-node@v4
+        with:
           node-version: 18
-          cache: 'npm'
+          cache: "npm"
           cache-dependency-path: server/package-lock.json
-    - name: Prepare and start Spacebar server
-      run: |
-        npm install
-        npm run setup
-        npm run start &
-      working-directory: ./server
-    - uses: Swatinem/rust-cache@v2
-      with:
-        cache-all-crates: "true"
-        prefix-key: "linux"
-    - name: Build, Test and Publish Coverage
-      run: |
-        if [ -n "${{ secrets.COVERALLS_REPO_TOKEN }}" ]; then
-          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-          cargo binstall --no-confirm cargo-tarpaulin --force
-          cargo tarpaulin --all-features --avoid-cfg-tarpaulin --tests --verbose --skip-clean --coveralls ${{ secrets.COVERALLS_REPO_TOKEN }} --timeout 120
-        else
-          echo "Code Coverage step is skipped on forks!"
-          cargo build --verbose --all-features
-          cargo test --verbose --all-features
-        fi
-    - name: Check common non-default feature configurations
-      run: |
-        echo "No features:"
-        cargo check --features="" --no-default-features
-        echo "Only client:"
-        cargo check --features="client" --no-default-features
-        echo "Only backend:"
-        cargo check --features="backend" --no-default-features
-        echo "Only voice:"
-        cargo check --features="voice" --no-default-features
-        echo "Only voice gateway:"
-        cargo check --features="voice_gateway" --no-default-features
-        echo "Backend + client:"
-        cargo check --features="backend, client" --no-default-features
-        echo "Backend + voice:"
-        cargo check --features="backend, voice" --no-default-features
-        echo "Backend + voice gateway:"
-        cargo check --features="backend, voice_gateway" --no-default-features
-        echo "Client + voice gateway:"
-        cargo check --features="client, voice_gateway" --no-default-features 
-  # wasm-safari:
-  #   runs-on: macos-latest
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - name: Clone spacebar server
-  #     run: |
-  #       git clone https://github.com/bitfl0wer/server.git
-  #   - uses: actions/setup-node@v4
-  #     with:
-  #         node-version: 18
-  #         cache: 'npm'
-  #         cache-dependency-path: server/package-lock.json
-  #   - name: Prepare and start Spacebar server
-  #     run: |
-  #       npm install
-  #       npm run setup
-  #       npm run start &
-  #     working-directory: ./server
-  #   - uses: Swatinem/rust-cache@v2 
-  #     with:
-  #       cache-all-crates: "true"
-  #       prefix-key: "macos-safari"
-  #   - name: Run WASM tests with Safari, Firefox, Chrome
-  #     run: |
-  #       rustup target add wasm32-unknown-unknown
-  #       curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-  #       cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.88" --force
-  #       SAFARIDRIVER=$(which safaridriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt" --no-fail-fast
+      - name: Prepare and start Spacebar server
+        run: |
+          npm install
+          npm run setup
+          npm run start &
+        working-directory: ./server
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: "true"
+          prefix-key: "linux"
+      - uses: taiki-e/install-action@nextest
+      - name: Build, Test with nextest, Publish Coverage
+        run: |
+          if [ -n "${{ secrets.COVERALLS_REPO_TOKEN }}" ]; then
+            if [ "${{github.event.pull_request.head.ref}}" = "main" ]; then
+              curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+              cargo binstall --no-confirm cargo-tarpaulin --force
+              cargo tarpaulin --all-features --avoid-cfg-tarpaulin --tests --verbose --skip-clean --coveralls ${{ secrets.COVERALLS_REPO_TOKEN }} --timeout 120
+            else
+              echo "Code Coverage step is skipped on non-main PRs and PRs from forks."
+              cargo build --verbose --all-features
+              cargo nextest run --verbose --all-features
+            fi
+          else
+            echo "Code Coverage step is skipped on non-main PRs and PRs from forks."
+            cargo build --verbose --all-features
+            cargo nextest run --verbose --all-features
+          fi
+      - name: Check common non-default feature configurations
+        run: |
+          echo "No features:"
+          cargo check --features="" --no-default-features
+          echo "Only client:"
+          cargo check --features="client" --no-default-features
+          echo "Only backend:"
+          cargo check --features="backend" --no-default-features
+          echo "Only voice:"
+          cargo check --features="voice" --no-default-features
+          echo "Only voice gateway:"
+          cargo check --features="voice_gateway" --no-default-features
+          echo "Backend + client:"
+          cargo check --features="backend, client" --no-default-features
+          echo "Backend + voice:"
+          cargo check --features="backend, voice" --no-default-features
+          echo "Backend + voice gateway:"
+          cargo check --features="backend, voice_gateway" --no-default-features
+          echo "Client + voice gateway:"
+          cargo check --features="client, voice_gateway" --no-default-features
   wasm-gecko:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v4
-    - name: Clone spacebar server
-      run: |
-        git clone https://github.com/bitfl0wer/server.git
-    - uses: actions/setup-node@v4
-      with:
+      - uses: actions/checkout@v4
+      - name: Clone spacebar server
+        run: |
+          git clone https://github.com/bitfl0wer/server.git
+      - uses: actions/setup-node@v4
+        with:
           node-version: 18
-          cache: 'npm'
+          cache: "npm"
           cache-dependency-path: server/package-lock.json
-    - name: Prepare and start Spacebar server
-      run: |
-        npm install
-        npm run setup
-        npm run start &
-      working-directory: ./server
-    - uses: Swatinem/rust-cache@v2 
-      with:
-        cache-all-crates: "true"
-        prefix-key: "macos"
-    - name: Run WASM tests with Safari, Firefox, Chrome
-      run: |
-        rustup target add wasm32-unknown-unknown
-        curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-        cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.92" --force
-        GECKODRIVER=$(which geckodriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt, voice_gateway"
+      - name: Prepare and start Spacebar server
+        run: |
+          npm install
+          npm run setup
+          npm run start &
+        working-directory: ./server
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: "true"
+          prefix-key: "macos"
+      - name: Run WASM tests with Safari, Firefox, Chrome
+        run: |
+          rustup target add wasm32-unknown-unknown
+          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+          cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.92" --force
+          GECKODRIVER=$(which geckodriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt, voice_gateway"
   wasm-chrome:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v4
-    - name: Clone spacebar server
-      run: |
-        git clone https://github.com/bitfl0wer/server.git
-    - uses: actions/setup-node@v4
-      with:
+      - uses: actions/checkout@v4
+      - name: Clone spacebar server
+        run: |
+          git clone https://github.com/bitfl0wer/server.git
+      - uses: actions/setup-node@v4
+        with:
           node-version: 18
-          cache: 'npm'
+          cache: "npm"
           cache-dependency-path: server/package-lock.json
-    - name: Prepare and start Spacebar server
-      run: |
-        npm install
-        npm run setup
-        npm run start &
-      working-directory: ./server
-    - uses: Swatinem/rust-cache@v2 
-      with:
-        cache-all-crates: "true"
-        prefix-key: "macos"
-    - name: Run WASM tests with Safari, Firefox, Chrome
-      run: |
-        rustup target add wasm32-unknown-unknown
-        curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-        cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.92" --force
-        CHROMEDRIVER=$(which chromedriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt, voice_gateway"
+      - name: Prepare and start Spacebar server
+        run: |
+          npm install
+          npm run setup
+          npm run start &
+        working-directory: ./server
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: "true"
+          prefix-key: "macos"
+      - name: Run WASM tests with Safari, Firefox, Chrome
+        run: |
+          rustup target add wasm32-unknown-unknown
+          curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+          cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.92" --force
+          CHROMEDRIVER=$(which chromedriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt, voice_gateway"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -49,6 +49,11 @@ jobs:
             echo "Code Coverage step is skipped on non-main PRs and PRs from forks."
             cargo nextest run --verbose --all-features
           fi
+  linux-non-default-features:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
       - name: Check common non-default feature configurations
         run: |
           echo "No features:"
@@ -97,7 +102,7 @@ jobs:
           rustup target add wasm32-unknown-unknown
           curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
           cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.92" --force
-          GECKODRIVER=$(which geckodriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt, voice_gateway"
+          GECKODRIVER=$(which geckodriver) cargo nextest run --target wasm32-unknown-unknown --no-default-features --features="client, rt, voice_gateway"
   wasm-chrome:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -126,4 +131,4 @@ jobs:
           rustup target add wasm32-unknown-unknown
           curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
           cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.92" --force
-          CHROMEDRIVER=$(which chromedriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt, voice_gateway"
+          CHROMEDRIVER=$(which chromedriver) cargo nextest run --target wasm32-unknown-unknown --no-default-features --features="client, rt, voice_gateway"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -97,6 +97,7 @@ jobs:
         with:
           cache-all-crates: "true"
           prefix-key: "macos"
+      - uses: taiki-e/install-action@nextest
       - name: Run WASM tests with Safari, Firefox, Chrome
         run: |
           rustup target add wasm32-unknown-unknown
@@ -126,6 +127,7 @@ jobs:
         with:
           cache-all-crates: "true"
           prefix-key: "macos"
+      - uses: taiki-e/install-action@nextest
       - name: Run WASM tests with Safari, Firefox, Chrome
         run: |
           rustup target add wasm32-unknown-unknown

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -97,13 +97,12 @@ jobs:
         with:
           cache-all-crates: "true"
           prefix-key: "macos"
-      - uses: taiki-e/install-action@nextest
       - name: Run WASM tests with Safari, Firefox, Chrome
         run: |
           rustup target add wasm32-unknown-unknown
           curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
           cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.92" --force
-          GECKODRIVER=$(which geckodriver) cargo nextest run --target wasm32-unknown-unknown --no-default-features --features="client, rt, voice_gateway"
+          GECKODRIVER=$(which geckodriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt, voice_gateway"
   wasm-chrome:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -127,10 +126,9 @@ jobs:
         with:
           cache-all-crates: "true"
           prefix-key: "macos"
-      - uses: taiki-e/install-action@nextest
       - name: Run WASM tests with Safari, Firefox, Chrome
         run: |
           rustup target add wasm32-unknown-unknown
           curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
           cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.92" --force
-          CHROMEDRIVER=$(which chromedriver) cargo nextest run --target wasm32-unknown-unknown --no-default-features --features="client, rt, voice_gateway"
+          CHROMEDRIVER=$(which chromedriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt, voice_gateway"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,8 +3,10 @@
 
 **Please refer to the [contribution guidelines](https://github.com/polyphony-chat/.github/blob/main/CONTRIBUTION_GUIDELINES.md) and [our Code of Conduct](https://github.com/polyphony-chat/.github/blob/main/CODE_OF_CONDUCT.md) before making a contribution.**
 
+Contributions should always fork from and merge back into the `dev` branch.
+
 Chorus is currently missing voice support and a lot of API endpoints, many of which should be trivial to implement,
 ever since [we streamlined the process of doing so](https://github.com/polyphony-chat/chorus/discussions/401).
 
 If you'd like to contribute new functionality, check out [The 'Meta'-issues.](https://github.com/polyphony-chat/chorus/issues?q=is%3Aissue+label%3A%22Type%3A+Meta%22+) They contain a comprehensive list of all features which are yet missing for full Discord.com compatibility.
-Please feel free to open an Issue with the idea you have, or a Pull Request. 
+Please feel free to open an Issue with the idea you have, or a Pull Request.


### PR DESCRIPTION
This PR switches the `linux` job from `cargo test` to `cargo nextest run` for > 50% time reduction in the test execution step of the CI pipeline. Also, the "check common non default feature configurations" step has been moved from the `linux` job to it's own job, to parallelize the CI pipeline further and reduce the time that CI needs to run to completion.