### PR TITLE
sqlx related improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -293,6 +292,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,9 +549,14 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fastrand"
@@ -773,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
 ]
@@ -806,12 +819,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1141,9 +1151,9 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1366,6 +1376,12 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
@@ -2059,6 +2075,9 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -2107,9 +2126,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a2ccff1a000a5a59cd33da541d9f2fdcd9e6e8229cc200565942bff36d0aaa"
+checksum = "27144619c6e5802f1380337a209d2ac1c431002dd74c6e60aebff3c506dc4f0c"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -2120,11 +2139,10 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6"
+checksum = "a999083c1af5b5d6c071d34a708a19ba3e02106ad82ef7bbd69f5e48266b613b"
 dependencies = [
- "ahash",
  "atoi",
  "byteorder",
  "bytes",
@@ -2138,6 +2156,7 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
+ "hashbrown 0.14.5",
  "hashlink",
  "hex",
  "indexmap 2.2.6",
@@ -2164,22 +2183,22 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea40e2345eb2faa9e1e5e326db8c34711317d2b5e08d0d5741619048a803127"
+checksum = "a23217eb7d86c584b8cbe0337b9eacf12ab76fe7673c513141ec42565698bb88"
 dependencies = [
  "proc-macro2",
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 1.0.109",
+ "syn 2.0.70",
 ]
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
+checksum = "1a099220ae541c5db479c6424bdf1b200987934033c2584f79a0e1693601e776"
 dependencies = [
  "dotenvy",
  "either",
@@ -2195,7 +2214,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 1.0.109",
+ "syn 2.0.70",
  "tempfile",
  "tokio",
  "url",
@@ -2203,12 +2222,12 @@ dependencies = [
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
+checksum = "5afe4c38a9b417b6a9a5eeffe7235d0a106716495536e7727d1c7f4b1ff3eba6"
 dependencies = [
  "atoi",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitflags 2.6.0",
  "byteorder",
  "bytes",
@@ -2246,12 +2265,12 @@ dependencies = [
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
+checksum = "b1dbb157e65f10dbe01f729339c06d239120221c9ad9fa0ba8408c4cc18ecf21"
 dependencies = [
  "atoi",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitflags 2.6.0",
  "byteorder",
  "chrono",
@@ -2286,9 +2305,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b244ef0a8414da0bed4bb1910426e890b19e5e9bccc27ada6b797d05c55ae0aa"
+checksum = "9b2cdd83c008a622d94499c0006d8ee5f821f36c89b7d625c900e5dc30b5c5ee"
 dependencies = [
  "atoi",
  "chrono",
@@ -2302,10 +2321,10 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
+ "serde_urlencoded",
  "sqlx-core",
  "tracing",
  "url",
- "urlencoding",
 ]
 
 [[package]]
@@ -2676,12 +2695,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4259d9d4425d9f0661581b804cb85fe66a4c631cadd8f490d1c13a35d5d9291"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
-
-[[package]]
 name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2719,12 +2732,6 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ jsonwebtoken = "8.3.0"
 log = "0.4.22"
 async-trait = "0.1.81"
 chorus-macros = { path = "./chorus-macros", version = "0" } # Note: version here is used when releasing. This will use the latest release. Make sure to republish the crate when code in macros is changed!
-sqlx = { version = "0.7.4", features = [
+sqlx = { version = "0.8.0", features = [
     "mysql",
     "sqlite",
     "json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,3 +87,6 @@ lazy_static = "1.5.0"
 wasm-bindgen-test = "0.3.42"
 wasm-bindgen = "0.2.92"
 simple_logger = { version = "5.0.0", default-features = false }
+
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = ['cfg(tarpaulin_include)'] }

--- a/chorus-macros/src/lib.rs
+++ b/chorus-macros/src/lib.rs
@@ -156,7 +156,6 @@ pub fn composite_derive(input: TokenStream) -> TokenStream {
     }
 }
 
-
 #[proc_macro_derive(SqlxBitFlags)]
 pub fn sqlx_bitflag_derive(input: TokenStream) -> TokenStream {
     let ast: syn::DeriveInput = syn::parse(input).unwrap();
@@ -165,22 +164,22 @@ pub fn sqlx_bitflag_derive(input: TokenStream) -> TokenStream {
 
     quote!{
         #[cfg(feature = "sqlx")]
-        impl sqlx::Type<sqlx::MySql> for #name {
-            fn type_info() -> sqlx::mysql::MySqlTypeInfo {
+        impl sqlx::Type<sqlx::Any> for #name {
+            fn type_info() -> sqlx::any::AnyTypeInfo {
                 u64::type_info()
             }
         }
 
         #[cfg(feature = "sqlx")]
-        impl<'q> sqlx::Encode<'q, sqlx::MySql> for #name {
-            fn encode_by_ref(&self, buf: &mut <sqlx::MySql as sqlx::database::HasArguments<'q>>::ArgumentBuffer) -> sqlx::encode::IsNull {
+        impl<'q> sqlx::Encode<'q, sqlx::Any> for #name {
+            fn encode_by_ref(&self, buf: &mut <sqlx::Any as sqlx::Database>::ArgumentBuffer<'q>) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
                 u64::encode_by_ref(&self.bits(), buf)
             }
         }
 
         #[cfg(feature = "sqlx")]
-        impl<'q> sqlx::Decode<'q, sqlx::MySql> for #name {
-            fn decode(value: <sqlx::MySql as sqlx::database::HasValueRef<'q>>::ValueRef) -> Result<Self, sqlx::error::BoxDynError> {
+        impl<'q> sqlx::Decode<'q, sqlx::Any> for #name {
+            fn decode(value: <sqlx::Any as sqlx::Database>::ValueRef<'q>) -> Result<Self, sqlx::error::BoxDynError> {
                 u64::decode(value).map(|d| #name::from_bits(d).unwrap())
             }
         }

--- a/chorus-macros/src/lib.rs
+++ b/chorus-macros/src/lib.rs
@@ -166,21 +166,21 @@ pub fn sqlx_bitflag_derive(input: TokenStream) -> TokenStream {
         #[cfg(feature = "sqlx")]
         impl sqlx::Type<sqlx::Any> for #name {
             fn type_info() -> sqlx::any::AnyTypeInfo {
-                u64::type_info()
+                <u64 as sqlx::Type<sqlx::Any>>::type_info()
             }
         }
 
         #[cfg(feature = "sqlx")]
         impl<'q> sqlx::Encode<'q, sqlx::Any> for #name {
             fn encode_by_ref(&self, buf: &mut <sqlx::Any as sqlx::Database>::ArgumentBuffer<'q>) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
-                u64::encode_by_ref(&self.bits(), buf)
+                <u64 as sqlx::Encode<sqlx::Any>>::encode_by_ref(&self.bits(), buf)
             }
         }
 
         #[cfg(feature = "sqlx")]
         impl<'q> sqlx::Decode<'q, sqlx::Any> for #name {
             fn decode(value: <sqlx::Any as sqlx::Database>::ValueRef<'q>) -> Result<Self, sqlx::error::BoxDynError> {
-                u64::decode(value).map(|d| #name::from_bits(d).unwrap())
+                <u64 as sqlx::Decode<sqlx::Any>>::decode(value).map(|d| #name::from_bits(d).unwrap())
             }
         }
     }

--- a/src/types/config/types/guild_configuration.rs
+++ b/src/types/config/types/guild_configuration.rs
@@ -196,13 +196,13 @@ impl<'q> sqlx::Encode<'q, sqlx::Any> for GuildFeaturesList {
 }
 
 #[cfg(feature = "sqlx")]
-impl sqlx::Type<sqlx::MySql> for GuildFeaturesList {
-    fn type_info() -> sqlx::mysql::MySqlTypeInfo {
-        <String as sqlx::Type<sqlx::MySql>>::type_info()
+impl sqlx::Type<sqlx::Any> for GuildFeaturesList {
+    fn type_info() -> sqlx::any::AnyTypeInfo {
+        <String as sqlx::Type<sqlx::Any>>::type_info()
     }
 
-    fn compatible(ty: &sqlx::mysql::MySqlTypeInfo) -> bool {
-        <String as sqlx::Type<sqlx::MySql>>::compatible(ty)
+    fn compatible(ty: &sqlx::any::AnyTypeInfo) -> bool {
+        <String as sqlx::Type<sqlx::Any>>::compatible(ty)
     }
 }
 

--- a/src/types/config/types/guild_configuration.rs
+++ b/src/types/config/types/guild_configuration.rs
@@ -162,9 +162,11 @@ impl Display for GuildFeaturesList {
 }
 
 #[cfg(feature = "sqlx")]
-impl<'r> sqlx::Decode<'r, sqlx::MySql> for GuildFeaturesList {
-    fn decode(value: <sqlx::MySql as sqlx::database::HasValueRef<'r>>::ValueRef) -> Result<Self, sqlx::error::BoxDynError> {
-        let v = <String as sqlx::Decode<sqlx::MySql>>::decode(value)?;
+impl<'r> sqlx::Decode<'r, sqlx::Any> for GuildFeaturesList {
+    fn decode(
+        value: <sqlx::Any as sqlx::Database>::ValueRef<'r>,
+    ) -> Result<Self, sqlx::error::BoxDynError> {
+        let v = <String as sqlx::Decode<sqlx::Any>>::decode(value)?;
         Ok(Self(
             v.split(',')
                 .filter(|f| !f.is_empty())
@@ -175,10 +177,13 @@ impl<'r> sqlx::Decode<'r, sqlx::MySql> for GuildFeaturesList {
 }
 
 #[cfg(feature = "sqlx")]
-impl<'q> sqlx::Encode<'q, sqlx::MySql> for GuildFeaturesList {
-    fn encode_by_ref(&self, buf: &mut <sqlx::MySql as sqlx::database::HasArguments<'q>>::ArgumentBuffer) -> sqlx::encode::IsNull {
+impl<'q> sqlx::Encode<'q, sqlx::Any> for GuildFeaturesList {
+    fn encode_by_ref(
+        &self,
+        buf: &mut <sqlx::Any as sqlx::Database>::ArgumentBuffer<'q>,
+    ) -> Result<sqlx::encode::IsNull, Box<dyn std::error::Error + Send + Sync>> {
         if self.is_empty() {
-            return sqlx::encode::IsNull::Yes;
+            return Ok(sqlx::encode::IsNull::Yes);
         }
         let features = self
             .iter()
@@ -186,7 +191,7 @@ impl<'q> sqlx::Encode<'q, sqlx::MySql> for GuildFeaturesList {
             .collect::<Vec<_>>()
             .join(",");
 
-        <String as sqlx::Encode<sqlx::MySql>>::encode_by_ref(&features, buf)
+        <String as sqlx::Encode<sqlx::Any>>::encode_by_ref(&features, buf)
     }
 }
 

--- a/src/types/entities/application.rs
+++ b/src/types/entities/application.rs
@@ -102,7 +102,10 @@ fn compare_install_params(
     b: &Option<sqlx::types::Json<InstallParams>>,
 ) -> bool {
     match (a, b) {
-        (Some(a), Some(b)) => a.encode_to_string() == b.encode_to_string(),
+        (Some(a), Some(b)) => match (a.encode_to_string(), b.encode_to_string()) {
+            (Ok(a), Ok(b)) => a == b,
+            _ => false,
+        },
         (None, None) => true,
         _ => false,
     }

--- a/src/types/entities/audit_log.rs
+++ b/src/types/entities/audit_log.rs
@@ -51,7 +51,10 @@ fn compare_options(
     b: &Option<sqlx::types::Json<AuditEntryInfo>>,
 ) -> bool {
     match (a, b) {
-        (Some(a), Some(b)) => a.encode_to_string() == b.encode_to_string(),
+        (Some(a), Some(b)) => match (a.encode_to_string(), b.encode_to_string()) {
+            (Ok(a), Ok(b)) => a == b,
+            _ => false,
+        },
         (None, None) => true,
         _ => false,
     }
@@ -69,7 +72,10 @@ fn compare_changes(
     a: &sqlx::types::Json<Option<Vec<Shared<AuditLogChange>>>>,
     b: &sqlx::types::Json<Option<Vec<Shared<AuditLogChange>>>>,
 ) -> bool {
-    a.encode_to_string() == b.encode_to_string()
+    match (a.encode_to_string(), b.encode_to_string()) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => false,
+    }
 }
 
 #[cfg(not(tarpaulin_include))]

--- a/src/types/entities/channel.rs
+++ b/src/types/entities/channel.rs
@@ -156,7 +156,10 @@ fn compare_permission_overwrites(
     b: &Option<Json<Vec<PermissionOverwrite>>>,
 ) -> bool {
     match (a, b) {
-        (Some(a), Some(b)) => a.encode_to_string() == b.encode_to_string(),
+        (Some(a), Some(b)) => match (a.encode_to_string(), b.encode_to_string()) {
+            (Ok(a), Ok(b)) => a == b,
+            _ => false,
+        },
         (None, None) => true,
         _ => false,
     }

--- a/src/types/entities/user.rs
+++ b/src/types/entities/user.rs
@@ -132,9 +132,9 @@ impl<'d> sqlx::Decode<'d, sqlx::Any> for ThemeColors {
 }
 
 #[cfg(feature = "sqlx")]
-impl sqlx::Type<sqlx::MySql> for ThemeColors {
-    fn type_info() -> <sqlx::MySql as sqlx::Database>::TypeInfo {
-        <String as sqlx::Type<sqlx::MySql>>::type_info()
+impl sqlx::Type<sqlx::Any> for ThemeColors {
+    fn type_info() -> <sqlx::Any as sqlx::Database>::TypeInfo {
+        <String as sqlx::Type<sqlx::Any>>::type_info()
     }
 }
 

--- a/src/types/entities/user.rs
+++ b/src/types/entities/user.rs
@@ -109,24 +109,24 @@ impl TryFrom<Vec<u8>> for ThemeColors {
 
 #[cfg(feature = "sqlx")]
 // TODO: Add tests for Encode and Decode.
-impl<'q> sqlx::Encode<'q, sqlx::MySql> for ThemeColors {
+impl<'q> sqlx::Encode<'q, sqlx::Any> for ThemeColors {
     fn encode_by_ref(
         &self,
-        buf: &mut <sqlx::MySql as sqlx::database::HasArguments<'q>>::ArgumentBuffer,
-    ) -> sqlx::encode::IsNull {
+        buf: &mut <sqlx::Any as sqlx::Database>::ArgumentBuffer<'q>,
+    ) -> Result<sqlx::encode::IsNull, Box<dyn std::error::Error + Send + Sync>> {
         let mut vec_u8 = Vec::new();
         vec_u8.extend_from_slice(&self.inner.0.to_be_bytes());
         vec_u8.extend_from_slice(&self.inner.1.to_be_bytes());
-        <Vec<u8> as sqlx::Encode<'q, sqlx::MySql>>::encode_by_ref(&vec_u8, buf)
+        <Vec<u8> as sqlx::Encode<sqlx::Any>>::encode_by_ref(&vec_u8, buf)
     }
 }
 
 #[cfg(feature = "sqlx")]
-impl<'d> sqlx::Decode<'d, sqlx::MySql> for ThemeColors {
+impl<'d> sqlx::Decode<'d, sqlx::Any> for ThemeColors {
     fn decode(
-        value: <sqlx::MySql as sqlx::database::HasValueRef<'d>>::ValueRef,
+        value: <sqlx::Any as sqlx::Database>::ValueRef<'d>,
     ) -> Result<Self, sqlx::error::BoxDynError> {
-        let value_vec = <Vec<u8> as sqlx::Decode<'d, sqlx::MySql>>::decode(value)?;
+        let value_vec = <Vec<u8> as sqlx::Decode<'d, sqlx::Any>>::decode(value)?;
         value_vec.try_into().map_err(|e: ChorusError| e.into())
     }
 }

--- a/src/types/utils/snowflake.rs
+++ b/src/types/utils/snowflake.rs
@@ -99,23 +99,29 @@ impl<'de> serde::Deserialize<'de> for Snowflake {
 }
 
 #[cfg(feature = "sqlx")]
-impl sqlx::Type<sqlx::MySql> for Snowflake {
-    fn type_info() -> <sqlx::MySql as sqlx::Database>::TypeInfo {
-        <String as sqlx::Type<sqlx::MySql>>::type_info()
+impl sqlx::Type<sqlx::Any> for Snowflake {
+    fn type_info() -> <sqlx::Any as sqlx::Database>::TypeInfo {
+        <String as sqlx::Type<sqlx::Any>>::type_info()
     }
 }
 
 #[cfg(feature = "sqlx")]
-impl<'q> sqlx::Encode<'q, sqlx::MySql> for Snowflake {
-    fn encode_by_ref(&self, buf: &mut <sqlx::MySql as sqlx::database::HasArguments<'q>>::ArgumentBuffer) -> sqlx::encode::IsNull {
-        <String as sqlx::Encode<'q, sqlx::MySql>>::encode_by_ref(&self.0.to_string(), buf)
+impl<'q> sqlx::Encode<'q, sqlx::Any> for Snowflake {
+    fn encode_by_ref(
+        &self,
+        buf: &mut <sqlx::Any as sqlx::Database>::ArgumentBuffer<'q>,
+    ) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
+        <String as sqlx::Encode<'q, sqlx::Any>>::encode_by_ref(&self.0.to_string(), buf)
     }
 }
 
 #[cfg(feature = "sqlx")]
-impl<'d> sqlx::Decode<'d, sqlx::MySql> for Snowflake {
-    fn decode(value: <sqlx::MySql as sqlx::database::HasValueRef<'d>>::ValueRef) -> Result<Self, sqlx::error::BoxDynError> {
-        <String as sqlx::Decode<'d, sqlx::MySql>>::decode(value).map(|s| s.parse::<u64>().map(Snowflake).unwrap())
+impl<'d> sqlx::Decode<'d, sqlx::Any> for Snowflake {
+    fn decode(
+        value: <sqlx::Any as sqlx::Database>::ValueRef<'d>,
+    ) -> Result<Self, sqlx::error::BoxDynError> {
+        <String as sqlx::Decode<'d, sqlx::Any>>::decode(value)
+            .map(|s| s.parse::<u64>().map(Snowflake).unwrap())
     }
 }
 


### PR DESCRIPTION
This PR bumps chorus from sqlx v0.7.4 to sqlx v0.8.0, which had some backwards incompatible changes. Also, instead of requiring MySQL/MariaDB to be used with chorus/sqlx, this PR enables any database driver to be used via the sqlx::Any Database Driver.

Closes #541 when merged.