### PR TITLE
sqlx_bitflag_derive: Use PgU64 as translation base

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "chorus-macros"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "quote",

--- a/chorus-macros/Cargo.toml
+++ b/chorus-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chorus-macros"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 license = "MPL-2.0"
 description = "Macros for the chorus crate."

--- a/chorus-macros/src/lib.rs
+++ b/chorus-macros/src/lib.rs
@@ -166,22 +166,21 @@ pub fn sqlx_bitflag_derive(input: TokenStream) -> TokenStream {
         #[cfg(feature = "sqlx")]
         impl sqlx::Type<sqlx::Postgres> for #name {
             fn type_info() -> sqlx::postgres::PgTypeInfo {
-                <Vec<u8> as sqlx::Type<sqlx::Postgres>>::type_info()
+                <sqlx_pg_uint::PgU64 as sqlx::Type<sqlx::Postgres>>::type_info()
             }
         }
 
         #[cfg(feature = "sqlx")]
         impl<'q> sqlx::Encode<'q, sqlx::Postgres> for #name {
             fn encode_by_ref(&self, buf: &mut <sqlx::Postgres as sqlx::Database>::ArgumentBuffer<'q>) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
-                <Vec<u8> as sqlx::Encode<sqlx::Postgres>>::encode_by_ref(&self.bits().to_be_bytes().into(), buf)
+                <sqlx_pg_uint::PgU64 as sqlx::Encode<sqlx::Postgres>>::encode_by_ref(&self.bits().into(), buf)
             }
         }
 
         #[cfg(feature = "sqlx")]
         impl<'q> sqlx::Decode<'q, sqlx::Postgres> for #name {
             fn decode(value: <sqlx::Postgres as sqlx::Database>::ValueRef<'q>) -> Result<Self, sqlx::error::BoxDynError> {
-                let vec = <Vec<u8> as sqlx::Decode<sqlx::Postgres>>::decode(value)?;
-                Ok(Self::from_bits(vec_u8_to_u64(vec)).unwrap())
+                <sqlx_pg_uint::PgU64 as sqlx::Decode<sqlx::Postgres>>::decode(value).map(|v| Self::from_bits_truncate(v.to_uint()))
             }
         }
 


### PR DESCRIPTION
The same as #551, applied to the `sqlx_bitflag_derive` derive macro in the `chorus_macros` helper crate.