### PR TITLE
CI/CD: add cargo-doc job

### DIFF
--- a/.github/workflows/cargo-doc.yml
+++ b/.github/workflows/cargo-doc.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Run cargo doc
         run:
-          cargo doc -no-deps --all-features --locked --message-format=json | clippy-sarif | tee cargo-doc-results.sarif | sarif-fmt
+          cargo doc --no-deps --all-features --locked --message-format=json | clippy-sarif | tee cargo-doc-results.sarif | sarif-fmt
         continue-on-error: true
 
       - name: Upload analysis results to GitHub

--- a/.github/workflows/cargo-doc.yml
+++ b/.github/workflows/cargo-doc.yml
@@ -1,0 +1,36 @@
+name: cargo doc lints
+
+on:
+  push:
+    branches: [ "main", "preserve/*" ]
+  pull_request:
+    branches: [ "main", "dev" ]
+
+jobs:
+  cargo-doc-lints:
+    name: Run cargo doc for doc lints
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install aditional components for sarif
+        run: cargo install clippy-sarif sarif-fmt
+
+      - name: Run cargo doc
+        run:
+          cargo doc -no-deps --all-features --locked --message-format=json | clippy-sarif | tee cargo-doc-results.sarif | sarif-fmt
+        continue-on-error: true
+
+      - name: Upload analysis results to GitHub
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: cargo-doc-results.sarif
+          wait-for-processing: true

--- a/.github/workflows/cargo-doc.yml
+++ b/.github/workflows/cargo-doc.yml
@@ -25,8 +25,7 @@ jobs:
         run: cargo install clippy-sarif sarif-fmt
 
       - name: Run cargo doc
-        run:
-          cargo doc --no-deps --all-features --locked --message-format=json | clippy-sarif | tee cargo-doc-results.sarif | sarif-fmt
+        run: cargo doc --no-deps --all-features --locked --message-format=json | clippy-sarif | sed 's/rust-lang.github.io\/rust-clippy/doc.rust-lang.org\/rustdoc\/lints.html/g' | sed 's/clippy/rustdoc/g' | tee cargo-doc-results.sarif | sarif-fmt
         continue-on-error: true
 
       - name: Upload analysis results to GitHub


### PR DESCRIPTION
Adds a `cargo doc` job to add rustdoc lints to code scanning, similar to clippy.

Note: under the hood, I literally used `clippy-sarif`; I haven't been able to find an equivalent for rustdoc, but it seems to work well