### PR TITLE
Add Gateway Opcode enum

### DIFF
--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-
 pub mod backends;
 pub mod events;
 pub mod gateway;
@@ -19,7 +18,7 @@ pub use message::*;
 pub use options::*;
 
 use crate::errors::GatewayError;
-use crate::types::Snowflake;
+use crate::types::{Opcode, Snowflake};
 
 use std::any::Any;
 use std::collections::HashMap;
@@ -29,51 +28,51 @@ use tokio::sync::Mutex;
 
 // Gateway opcodes
 /// Opcode received when the server dispatches a [crate::types::WebSocketEvent]
-const GATEWAY_DISPATCH: u8 = 0;
+const GATEWAY_DISPATCH: u8 = Opcode::Dispatch as u8;
 /// Opcode sent when sending a heartbeat
-const GATEWAY_HEARTBEAT: u8 = 1;
+const GATEWAY_HEARTBEAT: u8 = Opcode::Heartbeat as u8;
 /// Opcode sent to initiate a session
 ///
 /// See [types::GatewayIdentifyPayload]
-const GATEWAY_IDENTIFY: u8 = 2;
+const GATEWAY_IDENTIFY: u8 = Opcode::Identify as u8;
 /// Opcode sent to update our presence
 ///
 /// See [types::GatewayUpdatePresence]
-const GATEWAY_UPDATE_PRESENCE: u8 = 3;
+const GATEWAY_UPDATE_PRESENCE: u8 = Opcode::PresenceUpdate as u8;
 /// Opcode sent to update our state in vc
 ///
 /// Like muting, deafening, leaving, joining..
 ///
 /// See [types::UpdateVoiceState]
-const GATEWAY_UPDATE_VOICE_STATE: u8 = 4;
+const GATEWAY_UPDATE_VOICE_STATE: u8 = Opcode::VoiceStateUpdate as u8;
 /// Opcode sent to resume a session
 ///
 /// See [types::GatewayResume]
-const GATEWAY_RESUME: u8 = 6;
+const GATEWAY_RESUME: u8 = Opcode::Resume as u8;
 /// Opcode received to tell the client to reconnect
-const GATEWAY_RECONNECT: u8 = 7;
+const GATEWAY_RECONNECT: u8 = Opcode::Reconnect as u8;
 /// Opcode sent to request guild member data
 ///
 /// See [types::GatewayRequestGuildMembers]
-const GATEWAY_REQUEST_GUILD_MEMBERS: u8 = 8;
+const GATEWAY_REQUEST_GUILD_MEMBERS: u8 = Opcode::RequestGuildMembers as u8;
 /// Opcode received to tell the client their token / session is invalid
-const GATEWAY_INVALID_SESSION: u8 = 9;
+const GATEWAY_INVALID_SESSION: u8 = Opcode::InvalidSession as u8;
 /// Opcode received when initially connecting to the gateway, starts our heartbeat
 ///
 /// See [types::HelloData]
-const GATEWAY_HELLO: u8 = 10;
+const GATEWAY_HELLO: u8 = Opcode::Hello as u8;
 /// Opcode received to acknowledge a heartbeat
-const GATEWAY_HEARTBEAT_ACK: u8 = 11;
+const GATEWAY_HEARTBEAT_ACK: u8 = Opcode::HeartbeatAck as u8;
 /// Opcode sent to get the voice state of users in a given DM/group channel
 ///
 /// See [types::CallSync]
-const GATEWAY_CALL_SYNC: u8 = 13;
+const GATEWAY_CALL_SYNC: u8 = Opcode::CallConnect as u8;
 /// Opcode sent to get data for a server (Lazy Loading request)
 ///
 /// Sent by the official client when switching to a server
 ///
 /// See [types::LazyRequest]
-const GATEWAY_LAZY_REQUEST: u8 = 14;
+const GATEWAY_LAZY_REQUEST: u8 = Opcode::GuildSync as u8;
 
 pub type ObservableObject = dyn Send + Sync + Any;
 

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#![allow(deprecated)] // Since Opcode variants marked as deprecated are being used here, we need to suppress the warnings about them being deprecated
+
 pub mod backends;
 pub mod events;
 pub mod gateway;

--- a/src/types/utils/mod.rs
+++ b/src/types/utils/mod.rs
@@ -3,13 +3,14 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #![allow(unused_imports)]
+pub use opcode::*;
 pub use regexes::*;
 pub use rights::Rights;
 pub use snowflake::Snowflake;
 
 pub mod jwt;
+pub mod opcode;
 mod regexes;
 mod rights;
-mod snowflake;
 pub mod serde;
-
+mod snowflake;

--- a/src/types/utils/opcode.rs
+++ b/src/types/utils/opcode.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::errors::ChorusError;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize)]
+#[non_exhaustive]
 #[repr(u8)]
 /// Gateway opcodes used in the Spacebar Gateway Protocol.
 pub enum Opcode {

--- a/src/types/utils/opcode.rs
+++ b/src/types/utils/opcode.rs
@@ -1,0 +1,137 @@
+#![allow(deprecated)] // Required to suppress warnings about deprecated opcodes
+
+use serde::{Deserialize, Serialize};
+
+use crate::errors::ChorusError;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Deserialize, Serialize)]
+#[repr(u8)]
+/// Gateway opcodes used in the Spacebar Gateway Protocol.
+pub enum Opcode {
+    /// An event was dispatched.
+    Dispatch = 0,
+    /// Keep the WebSocket connection alive.
+    Heartbeat = 1,
+    /// Start a new session during the initial handshake.
+    Identify = 2,
+    /// Update the client's presence.
+    PresenceUpdate = 3,
+    /// Join/leave or move between voice channels and calls.
+    VoiceStateUpdate = 4,
+    /// Ping the Discord voice servers.
+    VoiceServerPing = 5,
+    /// Resume a previous session that was disconnected.
+    Resume = 6,
+    /// You should attempt to reconnect and resume immediately.
+    Reconnect = 7,
+    /// Request information about guild members.
+    RequestGuildMembers = 8,
+    /// The session has been invalidated. You should reconnect and identify/resume accordingly.
+    InvalidSession = 9,
+    /// Sent immediately after connecting, contains the heartbeat_interval to use.
+    Hello = 10,
+    /// Acknowledge a received heartbeat.
+    HeartbeatAck = 11,
+    /// Request all members and presences for guilds.
+    #[deprecated]
+    GuildSync = 12,
+    /// Request a private channel's pre-existing call data.
+    CallConnect = 13,
+    /// Update subscriptions for a guild.
+    GuildSubscriptions = 14,
+    /// Join a lobby.
+    LobbyConnect = 15,
+    /// Leave a lobby.
+    LobbyDisconnect = 16,
+    /// Update the client's voice state in a lobby.
+    LobbyVoiceStates = 17,
+    /// Create a stream for the client.
+    StreamCreate = 18,
+    /// End a client stream.
+    StreamDelete = 19,
+    /// Watch a user's stream.
+    StreamWatch = 20,
+    /// Ping a user stream's voice server.
+    StreamPing = 21,
+    /// Pause/resume a client stream.
+    StreamSetPaused = 22,
+    /// Update subscriptions for an LFG lobby.
+    #[deprecated]
+    LfgSubscriptions = 23,
+    /// Request guild application commands.
+    #[deprecated]
+    RequestGuildApplicationCommands = 24,
+    /// Launch an embedded activity in a voice channel or call.
+    EmbeddedActivityCreate = 25,
+    /// Stop an embedded activity.
+    EmbeddedActivityDelete = 26,
+    /// Update an embedded activity.
+    EmbeddedActivityUpdate = 27,
+    /// Request forum channel unread counts.
+    RequestForumUnreads = 28,
+    /// Send a remote command to an embedded (Xbox, PlayStation) voice session.
+    RemoteCommand = 29,
+    /// Request deleted entity IDs not matching a given hash for a guild.
+    RequestDeletedEntityIDs = 30,
+    /// Request soundboard sounds for guilds.
+    RequestSoundboardSounds = 31,
+    /// Create a voice speed test.
+    SpeedTestCreate = 32,
+    /// Delete a voice speed test.
+    SpeedTestDelete = 33,
+    /// Request last messages for a guild's channels.
+    RequestLastMessages = 34,
+    /// Request information about recently-joined guild members.
+    SearchRecentMembers = 35,
+    /// Request voice channel statuses for a guild.
+    RequestChannelStatuses = 36,
+}
+
+impl TryFrom<u8> for Opcode {
+    type Error = ChorusError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Dispatch),
+            1 => Ok(Self::Heartbeat),
+            2 => Ok(Self::Identify),
+            3 => Ok(Self::PresenceUpdate),
+            4 => Ok(Self::VoiceStateUpdate),
+            5 => Ok(Self::VoiceServerPing),
+            6 => Ok(Self::Resume),
+            7 => Ok(Self::Reconnect),
+            8 => Ok(Self::RequestGuildMembers),
+            9 => Ok(Self::InvalidSession),
+            10 => Ok(Self::Hello),
+            11 => Ok(Self::HeartbeatAck),
+            12 => Ok(Self::GuildSync),
+            13 => Ok(Self::CallConnect),
+            14 => Ok(Self::GuildSubscriptions),
+            15 => Ok(Self::LobbyConnect),
+            16 => Ok(Self::LobbyDisconnect),
+            17 => Ok(Self::LobbyVoiceStates),
+            18 => Ok(Self::StreamCreate),
+            19 => Ok(Self::StreamDelete),
+            20 => Ok(Self::StreamWatch),
+            21 => Ok(Self::StreamPing),
+            22 => Ok(Self::StreamSetPaused),
+            23 => Ok(Self::LfgSubscriptions),
+            24 => Ok(Self::RequestGuildApplicationCommands),
+            25 => Ok(Self::EmbeddedActivityCreate),
+            26 => Ok(Self::EmbeddedActivityDelete),
+            27 => Ok(Self::EmbeddedActivityUpdate),
+            28 => Ok(Self::RequestForumUnreads),
+            29 => Ok(Self::RemoteCommand),
+            30 => Ok(Self::RequestDeletedEntityIDs),
+            31 => Ok(Self::RequestSoundboardSounds),
+            32 => Ok(Self::SpeedTestCreate),
+            33 => Ok(Self::SpeedTestDelete),
+            34 => Ok(Self::RequestLastMessages),
+            35 => Ok(Self::SearchRecentMembers),
+            36 => Ok(Self::RequestChannelStatuses),
+            e => Err(ChorusError::InvalidArguments {
+                error: format!("Provided value {e} is not a valid opcode"),
+            }),
+        }
+    }
+}


### PR DESCRIPTION
Introduces and publicly exports an enum `Opcode` which represents all currently known Opcodes that can be sent to/received from Spacebar Gateway Protocol compatible services.