### PR TITLE
Make instance GatewayOptions configurable for library consumers

### DIFF
--- a/examples/instance.rs
+++ b/examples/instance.rs
@@ -6,7 +6,7 @@ use chorus::instance::Instance;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    let instance = Instance::new("https://example.com/")
+    let instance = Instance::new("https://example.com/", None)
         .await
         .expect("Failed to connect to the Spacebar server");
     dbg!(instance.instance_info);

--- a/examples/login.rs
+++ b/examples/login.rs
@@ -7,7 +7,7 @@ use chorus::types::LoginSchema;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    let mut instance = Instance::new("https://example.com/")
+    let mut instance = Instance::new("https://example.com/", None)
         .await
         .expect("Failed to connect to the Spacebar server");
     // Assume, you already have an account created on this instance. Registering an account works

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -66,7 +66,9 @@ pub(crate) async fn setup() -> TestBundle {
     )
     .init();
 
-    let instance = Instance::new("http://localhost:3001/api").await.unwrap();
+    let instance = Instance::new("http://localhost:3001/api", None)
+        .await
+        .unwrap();
     // Requires the existence of the below user.
     let reg = RegisterSchema {
         username: "integrationtestuser".into(),


### PR DESCRIPTION
zlib Gateway compression was introduced on the dev branch not too long ago. Library consumers do not yet have a straightforward option for selecting the newly added `GatewayOptions`, which describe the wanted set of encoding and compression capabilities for interacting with the Gateway of an instance. This PR modifies functions which yield a new Instance object by adding a `options` field, which allows to supply custom `GatewayOptions` if wanted, defaulting to `GatewayOptions::default()` if none are supplied.