### PR TITLE
Differentiate between instance softwares

### DIFF
--- a/src/api/instance.rs
+++ b/src/api/instance.rs
@@ -51,11 +51,11 @@ impl Instance {
             }
         };
 
-        return match from_str::<PingReturn>(&response_text) {
+        match from_str::<PingReturn>(&response_text) {
 			Ok(return_value) => Ok(return_value),
 			Err(e) => Err(ChorusError::InvalidResponse { error: format!("Error while trying to deserialize the JSON response into requested type T: {}. JSON Response: {}",
                         e, response_text) })
-		  };
+		  }
     }
 
     /// Fetches the instance's software implementation and version.
@@ -96,9 +96,9 @@ impl Instance {
             }
         };
 
-        return match from_str::<VersionReturn>(&response_text) {
+        match from_str::<VersionReturn>(&response_text) {
 			Ok(return_value) => Ok(return_value),
 			Err(e) => Err(ChorusError::InvalidResponse { error: format!("Error while trying to deserialize the JSON response into requested type T: {}. JSON Response: {}", e, response_text) })
-		  };
+		  }
     }
 }

--- a/src/api/instance.rs
+++ b/src/api/instance.rs
@@ -1,0 +1,104 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! Contains miscellaneous api routes, such as /version and /ping
+use serde_json::from_str;
+
+use crate::errors::{ChorusError, ChorusResult};
+use crate::instance::Instance;
+use crate::types::{GeneralConfiguration, PingReturn, VersionReturn};
+
+impl Instance {
+    /// Pings the instance, also fetches instance info.
+    ///
+    /// See: [PingReturn]
+    ///
+    /// # Notes
+    /// This is a Spacebar only endpoint.
+    ///
+    /// # Reference
+    /// See <https://docs.spacebar.chat/routes/#get-/ping/>
+    pub async fn ping(&self) -> ChorusResult<PingReturn> {
+        let endpoint_url = format!("{}/ping", self.urls.api.clone());
+
+        let request = match self.client.get(&endpoint_url).send().await {
+            Ok(result) => result,
+            Err(e) => {
+                return Err(ChorusError::RequestFailed {
+                    url: endpoint_url,
+                    error: e.to_string(),
+                });
+            }
+        };
+
+        if !request.status().as_str().starts_with('2') {
+            return Err(ChorusError::ReceivedErrorCode {
+                error_code: request.status().as_u16(),
+                error: request.text().await.unwrap(),
+            });
+        }
+
+        let response_text = match request.text().await {
+            Ok(string) => string,
+            Err(e) => {
+                return Err(ChorusError::InvalidResponse {
+                    error: format!(
+                        "Error while trying to process the HTTP response into a String: {}",
+                        e
+                    ),
+                });
+            }
+        };
+
+        return match from_str::<PingReturn>(&response_text) {
+			Ok(return_value) => Ok(return_value),
+			Err(e) => Err(ChorusError::InvalidResponse { error: format!("Error while trying to deserialize the JSON response into requested type T: {}. JSON Response: {}",
+                        e, response_text) })
+		  };
+    }
+
+    /// Fetches the instance's software implementation and version.
+    ///
+    /// See: [VersionReturn]
+    ///
+    /// # Notes
+    /// This is a Symfonia only endpoint. (For now, we hope that spacebar will adopt it as well)
+    pub async fn get_version(&self) -> ChorusResult<VersionReturn> {
+        let endpoint_url = format!("{}/version", self.urls.api.clone());
+
+        let request = match self.client.get(&endpoint_url).send().await {
+            Ok(result) => result,
+            Err(e) => {
+                return Err(ChorusError::RequestFailed {
+                    url: endpoint_url,
+                    error: e.to_string(),
+                });
+            }
+        };
+
+        if !request.status().as_str().starts_with('2') {
+            return Err(ChorusError::ReceivedErrorCode {
+                error_code: request.status().as_u16(),
+                error: request.text().await.unwrap(),
+            });
+        }
+
+        let response_text = match request.text().await {
+            Ok(string) => string,
+            Err(e) => {
+                return Err(ChorusError::InvalidResponse {
+                    error: format!(
+                        "Error while trying to process the HTTP response into a String: {}",
+                        e
+                    ),
+                });
+            }
+        };
+
+        return match from_str::<VersionReturn>(&response_text) {
+			Ok(return_value) => Ok(return_value),
+			Err(e) => Err(ChorusError::InvalidResponse { error: format!("Error while trying to deserialize the JSON response into requested type T: {}. JSON Response: {}", e, response_text) })
+		  };
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -10,6 +10,7 @@ pub use guilds::*;
 pub use invites::*;
 pub use policies::instance::instance::*;
 pub use users::*;
+pub use instance::*;
 
 pub mod auth;
 pub mod channels;
@@ -17,3 +18,4 @@ pub mod guilds;
 pub mod invites;
 pub mod policies;
 pub mod users;
+pub mod instance;

--- a/src/api/policies/instance/instance.rs
+++ b/src/api/policies/instance/instance.rs
@@ -47,7 +47,7 @@ impl Instance {
             }
         };
 
-        return match from_str::<GeneralConfiguration>(&response_text) {
+        match from_str::<GeneralConfiguration>(&response_text) {
             Ok(object) => Ok(object),
             Err(e) => {
                 Err(ChorusError::InvalidResponse {
@@ -57,6 +57,6 @@ impl Instance {
                     ),
                 })
             }
-        };
+        }
     }
 }

--- a/src/api/policies/instance/instance.rs
+++ b/src/api/policies/instance/instance.rs
@@ -17,7 +17,7 @@ impl Instance {
     /// # Reference
     /// See <https://docs.spacebar.chat/routes/#get-/policies/instance/>
     pub async fn general_configuration_schema(&self) -> ChorusResult<GeneralConfiguration> {
-        let endpoint_url = self.urls.api.clone() + "/policies/instance";
+        let endpoint_url = self.urls.api.clone() + "/policies/instance/";
         let request = match self.client.get(&endpoint_url).send().await {
             Ok(result) => result,
             Err(e) => {
@@ -35,7 +35,28 @@ impl Instance {
             });
         }
 
-        let body = request.text().await.unwrap();
-        Ok(from_str::<GeneralConfiguration>(&body).unwrap())
+        let response_text = match request.text().await {
+            Ok(string) => string,
+            Err(e) => {
+                return Err(ChorusError::InvalidResponse {
+                    error: format!(
+                        "Error while trying to process the HTTP response into a String: {}",
+                        e
+                    ),
+                });
+            }
+        };
+
+        return match from_str::<GeneralConfiguration>(&response_text) {
+            Ok(object) => Ok(object),
+            Err(e) => {
+                Err(ChorusError::InvalidResponse {
+                    error: format!(
+                        "Error while trying to deserialize the JSON response into requested type T: {}. JSON Response: {}",
+                        e, response_text
+                    ),
+                })
+            }
+        };
     }
 }

--- a/src/gateway/options.rs
+++ b/src/gateway/options.rs
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use crate::instance::InstanceSoftware;
+
 #[derive(Clone, PartialEq, Eq, Ord, PartialOrd, Debug, Default, Copy)]
 /// Options passed when initializing the gateway connection.
 ///
@@ -22,6 +24,23 @@ pub struct GatewayOptions {
 }
 
 impl GatewayOptions {
+    /// Creates the ideal gateway options for an [InstanceSoftware],
+    /// based off which features it supports.
+    pub fn for_instance_software(software: InstanceSoftware) -> GatewayOptions {
+        // TODO: Support ETF
+        let encoding = GatewayEncoding::Json;
+
+        let transport_compression = match software.supports_gateway_zlib() {
+            true => GatewayTransportCompression::ZLibStream,
+            false => GatewayTransportCompression::None,
+        };
+
+        GatewayOptions {
+            encoding,
+            transport_compression,
+        }
+    }
+
     /// Adds the options to an existing gateway url
     ///
     /// Returns the new url

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -149,18 +149,14 @@ impl Instance {
 
     /// Detects which [InstanceSoftware] the instance is running.
     pub async fn detect_software(&self) -> InstanceSoftware {
-        let version_res = self.get_version().await;
 
-        match version_res {
-            Ok(version) => {
-                match version.server.to_lowercase().as_str() {
-                    "symfonia" => return InstanceSoftware::Symfonia,
-                    // We can dream this will be implemented one day
-                    "spacebar" => return InstanceSoftware::SpacebarTypescript,
-                    _ => {}
-                }
+		 if let Ok(version) = self.get_version().await {
+            match version.server.to_lowercase().as_str() {
+                "symfonia" => return InstanceSoftware::Symfonia,
+                // We can dream this will be implemented one day
+                "spacebar" => return InstanceSoftware::SpacebarTypescript,
+                _ => {}
             }
-            _ => {}
         }
 
         // We know it isn't a symfonia server now, work around spacebar

--- a/src/types/schema/instance.rs
+++ b/src/types/schema/instance.rs
@@ -1,0 +1,84 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! Contains schema for miscellaneous api routes, such as /version and /ping
+//!
+//! Implementations of those routes can be found in /api/instance.rs
+
+use serde::{Deserialize, Serialize};
+
+use crate::types::{GeneralConfiguration, Snowflake};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// The return type of the spacebar-only /api/ping endpoint
+pub struct PingReturn {
+    /// Note: always "pong!"
+    pub ping: String,
+    pub instance: PingInstance,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[serde(rename_all = "camelCase")]
+/// [GeneralConfiguration] as returned from the /api/ping endpoint
+pub struct PingInstance {
+    pub id: Option<Snowflake>,
+    pub name: String,
+    pub description: Option<String>,
+    pub image: Option<String>,
+    pub correspondence_email: Option<String>,
+    pub correspondence_user_id: Option<String>,
+    pub front_page: Option<String>,
+    pub tos_page: Option<String>,
+}
+
+impl PingInstance {
+    /// Converts self into the [GeneralConfiguration] type
+    pub fn into_general_configuration(self) -> GeneralConfiguration {
+        GeneralConfiguration {
+            instance_name: self.name,
+            instance_description: self.description,
+            front_page: self.front_page,
+            tos_page: self.tos_page,
+            correspondence_email: self.correspondence_email,
+            correspondence_user_id: self.correspondence_user_id,
+            image: self.image,
+            instance_id: self.id,
+        }
+    }
+
+    /// Converts the [GeneralConfiguration] type into self
+    pub fn from_general_configuration(other: GeneralConfiguration) -> Self {
+        Self {
+            id: other.instance_id,
+            name: other.instance_name,
+            description: other.instance_description,
+            image: other.image,
+            correspondence_email: other.correspondence_email,
+            correspondence_user_id: other.correspondence_user_id,
+            front_page: other.front_page,
+            tos_page: other.tos_page,
+        }
+    }
+}
+
+impl From<PingInstance> for GeneralConfiguration {
+    fn from(value: PingInstance) -> Self {
+        value.into_general_configuration()
+    }
+}
+
+impl From<GeneralConfiguration> for PingInstance {
+    fn from(value: GeneralConfiguration) -> Self {
+        Self::from_general_configuration(value)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// The return type of the symfonia-only /version endpoint
+pub struct VersionReturn {
+    /// The instance's software version, e. g. "0.1.0"
+    pub version: String,
+    /// The instance's software, e. g. "symfonia" or "spacebar"
+    pub server: String,
+}

--- a/src/types/schema/mod.rs
+++ b/src/types/schema/mod.rs
@@ -13,6 +13,7 @@ pub use role::*;
 pub use user::*;
 pub use invites::*;
 pub use voice_state::*;
+pub use instance::*;
 
 mod apierror;
 mod audit_log;
@@ -25,6 +26,7 @@ mod role;
 mod user;
 mod invites;
 mod voice_state;
+mod instance;
 
 #[derive(Debug, serde::Deserialize, serde::Serialize, Clone, PartialEq, PartialOrd, Eq, Ord)]
 pub struct GenericSearchQueryWithLimit {

--- a/tests/instance.rs
+++ b/tests/instance.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 mod common;
+use chorus::instance::InstanceSoftware;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::*;
 #[cfg(target_arch = "wasm32")]
@@ -17,5 +18,18 @@ async fn generate_general_configuration_schema() {
         .general_configuration_schema()
         .await
         .unwrap();
+    common::teardown(bundle).await;
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+async fn detect_instance_software() {
+    let bundle = common::setup().await;
+
+    let software = bundle.instance.detect_software().await;
+    assert_eq!(software, InstanceSoftware::SpacebarTypescript);
+
+    assert_eq!(bundle.instance.software(), InstanceSoftware::SpacebarTypescript);
+
     common::teardown(bundle).await;
 }


### PR DESCRIPTION
- Implements the `/ping` and `/version` endpoints
- Adds a software field to `Instance`, which is automatically determined
- If no specific `GatewayOptions` are provided, they will be automatically created based off the instance's software
- Adds a bit better error handling to /policies/instance, fixes a bug where it doesn't work on spacebar (missing a trailing slash)