### PR TITLE
Initial support for PostgreSQL

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -101,7 +101,7 @@ jobs:
         run: |
           rustup target add wasm32-unknown-unknown
           curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-          cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.92" --force
+          cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.93" --force
           GECKODRIVER=$(which geckodriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt, voice_gateway"
   wasm-chrome:
     runs-on: ubuntu-latest
@@ -130,5 +130,5 @@ jobs:
         run: |
           rustup target add wasm32-unknown-unknown
           curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-          cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.92" --force
+          cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.93" --force
           CHROMEDRIVER=$(which chromedriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt, voice_gateway"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bigdecimal"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d712318a27c7150326677b321a5fa91b55f6d9034ffd67f20319e147d40cee"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,6 +244,7 @@ dependencies = [
  "jsonwebtoken",
  "lazy_static",
  "log",
+ "num-bigint",
  "poem",
  "pubserve",
  "rand",
@@ -2144,6 +2158,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a999083c1af5b5d6c071d34a708a19ba3e02106ad82ef7bbd69f5e48266b613b"
 dependencies = [
  "atoi",
+ "bigdecimal",
  "byteorder",
  "bytes",
  "chrono",
@@ -2228,6 +2243,7 @@ checksum = "5afe4c38a9b417b6a9a5eeffe7235d0a106716495536e7727d1c7f4b1ff3eba6"
 dependencies = [
  "atoi",
  "base64 0.22.1",
+ "bigdecimal",
  "bitflags 2.6.0",
  "byteorder",
  "bytes",
@@ -2271,6 +2287,7 @@ checksum = "b1dbb157e65f10dbe01f729339c06d239120221c9ad9fa0ba8408c4cc18ecf21"
 dependencies = [
  "atoi",
  "base64 0.22.1",
+ "bigdecimal",
  "bitflags 2.6.0",
  "byteorder",
  "chrono",
@@ -2290,6 +2307,7 @@ dependencies = [
  "log",
  "md-5",
  "memchr",
+ "num-bigint",
  "once_cell",
  "rand",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -162,6 +162,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -202,15 +203,18 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cc"
-version = "1.1.0"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaff6f8ce506b9773fa786672d63fc7a191ffea1be33f72bbd4aeacefca9ffc8"
+checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -220,9 +224,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chorus"
@@ -244,7 +248,6 @@ dependencies = [
  "jsonwebtoken",
  "lazy_static",
  "log",
- "num-bigint",
  "poem",
  "pubserve",
  "rand",
@@ -258,6 +261,7 @@ dependencies = [
  "serde_with",
  "simple_logger",
  "sqlx",
+ "sqlx-pg-uint",
  "thiserror",
  "tokio",
  "tokio-tungstenite",
@@ -276,7 +280,7 @@ version = "0.4.1"
 dependencies = [
  "async-trait",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -342,15 +346,15 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
 dependencies = [
  "libc",
 ]
@@ -447,7 +451,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.70",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -458,7 +462,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -580,9 +584,9 @@ checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "flate2"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+checksum = "7f211bbe8e69bbd0cfdea405084f128ae8b4aaa6b0b522fc8f2b009084797920"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -681,7 +685,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -756,7 +760,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -775,7 +779,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -922,9 +926,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http 1.1.0",
@@ -939,7 +943,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -990,7 +994,7 @@ dependencies = [
  "futures-util",
  "h2 0.4.5",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -1015,14 +1019,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
+checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
 dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "hyper 1.4.1",
  "pin-project-lite",
  "tokio",
@@ -1080,9 +1084,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
@@ -1121,9 +1125,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1153,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.157"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "374af5f94e54fa97cf75e945cce8a6b201e88a1a07e688b47dfd2a59c66dbd86"
 
 [[package]]
 name = "libm"
@@ -1235,6 +1239,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "minicov"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c71e683cd655513b99affab7d317deb690528255a0d5f717f1024093c12b169"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1251,9 +1265,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -1281,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -1372,9 +1386,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.1"
+version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
+checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
 dependencies = [
  "memchr",
 ]
@@ -1415,7 +1429,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.2",
+ "redox_syscall 0.5.3",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -1531,9 +1545,9 @@ dependencies = [
 
 [[package]]
 name = "poem"
-version = "3.0.1"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88b6912ed1e8833d7c22c9c986c517f4518d7d37e3c04566d917c789aaea591"
+checksum = "f1ba1c27f8f89e1bccdda0c680f72790545a11a8d8555819472f5839d7a8ca9d"
 dependencies = [
  "bytes",
  "futures-util",
@@ -1565,14 +1579,14 @@ dependencies = [
 
 [[package]]
 name = "poem-derive"
-version = "3.0.0"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b961d58a6c53380c20236394381d9292fda03577f902b158f1638932964dcf"
+checksum = "a62fea1692d80a000126f9b28d865012a160b80000abb53ccf152b428222c155"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1594,9 +1608,12 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -1675,18 +1692,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
  "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1863,9 +1880,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
 
 [[package]]
 name = "rustls-webpki"
@@ -1890,6 +1907,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1928,9 +1954,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
 dependencies = [
  "serde_derive",
 ]
@@ -1948,22 +1974,23 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.75",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -1976,7 +2003,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2001,7 +2028,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2018,7 +2045,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2042,6 +2069,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signature"
@@ -2174,7 +2207,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "hashlink",
  "hex",
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "ipnetwork",
  "log",
  "memchr",
@@ -2206,7 +2239,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.70",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2229,7 +2262,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.70",
+ "syn 2.0.75",
  "tempfile",
  "tokio",
  "url",
@@ -2277,6 +2310,29 @@ dependencies = [
  "thiserror",
  "tracing",
  "whoami",
+]
+
+[[package]]
+name = "sqlx-pg-uint"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252a4a55217704777814f5be098ab5563d1e21c7f0d3010a301f75373d68c8e2"
+dependencies = [
+ "bigdecimal",
+ "serde",
+ "sqlx",
+ "sqlx-pg-uint-macros",
+ "thiserror",
+]
+
+[[package]]
+name = "sqlx-pg-uint-macros"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4f5704fe7b866782ab87d9fe069c2f02be27b801e990af56a3d94a29290bd8"
+dependencies = [
+ "quote",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2381,9 +2437,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.70"
+version = "2.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0209b68b3613b093e0ec905354eccaedcfe83b8cb37cbdeae64026c3064c16"
+checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2428,14 +2484,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2455,7 +2512,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2506,9 +2563,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.2"
+version = "1.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
+checksum = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2528,7 +2585,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2582,9 +2639,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
@@ -2592,16 +2649,16 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.4.0",
  "toml_datetime",
  "winnow",
 ]
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -2623,7 +2680,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2765,9 +2822,19 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -2792,34 +2859,35 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.75",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2829,9 +2897,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2839,31 +2907,32 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.75",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.42"
+version = "0.3.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9bf62a58e0780af3e852044583deee40983e5886da43a271dd772379987667b"
+checksum = "68497a05fb21143a08a7d24fc81763384a3072ee43c44e86aad1744d6adef9d9"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
+ "minicov",
  "scoped-tls",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -2872,13 +2941,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.42"
+version = "0.3.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f89739351a2e03cb94beb799d47fb2cac01759b40ec441f7de39b00cbf7ef0"
+checksum = "4b8220be1fa9e4c889b30fd207d4906657e7e90b12e0e6b0c8b8d8709f5de021"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2897,9 +2966,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2953,6 +3022,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2981,6 +3059,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -3150,6 +3237,7 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 
@@ -3161,7 +3249,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.70",
+ "syn 2.0.75",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2314,9 +2314,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-pg-uint"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "252a4a55217704777814f5be098ab5563d1e21c7f0d3010a301f75373d68c8e2"
+checksum = "ba7acddf6774b42bfba10aad5a0496e3df8bc6a45a2a0ab010175b69280a5f2c"
 dependencies = [
  "bigdecimal",
  "serde",
@@ -2327,9 +2327,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-pg-uint-macros"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4f5704fe7b866782ab87d9fe069c2f02be27b801e990af56a3d94a29290bd8"
+checksum = "3415daefc001b6cda372707886d508a819196d39fc769e9d9aed2b4e659a51b3"
 dependencies = [
  "quote",
  "syn 2.0.75",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2315,8 +2315,7 @@ dependencies = [
 [[package]]
 name = "sqlx-pg-uint"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba7acddf6774b42bfba10aad5a0496e3df8bc6a45a2a0ab010175b69280a5f2c"
+source = "git+https://github.com/bitfl0wer/sqlx-pg-uint#a132f4ad12f6cd1f68cc07e01edd644b4735e346"
 dependencies = [
  "bigdecimal",
  "serde",
@@ -2328,8 +2327,7 @@ dependencies = [
 [[package]]
 name = "sqlx-pg-uint-macros"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3415daefc001b6cda372707886d508a819196d39fc769e9d9aed2b4e659a51b3"
+source = "git+https://github.com/bitfl0wer/sqlx-pg-uint#a132f4ad12f6cd1f68cc07e01edd644b4735e346"
 dependencies = [
  "quote",
  "syn 2.0.75",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,7 +128,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.7.4",
  "object",
  "rustc-demangle",
 ]
@@ -584,12 +590,12 @@ checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "flate2"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f211bbe8e69bbd0cfdea405084f128ae8b4aaa6b0b522fc8f2b009084797920"
+checksum = "9c0596c1eac1f9e04ed902702e9878208b336edc9d6fddc8a48387349bab3666"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.8.0",
 ]
 
 [[package]]
@@ -769,9 +775,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -992,7 +998,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.5",
+ "h2 0.4.6",
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
@@ -1157,9 +1163,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.157"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374af5f94e54fa97cf75e945cce8a6b201e88a1a07e688b47dfd2a59c66dbd86"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libm"
@@ -1261,6 +1267,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+dependencies = [
+ "adler2",
 ]
 
 [[package]]
@@ -2763,9 +2778,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-properties"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4259d9d4425d9f0661581b804cb85fe66a4c631cadd8f490d1c13a35d5d9291"
+checksum = "52ea75f83c0137a9b98608359a5f1af8144876eb67bcb1ce837368e906a9f524"
 
 [[package]]
 name = "unicode_categories"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,14 @@ rust-version = "1.70.0"
 
 [features]
 default = ["client", "rt-multi-thread"]
-backend = ["poem", "sqlx"]
+backend = ["poem", "sqlx", "num-bigint"]
 rt-multi-thread = ["tokio/rt-multi-thread"]
 rt = ["tokio/rt"]
 client = ["flate2"]
 voice = ["voice_udp", "voice_gateway"]
 voice_udp = ["dep:discortp", "dep:crypto_secretbox"]
 voice_gateway = []
+num-bigint = ["dep:num-bigint"]
 
 [dependencies]
 tokio = { version = "1.38.1", features = ["macros", "sync"] }
@@ -54,6 +55,7 @@ sqlx = { version = "0.8.0", features = [
     "ipnetwork",
     "runtime-tokio-rustls",
     "postgres",
+    "bigdecimal",
 ], optional = true }
 discortp = { version = "0.5.0", optional = true, features = [
     "rtp",
@@ -65,6 +67,7 @@ rand = "0.8.5"
 flate2 = { version = "1.0.30", optional = true }
 webpki-roots = "0.26.3"
 pubserve = { version = "1.1.0", features = ["async", "send"] }
+num-bigint = { version = "0.4.6", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rustls = "0.21.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,18 +13,18 @@ rust-version = "1.70.0"
 
 [features]
 default = ["client", "rt-multi-thread"]
-backend = ["poem", "sqlx", "num-bigint"]
+backend = ["poem", "sqlx", "sqlx-pg-uint"]
 rt-multi-thread = ["tokio/rt-multi-thread"]
 rt = ["tokio/rt"]
 client = ["flate2"]
 voice = ["voice_udp", "voice_gateway"]
 voice_udp = ["dep:discortp", "dep:crypto_secretbox"]
 voice_gateway = []
-num-bigint = ["dep:num-bigint"]
+sqlx-pg-uint = ["dep:sqlx-pg-uint", "sqlx-pg-uint/serde"]
 
 [dependencies]
 tokio = { version = "1.38.1", features = ["macros", "sync"] }
-serde = { version = "1.0.204", features = ["derive", "rc"] }
+serde = { version = "1.0.208", features = ["derive", "rc"] }
 serde_json = { version = "1.0.120", features = ["raw_value"] }
 serde-aux = "4.5.0"
 serde_with = "3.9.0"
@@ -67,7 +67,7 @@ rand = "0.8.5"
 flate2 = { version = "1.0.30", optional = true }
 webpki-roots = "0.26.3"
 pubserve = { version = "1.1.0", features = ["async", "send"] }
-num-bigint = { version = "0.4.6", optional = true }
+sqlx-pg-uint = { version = "0.2.0", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rustls = "0.21.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,9 @@ rand = "0.8.5"
 flate2 = { version = "1.0.30", optional = true }
 webpki-roots = "0.26.3"
 pubserve = { version = "1.1.0", features = ["async", "send"] }
-sqlx-pg-uint = { version = "0.3.0", optional = true }
+sqlx-pg-uint = { git = "https://github.com/bitfl0wer/sqlx-pg-uint", features = [
+    "serde",
+], optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rustls = "0.21.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ rand = "0.8.5"
 flate2 = { version = "1.0.30", optional = true }
 webpki-roots = "0.26.3"
 pubserve = { version = "1.1.0", features = ["async", "send"] }
-sqlx-pg-uint = { version = "0.2.0", optional = true }
+sqlx-pg-uint = { version = "0.3.0", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rustls = "0.21.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,13 +82,13 @@ getrandom = { version = "0.2.15" }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.15", features = ["js"] }
 ws_stream_wasm = "0.7.4"
-wasm-bindgen-futures = "0.4.42"
+wasm-bindgen-futures = "0.4.43"
 wasmtimer = "0.2.0"
 
 [dev-dependencies]
 lazy_static = "1.5.0"
-wasm-bindgen-test = "0.3.42"
-wasm-bindgen = "0.2.92"
+wasm-bindgen-test = "0.3.43"
+wasm-bindgen = "0.2.93"
 simple_logger = { version = "5.0.0", default-features = false }
 
 [lints.rust]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,13 +49,11 @@ log = "0.4.22"
 async-trait = "0.1.81"
 chorus-macros = { path = "./chorus-macros", version = "0" } # Note: version here is used when releasing. This will use the latest release. Make sure to republish the crate when code in macros is changed!
 sqlx = { version = "0.8.0", features = [
-    "mysql",
-    "sqlite",
     "json",
     "chrono",
     "ipnetwork",
     "runtime-tokio-rustls",
-    "any",
+    "postgres",
 ], optional = true }
 discortp = { version = "0.5.0", optional = true, features = [
     "rtp",

--- a/chorus-macros/src/lib.rs
+++ b/chorus-macros/src/lib.rs
@@ -164,23 +164,23 @@ pub fn sqlx_bitflag_derive(input: TokenStream) -> TokenStream {
 
     quote!{
         #[cfg(feature = "sqlx")]
-        impl sqlx::Type<sqlx::Any> for #name {
-            fn type_info() -> sqlx::any::AnyTypeInfo {
-                <Vec<u8> as sqlx::Type<sqlx::Any>>::type_info()
+        impl sqlx::Type<sqlx::Postgres> for #name {
+            fn type_info() -> sqlx::postgres::PgTypeInfo {
+                <Vec<u8> as sqlx::Type<sqlx::Postgres>>::type_info()
             }
         }
 
         #[cfg(feature = "sqlx")]
-        impl<'q> sqlx::Encode<'q, sqlx::Any> for #name {
-            fn encode_by_ref(&self, buf: &mut <sqlx::Any as sqlx::Database>::ArgumentBuffer<'q>) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
-                <Vec<u8> as sqlx::Encode<sqlx::Any>>::encode_by_ref(&self.bits().to_be_bytes().into(), buf)
+        impl<'q> sqlx::Encode<'q, sqlx::Postgres> for #name {
+            fn encode_by_ref(&self, buf: &mut <sqlx::Postgres as sqlx::Database>::ArgumentBuffer<'q>) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
+                <Vec<u8> as sqlx::Encode<sqlx::Postgres>>::encode_by_ref(&self.bits().to_be_bytes().into(), buf)
             }
         }
 
         #[cfg(feature = "sqlx")]
-        impl<'q> sqlx::Decode<'q, sqlx::Any> for #name {
-            fn decode(value: <sqlx::Any as sqlx::Database>::ValueRef<'q>) -> Result<Self, sqlx::error::BoxDynError> {
-                let vec = <Vec<u8> as sqlx::Decode<sqlx::Any>>::decode(value)?;
+        impl<'q> sqlx::Decode<'q, sqlx::Postgres> for #name {
+            fn decode(value: <sqlx::Postgres as sqlx::Database>::ValueRef<'q>) -> Result<Self, sqlx::error::BoxDynError> {
+                let vec = <Vec<u8> as sqlx::Decode<sqlx::Postgres>>::decode(value)?;
                 Ok(Self::from_bits(vec_u8_to_u64(vec)).unwrap())
             }
         }

--- a/src/api/channels/messages.rs
+++ b/src/api/channels/messages.rs
@@ -16,6 +16,7 @@ use crate::types::{
 };
 
 impl Message {
+    #[allow(clippy::useless_conversion)]
     /// Sends a message in the channel with the provided channel_id.
     /// Returns the sent message.
     ///

--- a/src/api/channels/messages.rs
+++ b/src/api/channels/messages.rs
@@ -40,7 +40,7 @@ impl Message {
             chorus_request.deserialize_response::<Message>(user).await
         } else {
             for (index, attachment) in message.attachments.iter_mut().enumerate() {
-                attachment.get_mut(index).unwrap().id = Some(index as i16);
+                attachment.get_mut(index).unwrap().id = Some((index as u64).into());
             }
             let mut form = reqwest::multipart::Form::new();
             let payload_json = to_string(&message).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,8 +101,7 @@ This crate uses Semantic Versioning 2.0.0 as its versioning scheme. You can read
     clippy::extra_unused_lifetimes,
     clippy::from_over_into,
     clippy::needless_borrow,
-    clippy::new_without_default,
-    clippy::useless_conversion
+    clippy::new_without_default
 )]
 #![warn(
     clippy::todo,
@@ -111,7 +110,8 @@ This crate uses Semantic Versioning 2.0.0 as its versioning scheme. You can read
     clippy::print_stdout,
     clippy::print_stderr,
     missing_debug_implementations,
-    missing_copy_implementations
+    missing_copy_implementations,
+    clippy::useless_conversion
 )]
 #[cfg(all(feature = "rt", feature = "rt_multi_thread"))]
 compile_error!("feature \"rt\" and feature \"rt_multi_thread\" cannot be enabled at the same time");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,27 @@ pub mod types;
 ))]
 pub mod voice;
 
+#[cfg(not(feature = "sqlx"))]
+pub type UInt128 = u128;
+#[cfg(feature = "sqlx")]
+pub type UInt128 = sqlx_pg_uint::PgU128;
+#[cfg(not(feature = "sqlx"))]
+pub type UInt64 = u64;
+#[cfg(feature = "sqlx")]
+pub type UInt64 = sqlx_pg_uint::PgU64;
+#[cfg(not(feature = "sqlx"))]
+pub type UInt32 = u32;
+#[cfg(feature = "sqlx")]
+pub type UInt32 = sqlx_pg_uint::PgU32;
+#[cfg(not(feature = "sqlx"))]
+pub type UInt16 = u16;
+#[cfg(feature = "sqlx")]
+pub type UInt16 = sqlx_pg_uint::PgU16;
+#[cfg(not(feature = "sqlx"))]
+pub type UInt8 = u8;
+#[cfg(feature = "sqlx")]
+pub type UInt8 = sqlx_pg_uint::PgU8;
+
 #[derive(Clone, Default, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 /// A URLBundle bundles together the API-, Gateway- and CDN-URLs of a Spacebar instance.
 ///

--- a/src/types/config/types/guild_configuration.rs
+++ b/src/types/config/types/guild_configuration.rs
@@ -162,11 +162,11 @@ impl Display for GuildFeaturesList {
 }
 
 #[cfg(feature = "sqlx")]
-impl<'r> sqlx::Decode<'r, sqlx::Any> for GuildFeaturesList {
+impl<'r> sqlx::Decode<'r, sqlx::Postgres> for GuildFeaturesList {
     fn decode(
-        value: <sqlx::Any as sqlx::Database>::ValueRef<'r>,
+        value: <sqlx::Postgres as sqlx::Database>::ValueRef<'r>,
     ) -> Result<Self, sqlx::error::BoxDynError> {
-        let v = <String as sqlx::Decode<sqlx::Any>>::decode(value)?;
+        let v = <String as sqlx::Decode<sqlx::Postgres>>::decode(value)?;
         Ok(Self(
             v.split(',')
                 .filter(|f| !f.is_empty())
@@ -177,10 +177,10 @@ impl<'r> sqlx::Decode<'r, sqlx::Any> for GuildFeaturesList {
 }
 
 #[cfg(feature = "sqlx")]
-impl<'q> sqlx::Encode<'q, sqlx::Any> for GuildFeaturesList {
+impl<'q> sqlx::Encode<'q, sqlx::Postgres> for GuildFeaturesList {
     fn encode_by_ref(
         &self,
-        buf: &mut <sqlx::Any as sqlx::Database>::ArgumentBuffer<'q>,
+        buf: &mut <sqlx::Postgres as sqlx::Database>::ArgumentBuffer<'q>,
     ) -> Result<sqlx::encode::IsNull, Box<dyn std::error::Error + Send + Sync>> {
         if self.is_empty() {
             return Ok(sqlx::encode::IsNull::Yes);
@@ -191,18 +191,18 @@ impl<'q> sqlx::Encode<'q, sqlx::Any> for GuildFeaturesList {
             .collect::<Vec<_>>()
             .join(",");
 
-        <String as sqlx::Encode<sqlx::Any>>::encode_by_ref(&features, buf)
+        <String as sqlx::Encode<sqlx::Postgres>>::encode_by_ref(&features, buf)
     }
 }
 
 #[cfg(feature = "sqlx")]
-impl sqlx::Type<sqlx::Any> for GuildFeaturesList {
-    fn type_info() -> sqlx::any::AnyTypeInfo {
-        <String as sqlx::Type<sqlx::Any>>::type_info()
+impl sqlx::Type<sqlx::Postgres> for GuildFeaturesList {
+    fn type_info() -> <sqlx::Postgres as sqlx::Database>::TypeInfo {
+        <String as sqlx::Type<sqlx::Postgres>>::type_info()
     }
 
-    fn compatible(ty: &sqlx::any::AnyTypeInfo) -> bool {
-        <String as sqlx::Type<sqlx::Any>>::compatible(ty)
+    fn compatible(ty: &<sqlx::Postgres as sqlx::Database>::TypeInfo) -> bool {
+        <String as sqlx::Type<sqlx::Postgres>>::compatible(ty)
     }
 }
 

--- a/src/types/entities/application.rs
+++ b/src/types/entities/application.rs
@@ -225,7 +225,7 @@ pub struct ApplicationCommandOptionChoice {
 #[derive(Debug, Clone, Copy, Serialize_repr, Deserialize_repr, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[cfg_attr(not(feature = "sqlx"), repr(u8))]
-#[cfg_attr(feature = "sqlx", repr(i8))]
+#[cfg_attr(feature = "sqlx", repr(i16))]
 /// # Reference
 /// See <https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-types>
 pub enum ApplicationCommandOptionType {
@@ -296,7 +296,7 @@ pub struct ApplicationCommandPermission {
 )]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[cfg_attr(not(feature = "sqlx"), repr(u8))]
-#[cfg_attr(feature = "sqlx", repr(i8))]
+#[cfg_attr(feature = "sqlx", repr(i16))]
 /// See <https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permission-type>
 pub enum ApplicationCommandPermissionType {
     #[default]

--- a/src/types/entities/application.rs
+++ b/src/types/entities/application.rs
@@ -224,7 +224,8 @@ pub struct ApplicationCommandOptionChoice {
 
 #[derive(Debug, Clone, Copy, Serialize_repr, Deserialize_repr, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
-#[repr(i32)]
+#[cfg_attr(not(feature = "sqlx"), repr(u8))]
+#[cfg_attr(feature = "sqlx", repr(i8))]
 /// # Reference
 /// See <https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-types>
 pub enum ApplicationCommandOptionType {
@@ -294,7 +295,8 @@ pub struct ApplicationCommandPermission {
     Ord,
 )]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-#[repr(u8)]
+#[cfg_attr(not(feature = "sqlx"), repr(u8))]
+#[cfg_attr(feature = "sqlx", repr(i8))]
 /// See <https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permission-type>
 pub enum ApplicationCommandPermissionType {
     #[default]

--- a/src/types/entities/attachment.rs
+++ b/src/types/entities/attachment.rs
@@ -3,10 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "sqlx")]
-use sqlx_pg_uint::PgU64;
 
 use crate::types::utils::Snowflake;
+use crate::UInt64;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, PartialOrd)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
@@ -18,20 +17,11 @@ pub struct Attachment {
     /// Max 1024 characters
     pub description: Option<String>,
     pub content_type: Option<String>,
-    #[cfg(not(feature = "sqlx"))]
-    pub size: u64,
-    #[cfg(feature = "sqlx")]
-    pub size: PgU64,
+    pub size: UInt64,
     pub url: String,
     pub proxy_url: String,
-    #[cfg(not(feature = "sqlx"))]
-    pub height: Option<u64>,
-    #[cfg(feature = "sqlx")]
-    pub height: Option<PgU64>,
-    #[cfg(not(feature = "sqlx"))]
-    pub width: Option<u64>,
-    #[cfg(feature = "sqlx")]
-    pub width: Option<PgU64>,
+    pub height: Option<UInt64>,
+    pub width: Option<UInt64>,
     pub ephemeral: Option<bool>,
     /// The duration of the audio file (only for voice messages)
     pub duration_secs: Option<f32>,
@@ -48,18 +38,12 @@ pub struct Attachment {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct PartialDiscordFileAttachment {
-    #[cfg(not(feature = "sqlx"))]
-    pub id: Option<u64>,
-    #[cfg(feature = "sqlx")]
-    pub id: Option<PgU64>,
+    pub id: Option<UInt64>,
     pub filename: String,
     /// Max 1024 characters
     pub description: Option<String>,
     pub content_type: Option<String>,
-    #[cfg(not(feature = "sqlx"))]
-    pub size: Option<u64>,
-    #[cfg(feature = "sqlx")]
-    pub size: Option<PgU64>,
+    pub size: Option<UInt64>,
     pub url: Option<String>,
     pub proxy_url: Option<String>,
     pub height: Option<i32>,

--- a/src/types/entities/attachment.rs
+++ b/src/types/entities/attachment.rs
@@ -3,6 +3,8 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "sqlx")]
+use sqlx_pg_uint::PgU64;
 
 use crate::types::utils::Snowflake;
 
@@ -16,11 +18,20 @@ pub struct Attachment {
     /// Max 1024 characters
     pub description: Option<String>,
     pub content_type: Option<String>,
+    #[cfg(not(feature = "sqlx"))]
     pub size: u64,
+    #[cfg(feature = "sqlx")]
+    pub size: PgU64,
     pub url: String,
     pub proxy_url: String,
+    #[cfg(not(feature = "sqlx"))]
     pub height: Option<u64>,
+    #[cfg(feature = "sqlx")]
+    pub height: Option<PgU64>,
+    #[cfg(not(feature = "sqlx"))]
     pub width: Option<u64>,
+    #[cfg(feature = "sqlx")]
+    pub width: Option<PgU64>,
     pub ephemeral: Option<bool>,
     /// The duration of the audio file (only for voice messages)
     pub duration_secs: Option<f32>,
@@ -42,7 +53,10 @@ pub struct PartialDiscordFileAttachment {
     /// Max 1024 characters
     pub description: Option<String>,
     pub content_type: Option<String>,
-    pub size: Option<i64>,
+    #[cfg(not(feature = "sqlx"))]
+    pub size: Option<u64>,
+    #[cfg(feature = "sqlx")]
+    pub size: Option<PgU64>,
     pub url: Option<String>,
     pub proxy_url: Option<String>,
     pub height: Option<i32>,

--- a/src/types/entities/attachment.rs
+++ b/src/types/entities/attachment.rs
@@ -48,7 +48,10 @@ pub struct Attachment {
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct PartialDiscordFileAttachment {
-    pub id: Option<i16>,
+    #[cfg(not(feature = "sqlx"))]
+    pub id: Option<u64>,
+    #[cfg(feature = "sqlx")]
+    pub id: Option<PgU64>,
     pub filename: String,
     /// Max 1024 characters
     pub description: Option<String>,

--- a/src/types/entities/audit_log.rs
+++ b/src/types/entities/audit_log.rs
@@ -110,7 +110,8 @@ pub struct AuditLogChange {
     PartialOrd,
     Ord,
 )]
-#[repr(u8)]
+#[cfg_attr(not(feature = "sqlx"), repr(u8))]
+#[cfg_attr(feature = "sqlx", repr(i16))]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 /// # Reference:
 /// See <https://docs.discord.sex/resources/audit-log#audit-log-events>

--- a/src/types/entities/audit_log.rs
+++ b/src/types/entities/audit_log.rs
@@ -7,6 +7,8 @@ use super::option_vec_arc_rwlock_ptr_eq;
 
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
+#[cfg(feature = "sqlx")]
+use sqlx_pg_uint::PgU64;
 
 use crate::types::utils::Snowflake;
 use crate::types::{
@@ -251,16 +253,28 @@ pub struct AuditEntryInfo {
     pub auto_moderation_rule_trigger_type: Option<AutoModerationRuleTriggerType>,
     pub channel_id: Option<Snowflake>,
     // #[serde(option_string)]
+    #[cfg(not(feature = "sqlx"))]
     pub count: Option<u64>,
+    #[cfg(feature = "sqlx")]
+    pub count: Option<PgU64>,
     // #[serde(option_string)]
+    #[cfg(not(feature = "sqlx"))]
     pub delete_member_days: Option<u64>,
+    #[cfg(feature = "sqlx")]
+    pub delete_member_days: Option<PgU64>,
     /// The ID of the overwritten entity
     pub id: Option<Snowflake>,
     pub integration_type: Option<IntegrationType>,
     // #[serde(option_string)]
+    #[cfg(not(feature = "sqlx"))]
     pub members_removed: Option<u64>,
+    #[cfg(feature = "sqlx")]
+    pub members_removed: Option<PgU64>,
     // #[serde(option_string)]
+    #[cfg(not(feature = "sqlx"))]
     pub message_id: Option<u64>,
+    #[cfg(feature = "sqlx")]
+    pub message_id: Option<PgU64>,
     pub role_name: Option<String>,
     #[serde(rename = "type")]
     pub overwrite_type: Option<PermissionOverwriteType>,

--- a/src/types/entities/audit_log.rs
+++ b/src/types/entities/audit_log.rs
@@ -7,13 +7,12 @@ use super::option_vec_arc_rwlock_ptr_eq;
 
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-#[cfg(feature = "sqlx")]
-use sqlx_pg_uint::PgU64;
 
 use crate::types::utils::Snowflake;
 use crate::types::{
     AutoModerationRuleTriggerType, IntegrationType, PermissionOverwriteType, Shared,
 };
+use crate::UInt64;
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
@@ -254,28 +253,16 @@ pub struct AuditEntryInfo {
     pub auto_moderation_rule_trigger_type: Option<AutoModerationRuleTriggerType>,
     pub channel_id: Option<Snowflake>,
     // #[serde(option_string)]
-    #[cfg(not(feature = "sqlx"))]
-    pub count: Option<u64>,
-    #[cfg(feature = "sqlx")]
-    pub count: Option<PgU64>,
+    pub count: Option<UInt64>,
     // #[serde(option_string)]
-    #[cfg(not(feature = "sqlx"))]
-    pub delete_member_days: Option<u64>,
-    #[cfg(feature = "sqlx")]
-    pub delete_member_days: Option<PgU64>,
+    pub delete_member_days: Option<UInt64>,
     /// The ID of the overwritten entity
     pub id: Option<Snowflake>,
     pub integration_type: Option<IntegrationType>,
     // #[serde(option_string)]
-    #[cfg(not(feature = "sqlx"))]
-    pub members_removed: Option<u64>,
-    #[cfg(feature = "sqlx")]
-    pub members_removed: Option<PgU64>,
+    pub members_removed: Option<UInt64>,
     // #[serde(option_string)]
-    #[cfg(not(feature = "sqlx"))]
-    pub message_id: Option<u64>,
-    #[cfg(feature = "sqlx")]
-    pub message_id: Option<PgU64>,
+    pub message_id: Option<UInt64>,
     pub role_name: Option<String>,
     #[serde(rename = "type")]
     pub overwrite_type: Option<PermissionOverwriteType>,

--- a/src/types/entities/auto_moderation.rs
+++ b/src/types/entities/auto_moderation.rs
@@ -5,6 +5,7 @@
 #[cfg(feature = "client")]
 use crate::gateway::Updateable;
 use crate::types::Shared;
+use crate::UInt8;
 
 #[cfg(feature = "client")]
 use chorus_macros::Updateable;
@@ -86,10 +87,7 @@ pub struct AutoModerationRuleTriggerMetadataForKeywordPreset {
 /// See <https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-metadata>
 pub struct AutoModerationRuleTriggerMetadataForMentionSpam {
     /// Max 50
-    #[cfg(not(feature = "sqlx"))]
-    pub mention_total_limit: u8,
-    #[cfg(feature = "sqlx")]
-    pub mention_total_limit: sqlx_pg_uint::PgU8,
+    pub mention_total_limit: UInt8,
     pub mention_raid_protection_enabled: bool,
 }
 

--- a/src/types/entities/auto_moderation.rs
+++ b/src/types/entities/auto_moderation.rs
@@ -83,6 +83,7 @@ pub struct AutoModerationRuleTriggerMetadataForKeywordPreset {
     pub allow_list: Vec<String>,
 }
 
+#[allow(missing_copy_implementations)]
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord)]
 /// See <https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-metadata>
 pub struct AutoModerationRuleTriggerMetadataForMentionSpam {

--- a/src/types/entities/auto_moderation.rs
+++ b/src/types/entities/auto_moderation.rs
@@ -32,7 +32,8 @@ pub struct AutoModerationRule {
 }
 
 #[derive(Serialize_repr, Deserialize_repr, Debug, Clone, Default, Copy)]
-#[repr(u8)]
+#[cfg_attr(not(feature = "sqlx"), repr(u8))]
+#[cfg_attr(feature = "sqlx", repr(i8))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// See <https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-event-types>
 pub enum AutoModerationRuleEventType {
@@ -43,7 +44,8 @@ pub enum AutoModerationRuleEventType {
 #[derive(
     Serialize_repr, Deserialize_repr, Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Copy,
 )]
-#[repr(u8)]
+#[cfg_attr(not(feature = "sqlx"), repr(u8))]
+#[cfg_attr(feature = "sqlx", repr(i8))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// See <https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-types>
 pub enum AutoModerationRuleTriggerType {
@@ -80,18 +82,22 @@ pub struct AutoModerationRuleTriggerMetadataForKeywordPreset {
     pub allow_list: Vec<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Copy)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord)]
 /// See <https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-metadata>
 pub struct AutoModerationRuleTriggerMetadataForMentionSpam {
     /// Max 50
+    #[cfg(not(feature = "sqlx"))]
     pub mention_total_limit: u8,
+    #[cfg(feature = "sqlx")]
+    pub mention_total_limit: sqlx_pg_uint::PgU8,
     pub mention_raid_protection_enabled: bool,
 }
 
 #[derive(
     Serialize_repr, Deserialize_repr, Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Copy,
 )]
-#[repr(u8)]
+#[cfg_attr(not(feature = "sqlx"), repr(u8))]
+#[cfg_attr(feature = "sqlx", repr(i8))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// See <https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-preset-types>
 pub enum AutoModerationRuleKeywordPresetType {
@@ -110,9 +116,20 @@ pub struct AutoModerationAction {
 }
 
 #[derive(
-    Serialize_repr, Deserialize_repr, Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Copy, Hash
+    Serialize_repr,
+    Deserialize_repr,
+    Debug,
+    Clone,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Copy,
+    Hash,
 )]
-#[repr(u8)]
+#[cfg_attr(not(feature = "sqlx"), repr(u8))]
+#[cfg_attr(feature = "sqlx", repr(i8))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// See <https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-action-object-action-types>
 pub enum AutoModerationActionType {

--- a/src/types/entities/auto_moderation.rs
+++ b/src/types/entities/auto_moderation.rs
@@ -33,7 +33,7 @@ pub struct AutoModerationRule {
 
 #[derive(Serialize_repr, Deserialize_repr, Debug, Clone, Default, Copy)]
 #[cfg_attr(not(feature = "sqlx"), repr(u8))]
-#[cfg_attr(feature = "sqlx", repr(i8))]
+#[cfg_attr(feature = "sqlx", repr(i16))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// See <https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-event-types>
 pub enum AutoModerationRuleEventType {
@@ -45,7 +45,7 @@ pub enum AutoModerationRuleEventType {
     Serialize_repr, Deserialize_repr, Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Copy,
 )]
 #[cfg_attr(not(feature = "sqlx"), repr(u8))]
-#[cfg_attr(feature = "sqlx", repr(i8))]
+#[cfg_attr(feature = "sqlx", repr(i16))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// See <https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-types>
 pub enum AutoModerationRuleTriggerType {
@@ -97,7 +97,7 @@ pub struct AutoModerationRuleTriggerMetadataForMentionSpam {
     Serialize_repr, Deserialize_repr, Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Copy,
 )]
 #[cfg_attr(not(feature = "sqlx"), repr(u8))]
-#[cfg_attr(feature = "sqlx", repr(i8))]
+#[cfg_attr(feature = "sqlx", repr(i16))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// See <https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-preset-types>
 pub enum AutoModerationRuleKeywordPresetType {
@@ -129,7 +129,7 @@ pub struct AutoModerationAction {
     Hash,
 )]
 #[cfg_attr(not(feature = "sqlx"), repr(u8))]
-#[cfg_attr(feature = "sqlx", repr(i8))]
+#[cfg_attr(feature = "sqlx", repr(i16))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// See <https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-action-object-action-types>
 pub enum AutoModerationActionType {

--- a/src/types/entities/channel.rs
+++ b/src/types/entities/channel.rs
@@ -41,13 +41,7 @@ use super::{option_arc_rwlock_ptr_eq, option_vec_arc_rwlock_ptr_eq};
 /// See <https://discord-userdoccers.vercel.app/resources/channel#channels-resource>
 pub struct Channel {
     pub application_id: Option<Snowflake>,
-    #[cfg(feature = "sqlx")]
-    pub applied_tags: Option<sqlx::types::Json<Vec<String>>>,
-    #[cfg(not(feature = "sqlx"))]
     pub applied_tags: Option<Vec<String>>,
-    #[cfg(feature = "sqlx")]
-    pub available_tags: Option<sqlx::types::Json<Vec<Tag>>>,
-    #[cfg(not(feature = "sqlx"))]
     pub available_tags: Option<Vec<Tag>>,
     pub bitrate: Option<i32>,
     #[serde(rename = "type")]
@@ -55,9 +49,7 @@ pub struct Channel {
     pub created_at: Option<chrono::DateTime<Utc>>,
     pub default_auto_archive_duration: Option<i32>,
     pub default_forum_layout: Option<i32>,
-    #[cfg(feature = "sqlx")]
-    pub default_reaction_emoji: Option<sqlx::types::Json<DefaultReaction>>,
-    #[cfg(not(feature = "sqlx"))]
+    // DefaultReaction could be stored in a separate table. However, there are a lot of default emojis. How would we handle that?
     pub default_reaction_emoji: Option<DefaultReaction>,
     pub default_sort_order: Option<i32>,
     pub default_thread_rate_limit_per_user: Option<i32>,

--- a/src/types/entities/channel.rs
+++ b/src/types/entities/channel.rs
@@ -22,6 +22,7 @@ use crate::gateway::GatewayHandle;
 
 #[cfg(feature = "client")]
 use crate::gateway::Updateable;
+use crate::UInt64;
 
 #[cfg(feature = "client")]
 use chorus_macros::{observe_option_vec, Composite, Updateable};
@@ -296,10 +297,7 @@ pub struct ThreadMember {
     pub id: Option<Snowflake>,
     pub user_id: Option<Snowflake>,
     pub join_timestamp: Option<DateTime<Utc>>,
-    #[cfg(not(feature = "sqlx"))]
-    pub flags: Option<u64>,
-    #[cfg(feature = "sqlx")]
-    pub flags: Option<sqlx_pg_uint::PgU64>,
+    pub flags: Option<UInt64>,
     pub member: Option<Shared<GuildMember>>,
 }
 

--- a/src/types/entities/channel.rs
+++ b/src/types/entities/channel.rs
@@ -171,6 +171,8 @@ fn compare_permission_overwrites(
 ///
 /// # Reference
 /// See <https://discord-userdoccers.vercel.app/resources/channel#forum-tag-object>
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow, sqlx::Type))]
+#[cfg_attr(feature = "sqlx", sqlx(type_name = "interface_type"))]
 pub struct Tag {
     pub id: Snowflake,
     /// The name of the tag (max 20 characters)

--- a/src/types/entities/channel.rs
+++ b/src/types/entities/channel.rs
@@ -293,7 +293,10 @@ pub struct ThreadMember {
     pub id: Option<Snowflake>,
     pub user_id: Option<Snowflake>,
     pub join_timestamp: Option<DateTime<Utc>>,
+    #[cfg(not(feature = "sqlx"))]
     pub flags: Option<u64>,
+    #[cfg(feature = "sqlx")]
+    pub flags: Option<sqlx_pg_uint::PgU64>,
     pub member: Option<Shared<GuildMember>>,
 }
 

--- a/src/types/entities/channel.rs
+++ b/src/types/entities/channel.rs
@@ -317,6 +317,8 @@ impl PartialEq for ThreadMember {
 ///
 /// # Reference
 /// See <https://discord-userdoccers.vercel.app/resources/channel#default-reaction-object>
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow, sqlx::Type))]
+#[cfg_attr(feature = "sqlx", sqlx(type_name = "interface_type"))]
 pub struct DefaultReaction {
     #[serde(default)]
     pub emoji_id: Option<Snowflake>,

--- a/src/types/entities/channel.rs
+++ b/src/types/entities/channel.rs
@@ -342,7 +342,7 @@ pub struct DefaultReaction {
 )]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-#[repr(u32)]
+#[repr(i32)]
 /// # Reference
 /// See <https://discord-userdoccers.vercel.app/resources/channel#channel-type>
 pub enum ChannelType {

--- a/src/types/entities/channel.rs
+++ b/src/types/entities/channel.rs
@@ -194,7 +194,8 @@ pub struct PermissionOverwrite {
 }
 
 #[derive(Debug, Serialize_repr, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
-#[repr(u8)]
+#[cfg_attr(not(feature = "sqlx"), repr(u8))]
+#[cfg_attr(feature = "sqlx", repr(i16))]
 /// # Reference
 ///
 /// See <https://docs.discord.sex/resources/channel#permission-overwrite-type>

--- a/src/types/entities/emoji.rs
+++ b/src/types/entities/emoji.rs
@@ -32,9 +32,6 @@ use super::option_arc_rwlock_ptr_eq;
 pub struct Emoji {
     pub id: Snowflake,
     pub name: Option<String>,
-    #[cfg(feature = "sqlx")]
-    pub roles: Option<sqlx::types::Json<Vec<Snowflake>>>,
-    #[cfg(not(feature = "sqlx"))]
     pub roles: Option<Vec<Snowflake>>,
     #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub user: Option<Shared<User>>,

--- a/src/types/entities/guild.rs
+++ b/src/types/entities/guild.rs
@@ -303,7 +303,8 @@ impl PartialEq for GuildScheduledEvent {
 }
 
 #[derive(Serialize_repr, Deserialize_repr, Debug, Default, Clone, PartialEq, Copy)]
-#[repr(u8)]
+#[cfg_attr(not(feature = "sqlx"), repr(u8))]
+#[cfg_attr(feature = "sqlx", repr(i8))]
 /// See <https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-privacy-level>
 pub enum GuildScheduledEventPrivacyLevel {
     #[default]
@@ -311,7 +312,8 @@ pub enum GuildScheduledEventPrivacyLevel {
 }
 
 #[derive(Serialize_repr, Deserialize_repr, Debug, Default, Clone, PartialEq, Copy)]
-#[repr(u8)]
+#[cfg_attr(not(feature = "sqlx"), repr(u8))]
+#[cfg_attr(feature = "sqlx", repr(i8))]
 /// See <https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-status>
 pub enum GuildScheduledEventStatus {
     #[default]
@@ -334,7 +336,8 @@ pub enum GuildScheduledEventStatus {
     Copy,
     Hash,
 )]
-#[repr(u8)]
+#[cfg_attr(not(feature = "sqlx"), repr(u8))]
+#[cfg_attr(feature = "sqlx", repr(i8))]
 /// See <https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-types>
 pub enum GuildScheduledEventEntityType {
     #[default]
@@ -372,7 +375,8 @@ pub struct VoiceRegion {
     Ord,
 )]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
-#[repr(u8)]
+#[cfg_attr(not(feature = "sqlx"), repr(u8))]
+#[cfg_attr(feature = "sqlx", repr(i16))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// See <https://discord-userdoccers.vercel.app/resources/guild#message-notification-level>
 pub enum MessageNotificationLevel {
@@ -395,7 +399,8 @@ pub enum MessageNotificationLevel {
     Ord,
 )]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
-#[repr(u8)]
+#[cfg_attr(not(feature = "sqlx"), repr(u8))]
+#[cfg_attr(feature = "sqlx", repr(i8))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// See <https://discord-userdoccers.vercel.app/resources/guild#explicit-content-filter-level>
 pub enum ExplicitContentFilterLevel {
@@ -419,7 +424,8 @@ pub enum ExplicitContentFilterLevel {
     Ord,
 )]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
-#[repr(u8)]
+#[cfg_attr(not(feature = "sqlx"), repr(u8))]
+#[cfg_attr(feature = "sqlx", repr(i8))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// See <https://discord-userdoccers.vercel.app/resources/guild#verification-level>
 pub enum VerificationLevel {
@@ -445,7 +451,8 @@ pub enum VerificationLevel {
     Ord,
 )]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
-#[repr(u8)]
+#[cfg_attr(not(feature = "sqlx"), repr(u8))]
+#[cfg_attr(feature = "sqlx", repr(i8))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// See <https://discord-userdoccers.vercel.app/resources/guild#verification-level>
 pub enum MFALevel {
@@ -468,7 +475,8 @@ pub enum MFALevel {
     Ord,
 )]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
-#[repr(u8)]
+#[cfg_attr(not(feature = "sqlx"), repr(u8))]
+#[cfg_attr(feature = "sqlx", repr(i8))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// See <https://discord-userdoccers.vercel.app/resources/guild#verification-level>
 pub enum NSFWLevel {
@@ -493,7 +501,8 @@ pub enum NSFWLevel {
     Ord,
 )]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
-#[repr(u8)]
+#[cfg_attr(not(feature = "sqlx"), repr(u8))]
+#[cfg_attr(feature = "sqlx", repr(i8))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// See <https://discord-userdoccers.vercel.app/resources/guild#verification-level>
 pub enum PremiumTier {

--- a/src/types/entities/guild.rs
+++ b/src/types/entities/guild.rs
@@ -273,7 +273,10 @@ pub struct GuildScheduledEvent {
     pub entity_id: Option<Snowflake>,
     pub entity_metadata: Option<GuildScheduledEventEntityMetadata>,
     pub creator: Option<Shared<User>>,
+    #[cfg(not(feature = "sqlx"))]
     pub user_count: Option<u64>,
+    #[cfg(feature = "sqlx")]
+    pub user_count: Option<sqlx_pg_uint::PgU64>,
     pub image: Option<String>,
 }
 

--- a/src/types/entities/guild.rs
+++ b/src/types/entities/guild.rs
@@ -17,6 +17,7 @@ use crate::types::{
     interfaces::WelcomeScreenObject,
     utils::Snowflake,
 };
+use crate::UInt64;
 
 use super::{option_arc_rwlock_ptr_eq, vec_arc_rwlock_ptr_eq, PublicUser};
 
@@ -273,10 +274,7 @@ pub struct GuildScheduledEvent {
     pub entity_id: Option<Snowflake>,
     pub entity_metadata: Option<GuildScheduledEventEntityMetadata>,
     pub creator: Option<Shared<User>>,
-    #[cfg(not(feature = "sqlx"))]
-    pub user_count: Option<u64>,
-    #[cfg(feature = "sqlx")]
-    pub user_count: Option<sqlx_pg_uint::PgU64>,
+    pub user_count: Option<UInt64>,
     pub image: Option<String>,
 }
 

--- a/src/types/entities/guild.rs
+++ b/src/types/entities/guild.rs
@@ -304,7 +304,7 @@ impl PartialEq for GuildScheduledEvent {
 
 #[derive(Serialize_repr, Deserialize_repr, Debug, Default, Clone, PartialEq, Copy)]
 #[cfg_attr(not(feature = "sqlx"), repr(u8))]
-#[cfg_attr(feature = "sqlx", repr(i8))]
+#[cfg_attr(feature = "sqlx", repr(i16))]
 /// See <https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-privacy-level>
 pub enum GuildScheduledEventPrivacyLevel {
     #[default]
@@ -313,7 +313,7 @@ pub enum GuildScheduledEventPrivacyLevel {
 
 #[derive(Serialize_repr, Deserialize_repr, Debug, Default, Clone, PartialEq, Copy)]
 #[cfg_attr(not(feature = "sqlx"), repr(u8))]
-#[cfg_attr(feature = "sqlx", repr(i8))]
+#[cfg_attr(feature = "sqlx", repr(i16))]
 /// See <https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-status>
 pub enum GuildScheduledEventStatus {
     #[default]
@@ -337,7 +337,7 @@ pub enum GuildScheduledEventStatus {
     Hash,
 )]
 #[cfg_attr(not(feature = "sqlx"), repr(u8))]
-#[cfg_attr(feature = "sqlx", repr(i8))]
+#[cfg_attr(feature = "sqlx", repr(i16))]
 /// See <https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-types>
 pub enum GuildScheduledEventEntityType {
     #[default]
@@ -400,7 +400,7 @@ pub enum MessageNotificationLevel {
 )]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[cfg_attr(not(feature = "sqlx"), repr(u8))]
-#[cfg_attr(feature = "sqlx", repr(i8))]
+#[cfg_attr(feature = "sqlx", repr(i16))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// See <https://discord-userdoccers.vercel.app/resources/guild#explicit-content-filter-level>
 pub enum ExplicitContentFilterLevel {
@@ -425,7 +425,7 @@ pub enum ExplicitContentFilterLevel {
 )]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[cfg_attr(not(feature = "sqlx"), repr(u8))]
-#[cfg_attr(feature = "sqlx", repr(i8))]
+#[cfg_attr(feature = "sqlx", repr(i16))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// See <https://discord-userdoccers.vercel.app/resources/guild#verification-level>
 pub enum VerificationLevel {
@@ -452,7 +452,7 @@ pub enum VerificationLevel {
 )]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[cfg_attr(not(feature = "sqlx"), repr(u8))]
-#[cfg_attr(feature = "sqlx", repr(i8))]
+#[cfg_attr(feature = "sqlx", repr(i16))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// See <https://discord-userdoccers.vercel.app/resources/guild#verification-level>
 pub enum MFALevel {
@@ -476,7 +476,7 @@ pub enum MFALevel {
 )]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[cfg_attr(not(feature = "sqlx"), repr(u8))]
-#[cfg_attr(feature = "sqlx", repr(i8))]
+#[cfg_attr(feature = "sqlx", repr(i16))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// See <https://discord-userdoccers.vercel.app/resources/guild#verification-level>
 pub enum NSFWLevel {
@@ -502,7 +502,7 @@ pub enum NSFWLevel {
 )]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[cfg_attr(not(feature = "sqlx"), repr(u8))]
-#[cfg_attr(feature = "sqlx", repr(i8))]
+#[cfg_attr(feature = "sqlx", repr(i16))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// See <https://discord-userdoccers.vercel.app/resources/guild#verification-level>
 pub enum PremiumTier {

--- a/src/types/entities/integration.rs
+++ b/src/types/entities/integration.rs
@@ -23,8 +23,14 @@ pub struct Integration {
     pub syncing: Option<bool>,
     pub role_id: Option<String>,
     pub enabled_emoticons: Option<bool>,
+    #[cfg(not(feature = "sqlx"))]
     pub expire_behaviour: Option<u8>,
+    #[cfg(feature = "sqlx")]
+    pub expire_behaviour: Option<sqlx_pg_uint::PgU8>,
+    #[cfg(not(feature = "sqlx"))]
     pub expire_grace_period: Option<u16>,
+    #[cfg(feature = "sqlx")]
+    pub expire_grace_period: Option<sqlx_pg_uint::PgU16>,
     #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub user: Option<Shared<User>>,
     #[cfg_attr(feature = "sqlx", sqlx(skip))]

--- a/src/types/entities/integration.rs
+++ b/src/types/entities/integration.rs
@@ -10,6 +10,7 @@ use crate::types::{
     utils::Snowflake,
     Shared,
 };
+use crate::{UInt16, UInt8};
 
 #[derive(Default, Debug, Deserialize, Serialize, Clone)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
@@ -23,14 +24,8 @@ pub struct Integration {
     pub syncing: Option<bool>,
     pub role_id: Option<String>,
     pub enabled_emoticons: Option<bool>,
-    #[cfg(not(feature = "sqlx"))]
-    pub expire_behaviour: Option<u8>,
-    #[cfg(feature = "sqlx")]
-    pub expire_behaviour: Option<sqlx_pg_uint::PgU8>,
-    #[cfg(not(feature = "sqlx"))]
-    pub expire_grace_period: Option<u16>,
-    #[cfg(feature = "sqlx")]
-    pub expire_grace_period: Option<sqlx_pg_uint::PgU16>,
+    pub expire_behaviour: Option<UInt8>,
+    pub expire_grace_period: Option<UInt16>,
     #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub user: Option<Shared<User>>,
     #[cfg_attr(feature = "sqlx", sqlx(skip))]

--- a/src/types/entities/invite.rs
+++ b/src/types/entities/invite.rs
@@ -10,6 +10,7 @@ use crate::types::{
     Guild, InviteFlags, InviteTargetType, InviteType, Shared, Snowflake, VerificationLevel,
     WelcomeScreenObject,
 };
+use crate::{UInt32, UInt8};
 
 use super::guild::GuildScheduledEvent;
 use super::{Application, Channel, GuildMember, NSFWLevel, User};
@@ -39,14 +40,8 @@ pub struct Invite {
     pub invite_type: Option<InviteType>,
     #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub inviter: Option<User>,
-    #[cfg(not(feature = "sqlx"))]
-    pub max_age: Option<u32>,
-    #[cfg(feature = "sqlx")]
-    pub max_age: Option<sqlx_pg_uint::PgU32>,
-    #[cfg(not(feature = "sqlx"))]
-    pub max_uses: Option<u8>,
-    #[cfg(feature = "sqlx")]
-    pub max_uses: Option<sqlx_pg_uint::PgU8>,
+    pub max_age: Option<UInt32>,
+    pub max_uses: Option<UInt8>,
     #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub stage_instance: Option<InviteStageInstance>,
     #[cfg_attr(feature = "sqlx", sqlx(skip))]
@@ -56,10 +51,7 @@ pub struct Invite {
     #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub target_user: Option<User>,
     pub temporary: Option<bool>,
-    #[cfg(not(feature = "sqlx"))]
-    pub uses: Option<u32>,
-    #[cfg(feature = "sqlx")]
-    pub uses: Option<sqlx_pg_uint::PgU32>,
+    pub uses: Option<UInt32>,
 }
 
 /// The guild an invite is for.

--- a/src/types/entities/invite.rs
+++ b/src/types/entities/invite.rs
@@ -5,8 +5,11 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::types::{Snowflake, WelcomeScreenObject, Shared, InviteFlags, InviteType, InviteTargetType, Guild, VerificationLevel};
 use crate::types::types::guild_configuration::GuildFeaturesList;
+use crate::types::{
+    Guild, InviteFlags, InviteTargetType, InviteType, Shared, Snowflake, VerificationLevel,
+    WelcomeScreenObject,
+};
 
 use super::guild::GuildScheduledEvent;
 use super::{Application, Channel, GuildMember, NSFWLevel, User};
@@ -36,8 +39,14 @@ pub struct Invite {
     pub invite_type: Option<InviteType>,
     #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub inviter: Option<User>,
+    #[cfg(not(feature = "sqlx"))]
     pub max_age: Option<u32>,
+    #[cfg(feature = "sqlx")]
+    pub max_age: Option<sqlx_pg_uint::PgU32>,
+    #[cfg(not(feature = "sqlx"))]
     pub max_uses: Option<u8>,
+    #[cfg(feature = "sqlx")]
+    pub max_uses: Option<sqlx_pg_uint::PgU8>,
     #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub stage_instance: Option<InviteStageInstance>,
     #[cfg_attr(feature = "sqlx", sqlx(skip))]
@@ -47,7 +56,10 @@ pub struct Invite {
     #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub target_user: Option<User>,
     pub temporary: Option<bool>,
+    #[cfg(not(feature = "sqlx"))]
     pub uses: Option<u32>,
+    #[cfg(feature = "sqlx")]
+    pub uses: Option<sqlx_pg_uint::PgU32>,
 }
 
 /// The guild an invite is for.

--- a/src/types/entities/message.rs
+++ b/src/types/entities/message.rs
@@ -150,7 +150,10 @@ pub enum MessageReferenceType {
 pub struct MessageInteraction {
     pub id: Snowflake,
     #[serde(rename = "type")]
+    #[cfg(not(feature = "sqlx"))]
     pub interaction_type: u8,
+    #[cfg(feature = "sqlx")]
+    pub interaction_type: sqlx_pg_uint::PgU8,
     pub name: String,
     pub user: User,
     pub member: Option<Shared<GuildMember>>,
@@ -282,8 +285,14 @@ pub struct EmbedField {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Reaction {
+    #[cfg(not(feature = "sqlx"))]
     pub count: u32,
+    #[cfg(feature = "sqlx")]
+    pub count: sqlx_pg_uint::PgU32,
+    #[cfg(not(feature = "sqlx"))]
     pub burst_count: u32,
+    #[cfg(feature = "sqlx")]
+    pub burst_count: sqlx_pg_uint::PgU32,
     #[serde(default)]
     pub me: bool,
     #[serde(default)]
@@ -296,6 +305,8 @@ pub struct Reaction {
 }
 
 #[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize, Eq, PartialOrd, Ord)]
+#[cfg_attr(not(feature = "sqlx"), repr(u8))]
+#[cfg_attr(feature = "sqlx", repr(i16))]
 pub enum Component {
     ActionRow = 1,
     Button = 2,
@@ -320,7 +331,8 @@ pub struct MessageActivity {
     Debug, Default, PartialEq, Clone, Copy, Serialize_repr, Deserialize_repr, Eq, PartialOrd, Ord,
 )]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-#[repr(u8)]
+#[cfg_attr(not(feature = "sqlx"), repr(u8))]
+#[cfg_attr(feature = "sqlx", repr(i16))]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 /// # Reference
 /// See <https://docs.discord.sex/resources/message#message-type>
@@ -464,7 +476,8 @@ pub struct PartialEmoji {
 #[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize, PartialOrd, Ord, Eq, Hash)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
-#[repr(u8)]
+#[cfg_attr(not(feature = "sqlx"), repr(u8))]
+#[cfg_attr(feature = "sqlx", repr(i16))]
 pub enum ReactionType {
     Normal = 0,
     Burst = 1, // The dreaded super reactions

--- a/src/types/entities/message.rs
+++ b/src/types/entities/message.rs
@@ -15,6 +15,7 @@ use crate::types::{
     utils::Snowflake,
     Shared,
 };
+use crate::{UInt32, UInt8};
 
 use super::option_arc_rwlock_ptr_eq;
 
@@ -150,10 +151,7 @@ pub enum MessageReferenceType {
 pub struct MessageInteraction {
     pub id: Snowflake,
     #[serde(rename = "type")]
-    #[cfg(not(feature = "sqlx"))]
-    pub interaction_type: u8,
-    #[cfg(feature = "sqlx")]
-    pub interaction_type: sqlx_pg_uint::PgU8,
+    pub interaction_type: UInt8,
     pub name: String,
     pub user: User,
     pub member: Option<Shared<GuildMember>>,
@@ -285,14 +283,8 @@ pub struct EmbedField {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Reaction {
-    #[cfg(not(feature = "sqlx"))]
-    pub count: u32,
-    #[cfg(feature = "sqlx")]
-    pub count: sqlx_pg_uint::PgU32,
-    #[cfg(not(feature = "sqlx"))]
-    pub burst_count: u32,
-    #[cfg(feature = "sqlx")]
-    pub burst_count: sqlx_pg_uint::PgU32,
+    pub count: UInt32,
+    pub burst_count: UInt32,
     #[serde(default)]
     pub me: bool,
     #[serde(default)]

--- a/src/types/entities/relationship.rs
+++ b/src/types/entities/relationship.rs
@@ -45,7 +45,8 @@ impl PartialEq for Relationship {
     Copy,
     Hash,
 )]
-#[repr(u8)]
+#[cfg_attr(not(feature = "sqlx"), repr(u8))]
+#[cfg_attr(feature = "sqlx", repr(i16))]
 /// See <https://discord-userdoccers.vercel.app/resources/user#relationship-type>
 pub enum RelationshipType {
     Suggestion = 6,

--- a/src/types/entities/role.rs
+++ b/src/types/entities/role.rs
@@ -8,6 +8,7 @@ use serde_aux::prelude::deserialize_option_number_from_string;
 use std::fmt::Debug;
 
 use crate::types::utils::Snowflake;
+use crate::{UInt16, UInt32};
 
 #[cfg(feature = "client")]
 use chorus_macros::{Composite, Updateable};
@@ -32,10 +33,7 @@ pub struct RoleObject {
     pub hoist: bool,
     pub icon: Option<String>,
     pub unicode_emoji: Option<String>,
-    #[cfg(not(feature = "sqlx"))]
-    pub position: u16,
-    #[cfg(feature = "sqlx")]
-    pub position: sqlx_pg_uint::PgU16,
+    pub position: UInt16,
     #[serde(default)]
     pub permissions: PermissionFlags,
     pub managed: bool,
@@ -50,10 +48,7 @@ pub struct RoleObject {
 pub struct RoleSubscriptionData {
     pub role_subscription_listing_id: Snowflake,
     pub tier_name: String,
-    #[cfg(not(feature = "sqlx"))]
-    pub total_months_subscribed: u32,
-    #[cfg(feature = "sqlx")]
-    pub total_months_subscribed: sqlx_pg_uint::PgU32,
+    pub total_months_subscribed: UInt32,
     pub is_renewal: bool,
 }
 

--- a/src/types/entities/role.rs
+++ b/src/types/entities/role.rs
@@ -32,7 +32,10 @@ pub struct RoleObject {
     pub hoist: bool,
     pub icon: Option<String>,
     pub unicode_emoji: Option<String>,
+    #[cfg(not(feature = "sqlx"))]
     pub position: u16,
+    #[cfg(feature = "sqlx")]
+    pub position: sqlx_pg_uint::PgU16,
     #[serde(default)]
     pub permissions: PermissionFlags,
     pub managed: bool,
@@ -47,11 +50,16 @@ pub struct RoleObject {
 pub struct RoleSubscriptionData {
     pub role_subscription_listing_id: Snowflake,
     pub tier_name: String,
+    #[cfg(not(feature = "sqlx"))]
     pub total_months_subscribed: u32,
+    #[cfg(feature = "sqlx")]
+    pub total_months_subscribed: sqlx_pg_uint::PgU32,
     pub is_renewal: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq, Hash, Copy, PartialOrd, Ord)]
+#[derive(
+    Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq, Hash, Copy, PartialOrd, Ord,
+)]
 /// See <https://discord.com/developers/docs/topics/permissions#role-object-role-tags-structure>
 pub struct RoleTags {
     #[serde(default)]

--- a/src/types/entities/security_key.rs
+++ b/src/types/entities/security_key.rs
@@ -25,7 +25,8 @@ impl Default for SecurityKey {
             user_id: String::new(),
             key_id: String::new(),
             public_key: String::new(),
-            counter: 0.into(),
+            #[allow(clippy::useless_conversion)]
+            counter: 0u64.into(),
             name: String::new(),
         }
     }

--- a/src/types/entities/security_key.rs
+++ b/src/types/entities/security_key.rs
@@ -13,7 +13,10 @@ pub struct SecurityKey {
     pub user_id: String,
     pub key_id: String,
     pub public_key: String,
+    #[cfg(not(feature = "sqlx"))]
     pub counter: u64,
+    #[cfg(feature = "sqlx")]
+    pub counter: sqlx_pg_uint::PgU64,
     pub name: String,
 }
 
@@ -24,7 +27,10 @@ impl Default for SecurityKey {
             user_id: String::new(),
             key_id: String::new(),
             public_key: String::new(),
+            #[cfg(not(feature = "sqlx"))]
             counter: 0,
+            #[cfg(feature = "sqlx")]
+            counter: sqlx_pg_uint::PgU64::from(0),
             name: String::new(),
         }
     }

--- a/src/types/entities/security_key.rs
+++ b/src/types/entities/security_key.rs
@@ -5,6 +5,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::types::utils::Snowflake;
+use crate::UInt64;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
@@ -13,10 +14,7 @@ pub struct SecurityKey {
     pub user_id: String,
     pub key_id: String,
     pub public_key: String,
-    #[cfg(not(feature = "sqlx"))]
-    pub counter: u64,
-    #[cfg(feature = "sqlx")]
-    pub counter: sqlx_pg_uint::PgU64,
+    pub counter: UInt64,
     pub name: String,
 }
 
@@ -27,10 +25,7 @@ impl Default for SecurityKey {
             user_id: String::new(),
             key_id: String::new(),
             public_key: String::new(),
-            #[cfg(not(feature = "sqlx"))]
-            counter: 0,
-            #[cfg(feature = "sqlx")]
-            counter: sqlx_pg_uint::PgU64::from(0),
+            counter: 0.into(),
             name: String::new(),
         }
     }

--- a/src/types/entities/stage_instance.rs
+++ b/src/types/entities/stage_instance.rs
@@ -21,8 +21,11 @@ pub struct StageInstance {
     pub guild_scheduled_event_id: Option<Snowflake>,
 }
 
-#[derive(Serialize_repr, Deserialize_repr, Debug, Clone, Default, Copy, PartialEq, Eq, PartialOrd, Ord)]
-#[repr(u8)]
+#[derive(
+    Serialize_repr, Deserialize_repr, Debug, Clone, Default, Copy, PartialEq, Eq, PartialOrd, Ord,
+)]
+#[cfg_attr(not(feature = "sqlx"), repr(u8))]
+#[cfg_attr(feature = "sqlx", repr(i16))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// See <https://discord.com/developers/docs/resources/stage-instance#stage-instance-object-privacy-level>
 pub enum StageInstancePrivacyLevel {

--- a/src/types/entities/sticker.rs
+++ b/src/types/entities/sticker.rs
@@ -77,7 +77,8 @@ pub struct StickerItem {
 #[derive(
     Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Hash, Serialize_repr, Deserialize_repr,
 )]
-#[repr(u8)]
+#[cfg_attr(not(feature = "sqlx"), repr(u8))]
+#[cfg_attr(feature = "sqlx", repr(i16))]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[serde(rename = "SCREAMING_SNAKE_CASE")]
 /// # Reference
@@ -93,7 +94,8 @@ pub enum StickerType {
 #[derive(
     Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Hash, Serialize_repr, Deserialize_repr,
 )]
-#[repr(u8)]
+#[cfg_attr(not(feature = "sqlx"), repr(u8))]
+#[cfg_attr(feature = "sqlx", repr(i16))]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 /// # Reference
 /// See <https://docs.discord.sex/resources/sticker#sticker-format-types>

--- a/src/types/entities/team.rs
+++ b/src/types/entities/team.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::types::entities::User;
 use crate::types::Shared;
 use crate::types::Snowflake;
+use crate::UInt8;
 
 use super::arc_rwlock_ptr_eq;
 
@@ -34,10 +35,7 @@ impl PartialEq for Team {
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct TeamMember {
-    #[cfg(not(feature = "sqlx"))]
-    pub membership_state: u8,
-    #[cfg(feature = "sqlx")]
-    pub membership_state: sqlx_pg_uint::PgU8,
+    pub membership_state: UInt8,
     pub permissions: Vec<String>,
     pub team_id: Snowflake,
     pub user: Shared<User>,

--- a/src/types/entities/team.rs
+++ b/src/types/entities/team.rs
@@ -34,7 +34,10 @@ impl PartialEq for Team {
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct TeamMember {
+    #[cfg(not(feature = "sqlx"))]
     pub membership_state: u8,
+    #[cfg(feature = "sqlx")]
+    pub membership_state: sqlx_pg_uint::PgU8,
     pub permissions: Vec<String>,
     pub team_id: Snowflake,
     pub user: Shared<User>,

--- a/src/types/entities/template.rs
+++ b/src/types/entities/template.rs
@@ -6,9 +6,9 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::types::{
-    Shared,
     entities::{Guild, User},
     utils::Snowflake,
+    Shared,
 };
 
 /// See <https://docs.spacebar.chat/routes/#cmp--schemas-template>
@@ -18,7 +18,10 @@ pub struct GuildTemplate {
     pub code: String,
     pub name: String,
     pub description: Option<String>,
+    #[cfg(not(feature = "sqlx"))]
     pub usage_count: Option<u64>,
+    #[cfg(feature = "sqlx")]
+    pub usage_count: Option<sqlx_pg_uint::PgU64>,
     pub creator_id: Snowflake,
     #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub creator: Shared<User>,

--- a/src/types/entities/template.rs
+++ b/src/types/entities/template.rs
@@ -10,6 +10,7 @@ use crate::types::{
     utils::Snowflake,
     Shared,
 };
+use crate::UInt64;
 
 /// See <https://docs.spacebar.chat/routes/#cmp--schemas-template>
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
@@ -18,10 +19,7 @@ pub struct GuildTemplate {
     pub code: String,
     pub name: String,
     pub description: Option<String>,
-    #[cfg(not(feature = "sqlx"))]
-    pub usage_count: Option<u64>,
-    #[cfg(feature = "sqlx")]
-    pub usage_count: Option<sqlx_pg_uint::PgU64>,
+    pub usage_count: Option<UInt64>,
     pub creator_id: Snowflake,
     #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub creator: Shared<User>,

--- a/src/types/entities/user.rs
+++ b/src/types/entities/user.rs
@@ -47,7 +47,10 @@ pub struct User {
     pub bot: Option<bool>,
     pub system: Option<bool>,
     pub mfa_enabled: Option<bool>,
+    #[cfg(not(feature = "sqlx"))]
     pub accent_color: Option<u32>,
+    #[cfg(feature = "sqlx")]
+    pub accent_color: Option<sqlx_pg_uint::PgU32>,
     #[cfg_attr(feature = "sqlx", sqlx(default))]
     pub locale: Option<String>,
     pub verified: Option<bool>,
@@ -58,7 +61,10 @@ pub struct User {
     #[serde(deserialize_with = "deserialize_option_number_from_string")]
     pub flags: Option<UserFlags>,
     pub premium_since: Option<DateTime<Utc>>,
+    #[cfg(not(feature = "sqlx"))]
     pub premium_type: Option<u8>,
+    #[cfg(feature = "sqlx")]
+    pub premium_type: Option<sqlx_pg_uint::PgU8>,
     pub pronouns: Option<String>,
     pub public_flags: Option<UserFlags>,
     pub banner: Option<String>,
@@ -144,13 +150,19 @@ pub struct PublicUser {
     pub username: Option<String>,
     pub discriminator: Option<String>,
     pub avatar: Option<String>,
+    #[cfg(not(feature = "sqlx"))]
     pub accent_color: Option<u32>,
+    #[cfg(feature = "sqlx")]
+    pub accent_color: Option<sqlx_pg_uint::PgU32>,
     pub banner: Option<String>,
     pub theme_colors: Option<ThemeColors>,
     pub pronouns: Option<String>,
     pub bot: Option<bool>,
     pub bio: Option<String>,
+    #[cfg(not(feature = "sqlx"))]
     pub premium_type: Option<u8>,
+    #[cfg(feature = "sqlx")]
+    pub premium_type: Option<sqlx_pg_uint::PgU8>,
     pub premium_since: Option<DateTime<Utc>>,
     pub public_flags: Option<UserFlags>,
 }

--- a/src/types/entities/user.rs
+++ b/src/types/entities/user.rs
@@ -4,6 +4,7 @@
 
 use crate::errors::ChorusError;
 use crate::types::utils::Snowflake;
+use crate::{UInt32, UInt8};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_aux::prelude::deserialize_option_number_from_string;
@@ -47,10 +48,7 @@ pub struct User {
     pub bot: Option<bool>,
     pub system: Option<bool>,
     pub mfa_enabled: Option<bool>,
-    #[cfg(not(feature = "sqlx"))]
-    pub accent_color: Option<u32>,
-    #[cfg(feature = "sqlx")]
-    pub accent_color: Option<sqlx_pg_uint::PgU32>,
+    pub accent_color: Option<UInt32>,
     #[cfg_attr(feature = "sqlx", sqlx(default))]
     pub locale: Option<String>,
     pub verified: Option<bool>,
@@ -61,10 +59,7 @@ pub struct User {
     #[serde(deserialize_with = "deserialize_option_number_from_string")]
     pub flags: Option<UserFlags>,
     pub premium_since: Option<DateTime<Utc>>,
-    #[cfg(not(feature = "sqlx"))]
-    pub premium_type: Option<u8>,
-    #[cfg(feature = "sqlx")]
-    pub premium_type: Option<sqlx_pg_uint::PgU8>,
+    pub premium_type: Option<UInt8>,
     pub pronouns: Option<String>,
     pub public_flags: Option<UserFlags>,
     pub banner: Option<String>,
@@ -150,19 +145,13 @@ pub struct PublicUser {
     pub username: Option<String>,
     pub discriminator: Option<String>,
     pub avatar: Option<String>,
-    #[cfg(not(feature = "sqlx"))]
-    pub accent_color: Option<u32>,
-    #[cfg(feature = "sqlx")]
-    pub accent_color: Option<sqlx_pg_uint::PgU32>,
+    pub accent_color: Option<UInt32>,
     pub banner: Option<String>,
     pub theme_colors: Option<ThemeColors>,
     pub pronouns: Option<String>,
     pub bot: Option<bool>,
     pub bio: Option<String>,
-    #[cfg(not(feature = "sqlx"))]
-    pub premium_type: Option<u8>,
-    #[cfg(feature = "sqlx")]
-    pub premium_type: Option<sqlx_pg_uint::PgU8>,
+    pub premium_type: Option<UInt8>,
     pub premium_since: Option<DateTime<Utc>>,
     pub public_flags: Option<UserFlags>,
 }

--- a/src/types/entities/user.rs
+++ b/src/types/entities/user.rs
@@ -109,32 +109,32 @@ impl TryFrom<Vec<u8>> for ThemeColors {
 
 #[cfg(feature = "sqlx")]
 // TODO: Add tests for Encode and Decode.
-impl<'q> sqlx::Encode<'q, sqlx::Any> for ThemeColors {
+impl<'q> sqlx::Encode<'q, sqlx::Postgres> for ThemeColors {
     fn encode_by_ref(
         &self,
-        buf: &mut <sqlx::Any as sqlx::Database>::ArgumentBuffer<'q>,
+        buf: &mut <sqlx::Postgres as sqlx::Database>::ArgumentBuffer<'q>,
     ) -> Result<sqlx::encode::IsNull, Box<dyn std::error::Error + Send + Sync>> {
         let mut vec_u8 = Vec::new();
         vec_u8.extend_from_slice(&self.inner.0.to_be_bytes());
         vec_u8.extend_from_slice(&self.inner.1.to_be_bytes());
-        <Vec<u8> as sqlx::Encode<sqlx::Any>>::encode_by_ref(&vec_u8, buf)
+        <Vec<u8> as sqlx::Encode<sqlx::Postgres>>::encode_by_ref(&vec_u8, buf)
     }
 }
 
 #[cfg(feature = "sqlx")]
-impl<'d> sqlx::Decode<'d, sqlx::Any> for ThemeColors {
+impl<'d> sqlx::Decode<'d, sqlx::Postgres> for ThemeColors {
     fn decode(
-        value: <sqlx::Any as sqlx::Database>::ValueRef<'d>,
+        value: <sqlx::Postgres as sqlx::Database>::ValueRef<'d>,
     ) -> Result<Self, sqlx::error::BoxDynError> {
-        let value_vec = <Vec<u8> as sqlx::Decode<'d, sqlx::Any>>::decode(value)?;
+        let value_vec = <Vec<u8> as sqlx::Decode<'d, sqlx::Postgres>>::decode(value)?;
         value_vec.try_into().map_err(|e: ChorusError| e.into())
     }
 }
 
 #[cfg(feature = "sqlx")]
-impl sqlx::Type<sqlx::Any> for ThemeColors {
-    fn type_info() -> <sqlx::Any as sqlx::Database>::TypeInfo {
-        <String as sqlx::Type<sqlx::Any>>::type_info()
+impl sqlx::Type<sqlx::Postgres> for ThemeColors {
+    fn type_info() -> <sqlx::Postgres as sqlx::Database>::TypeInfo {
+        <String as sqlx::Type<sqlx::Postgres>>::type_info()
     }
 }
 

--- a/src/types/entities/user_settings.rs
+++ b/src/types/entities/user_settings.rs
@@ -42,7 +42,10 @@ pub enum UserTheme {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 pub struct UserSettings {
+    #[cfg(not(feature = "sqlx"))]
     pub afk_timeout: Option<u16>,
+    #[cfg(feature = "sqlx")]
+    pub afk_timeout: Option<sqlx_pg_uint::PgU16>,
     pub allow_accessibility_detection: bool,
     pub animate_emoji: bool,
     #[cfg(not(feature = "sqlx"))]
@@ -85,7 +88,7 @@ pub struct UserSettings {
 impl Default for UserSettings {
     fn default() -> Self {
         Self {
-            afk_timeout: Some(3600),
+            afk_timeout: Some(3600.into()),
             allow_accessibility_detection: true,
             animate_emoji: true,
             #[cfg(not(feature = "sqlx"))]
@@ -137,6 +140,7 @@ pub struct CustomStatus {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 pub struct FriendSourceFlags {
     pub all: bool,
 }
@@ -148,6 +152,7 @@ impl Default for FriendSourceFlags {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 pub struct GuildFolder {
     #[cfg(not(feature = "sqlx"))]
     pub color: Option<u32>,

--- a/src/types/entities/user_settings.rs
+++ b/src/types/entities/user_settings.rs
@@ -8,7 +8,9 @@ use serde::{Deserialize, Serialize};
 use crate::types::Shared;
 use serde_aux::field_attributes::deserialize_option_number_from_string;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default, Copy, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default, Copy, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[serde(rename_all = "lowercase")]
 pub enum UserStatus {
@@ -26,7 +28,9 @@ impl std::fmt::Display for UserStatus {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default, Copy, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default, Copy, PartialOrd, Ord, Hash,
+)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[serde(rename_all = "lowercase")]
 pub enum UserTheme {
@@ -44,9 +48,6 @@ pub struct UserSettings {
     pub animate_stickers: u8,
     pub contact_sync_enabled: bool,
     pub convert_emoticons: bool,
-    #[cfg(feature = "sqlx")]
-    pub custom_status: Option<sqlx::types::Json<CustomStatus>>,
-    #[cfg(not(feature = "sqlx"))]
     pub custom_status: Option<CustomStatus>,
     pub default_guilds_restricted: bool,
     pub detect_platform_accounts: bool,
@@ -54,20 +55,10 @@ pub struct UserSettings {
     pub disable_games_tab: bool,
     pub enable_tts_command: bool,
     pub explicit_content_filter: u8,
-    #[cfg(feature = "sqlx")]
-    pub friend_source_flags: sqlx::types::Json<FriendSourceFlags>,
-    #[cfg(not(feature = "sqlx"))]
     pub friend_source_flags: FriendSourceFlags,
     pub gateway_connected: Option<bool>,
     pub gif_auto_play: bool,
-    #[cfg(feature = "sqlx")]
-    pub guild_folders: sqlx::types::Json<Vec<GuildFolder>>,
-    #[cfg(not(feature = "sqlx"))]
     pub guild_folders: Vec<GuildFolder>,
-    #[cfg(feature = "sqlx")]
-    #[serde(default)]
-    pub guild_positions: sqlx::types::Json<Vec<String>>,
-    #[cfg(not(feature = "sqlx"))]
     #[serde(default)]
     pub guild_positions: Vec<String>,
     pub inline_attachment_media: bool,
@@ -77,9 +68,6 @@ pub struct UserSettings {
     pub native_phone_integration_enabled: bool,
     pub render_embeds: bool,
     pub render_reactions: bool,
-    #[cfg(feature = "sqlx")]
-    pub restricted_guilds: sqlx::types::Json<Vec<String>>,
-    #[cfg(not(feature = "sqlx"))]
     pub restricted_guilds: Vec<String>,
     pub show_current_game: bool,
     pub status: Shared<UserStatus>,

--- a/src/types/entities/user_settings.rs
+++ b/src/types/entities/user_settings.rs
@@ -140,7 +140,7 @@ pub struct CustomStatus {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow, sqlx::Type))]
 pub struct FriendSourceFlags {
     pub all: bool,
 }
@@ -152,7 +152,8 @@ impl Default for FriendSourceFlags {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow, sqlx::Type))]
+#[cfg_attr(feature = "sqlx", sqlx(type_name = "interface_type"))]
 pub struct GuildFolder {
     #[cfg(not(feature = "sqlx"))]
     pub color: Option<u32>,

--- a/src/types/entities/user_settings.rs
+++ b/src/types/entities/user_settings.rs
@@ -45,7 +45,10 @@ pub struct UserSettings {
     pub afk_timeout: Option<u16>,
     pub allow_accessibility_detection: bool,
     pub animate_emoji: bool,
+    #[cfg(not(feature = "sqlx"))]
     pub animate_stickers: u8,
+    #[cfg(feature = "sqlx")]
+    pub animate_stickers: sqlx_pg_uint::PgU8,
     pub contact_sync_enabled: bool,
     pub convert_emoticons: bool,
     pub custom_status: Option<CustomStatus>,
@@ -54,7 +57,10 @@ pub struct UserSettings {
     pub developer_mode: bool,
     pub disable_games_tab: bool,
     pub enable_tts_command: bool,
+    #[cfg(not(feature = "sqlx"))]
     pub explicit_content_filter: u8,
+    #[cfg(feature = "sqlx")]
+    pub explicit_content_filter: sqlx_pg_uint::PgU8,
     pub friend_source_flags: FriendSourceFlags,
     pub gateway_connected: Option<bool>,
     pub gif_auto_play: bool,
@@ -82,7 +88,10 @@ impl Default for UserSettings {
             afk_timeout: Some(3600),
             allow_accessibility_detection: true,
             animate_emoji: true,
+            #[cfg(not(feature = "sqlx"))]
             animate_stickers: 0,
+            #[cfg(feature = "sqlx")]
+            animate_stickers: 0.into(),
             contact_sync_enabled: false,
             convert_emoticons: false,
             custom_status: None,
@@ -91,7 +100,10 @@ impl Default for UserSettings {
             developer_mode: true,
             disable_games_tab: true,
             enable_tts_command: false,
+            #[cfg(not(feature = "sqlx"))]
             explicit_content_filter: 0,
+            #[cfg(feature = "sqlx")]
+            explicit_content_filter: 0.into(),
             friend_source_flags: Default::default(),
             gateway_connected: Some(false),
             gif_auto_play: false,
@@ -137,7 +149,10 @@ impl Default for FriendSourceFlags {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GuildFolder {
+    #[cfg(not(feature = "sqlx"))]
     pub color: Option<u32>,
+    #[cfg(feature = "sqlx")]
+    pub color: Option<sqlx_pg_uint::PgU32>,
     pub guild_ids: Vec<String>,
     // FIXME: What is this thing?
     // It's not a snowflake, and it's sometimes a string and sometimes an integer.

--- a/src/types/entities/user_settings.rs
+++ b/src/types/entities/user_settings.rs
@@ -6,6 +6,7 @@ use chrono::{serde::ts_milliseconds_option, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::types::Shared;
+use crate::{UInt16, UInt32, UInt8};
 use serde_aux::field_attributes::deserialize_option_number_from_string;
 
 #[derive(
@@ -42,16 +43,10 @@ pub enum UserTheme {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 pub struct UserSettings {
-    #[cfg(not(feature = "sqlx"))]
-    pub afk_timeout: Option<u16>,
-    #[cfg(feature = "sqlx")]
-    pub afk_timeout: Option<sqlx_pg_uint::PgU16>,
+    pub afk_timeout: Option<UInt16>,
     pub allow_accessibility_detection: bool,
     pub animate_emoji: bool,
-    #[cfg(not(feature = "sqlx"))]
-    pub animate_stickers: u8,
-    #[cfg(feature = "sqlx")]
-    pub animate_stickers: sqlx_pg_uint::PgU8,
+    pub animate_stickers: UInt8,
     pub contact_sync_enabled: bool,
     pub convert_emoticons: bool,
     pub custom_status: Option<CustomStatus>,
@@ -60,10 +55,7 @@ pub struct UserSettings {
     pub developer_mode: bool,
     pub disable_games_tab: bool,
     pub enable_tts_command: bool,
-    #[cfg(not(feature = "sqlx"))]
-    pub explicit_content_filter: u8,
-    #[cfg(feature = "sqlx")]
-    pub explicit_content_filter: sqlx_pg_uint::PgU8,
+    pub explicit_content_filter: UInt8,
     pub friend_source_flags: FriendSourceFlags,
     pub gateway_connected: Option<bool>,
     pub gif_auto_play: bool,
@@ -156,10 +148,7 @@ impl Default for FriendSourceFlags {
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow, sqlx::Type))]
 #[cfg_attr(feature = "sqlx", sqlx(type_name = "interface_type"))]
 pub struct GuildFolder {
-    #[cfg(not(feature = "sqlx"))]
-    pub color: Option<u32>,
-    #[cfg(feature = "sqlx")]
-    pub color: Option<sqlx_pg_uint::PgU32>,
+    pub color: Option<UInt32>,
     pub guild_ids: Vec<String>,
     // FIXME: What is this thing?
     // It's not a snowflake, and it's sometimes a string and sometimes an integer.

--- a/src/types/entities/user_settings.rs
+++ b/src/types/entities/user_settings.rs
@@ -130,7 +130,8 @@ impl Default for UserSettings {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
+#[cfg_attr(feature = "sqlx", derive(sqlx::FromRow, sqlx::Type))]
+#[cfg_attr(feature = "sqlx", sqlx(type_name = "interface_type"))]
 pub struct CustomStatus {
     pub emoji_id: Option<String>,
     pub emoji_name: Option<String>,

--- a/src/types/entities/user_settings.rs
+++ b/src/types/entities/user_settings.rs
@@ -80,7 +80,8 @@ pub struct UserSettings {
 impl Default for UserSettings {
     fn default() -> Self {
         Self {
-            afk_timeout: Some(3600.into()),
+            #[allow(clippy::useless_conversion)]
+            afk_timeout: Some(3600u16.into()),
             allow_accessibility_detection: true,
             animate_emoji: true,
             #[cfg(not(feature = "sqlx"))]

--- a/src/types/entities/webhook.rs
+++ b/src/types/entities/webhook.rs
@@ -71,7 +71,8 @@ impl PartialEq for Webhook {
 #[derive(
     Serialize, Deserialize, Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash,
 )]
-#[repr(u8)]
+#[cfg_attr(not(feature = "sqlx"), repr(u8))]
+#[cfg_attr(feature = "sqlx", repr(i16))]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 pub enum WebhookType {
     #[default]

--- a/src/types/schema/channel.rs
+++ b/src/types/schema/channel.rs
@@ -5,7 +5,7 @@
 use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
 
-use crate::types::{ChannelType, DefaultReaction, entities::PermissionOverwrite, Snowflake};
+use crate::types::{entities::PermissionOverwrite, ChannelType, DefaultReaction, Snowflake};
 
 #[derive(Debug, Deserialize, Serialize, Default, PartialEq, PartialOrd)]
 #[serde(rename_all = "snake_case")]
@@ -141,7 +141,8 @@ bitflags! {
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, Default, PartialOrd, Ord, PartialEq, Eq)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-#[repr(u8)]
+#[cfg_attr(not(feature = "sqlx"), repr(u8))]
+#[cfg_attr(feature = "sqlx", repr(i16))]
 pub enum InviteType {
     #[default]
     Guild = 0,
@@ -152,7 +153,8 @@ pub enum InviteType {
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, Default, PartialOrd, Ord, PartialEq, Eq)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-#[repr(u8)]
+#[cfg_attr(not(feature = "sqlx"), repr(u8))]
+#[cfg_attr(feature = "sqlx", repr(i16))]
 pub enum InviteTargetType {
     #[default]
     Stream = 1,
@@ -169,7 +171,9 @@ pub struct AddChannelRecipientSchema {
 }
 
 /// See <https://discord-userdoccers.vercel.app/resources/channel#add-channel-recipient>
-#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialOrd, Ord, PartialEq, Eq, Copy, Hash)]
+#[derive(
+    Debug, Deserialize, Serialize, Clone, Default, PartialOrd, Ord, PartialEq, Eq, Copy, Hash,
+)]
 pub struct ModifyChannelPositionsSchema {
     pub id: Snowflake,
     pub position: Option<u32>,
@@ -178,7 +182,9 @@ pub struct ModifyChannelPositionsSchema {
 }
 
 /// See <https://docs.discord.sex/resources/channel#follow-channel>
-#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialOrd, Ord, PartialEq, Eq, Copy, Hash)]
+#[derive(
+    Debug, Deserialize, Serialize, Clone, Default, PartialOrd, Ord, PartialEq, Eq, Copy, Hash,
+)]
 pub struct AddFollowingChannelSchema {
     pub webhook_channel_id: Snowflake,
 }

--- a/src/types/utils/snowflake.rs
+++ b/src/types/utils/snowflake.rs
@@ -53,12 +53,9 @@ impl Display for Snowflake {
     }
 }
 
-impl<T> From<T> for Snowflake
-where
-    T: Into<u64>,
-{
-    fn from(item: T) -> Self {
-        Self(item.into())
+impl From<u64> for Snowflake {
+    fn from(item: u64) -> Self {
+        Self(item)
     }
 }
 

--- a/src/types/utils/snowflake.rs
+++ b/src/types/utils/snowflake.rs
@@ -99,28 +99,28 @@ impl<'de> serde::Deserialize<'de> for Snowflake {
 }
 
 #[cfg(feature = "sqlx")]
-impl sqlx::Type<sqlx::Any> for Snowflake {
-    fn type_info() -> <sqlx::Any as sqlx::Database>::TypeInfo {
-        <String as sqlx::Type<sqlx::Any>>::type_info()
+impl sqlx::Type<sqlx::Postgres> for Snowflake {
+    fn type_info() -> <sqlx::Postgres as sqlx::Database>::TypeInfo {
+        <String as sqlx::Type<sqlx::Postgres>>::type_info()
     }
 }
 
 #[cfg(feature = "sqlx")]
-impl<'q> sqlx::Encode<'q, sqlx::Any> for Snowflake {
+impl<'q> sqlx::Encode<'q, sqlx::Postgres> for Snowflake {
     fn encode_by_ref(
         &self,
-        buf: &mut <sqlx::Any as sqlx::Database>::ArgumentBuffer<'q>,
+        buf: &mut <sqlx::Postgres as sqlx::Database>::ArgumentBuffer<'q>,
     ) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
-        <String as sqlx::Encode<'q, sqlx::Any>>::encode_by_ref(&self.0.to_string(), buf)
+        <String as sqlx::Encode<'q, sqlx::Postgres>>::encode_by_ref(&self.0.to_string(), buf)
     }
 }
 
 #[cfg(feature = "sqlx")]
-impl<'d> sqlx::Decode<'d, sqlx::Any> for Snowflake {
+impl<'d> sqlx::Decode<'d, sqlx::Postgres> for Snowflake {
     fn decode(
-        value: <sqlx::Any as sqlx::Database>::ValueRef<'d>,
+        value: <sqlx::Postgres as sqlx::Database>::ValueRef<'d>,
     ) -> Result<Self, sqlx::error::BoxDynError> {
-        <String as sqlx::Decode<'d, sqlx::Any>>::decode(value)
+        <String as sqlx::Decode<'d, sqlx::Postgres>>::decode(value)
             .map(|s| s.parse::<u64>().map(Snowflake).unwrap())
     }
 }

--- a/src/types/utils/snowflake.rs
+++ b/src/types/utils/snowflake.rs
@@ -103,6 +103,13 @@ impl sqlx::Type<sqlx::Postgres> for Snowflake {
 }
 
 #[cfg(feature = "sqlx")]
+impl sqlx::postgres::PgHasArrayType for Snowflake {
+    fn array_type_info() -> sqlx::postgres::PgTypeInfo {
+        <Vec<String> as sqlx::Type<sqlx::Postgres>>::type_info()
+    }
+}
+
+#[cfg(feature = "sqlx")]
 impl<'q> sqlx::Encode<'q, sqlx::Postgres> for Snowflake {
     fn encode_by_ref(
         &self,


### PR DESCRIPTION
Initial support for using chorus with a PostgreSQL database, using the `backend` feature. In the same step, this removes support for MySQL/MariaDB. This does not mean that all types are now fully compatible with Postgres. Only the types needed in the current revision of symfonia have been ported over.

Interestingly, the `sqlx` docs mention the following when deriving `sqlx::Type` for structs in Postgres:

> ### Records
>
> User-defined composite types are supported through deriving a struct.
> 
> This is only supported for PostgreSQL.
> [ⓘ](https://docs.rs/sqlx/latest/sqlx/trait.Type.html#)
> 
> ```rs
> #[derive(sqlx::Type)]
> #[sqlx(type_name = "interface_type")]
> struct InterfaceType {
>     name: String,
>     supplier_id: i32,
>     price: f64
> }
> ```

