### PR TITLE
Refactor the gateway to properly accept close frames

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -102,7 +102,7 @@ jobs:
         run: |
           rustup target add wasm32-unknown-unknown
           curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-          cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.93" --force
+          cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.95" --force
           GECKODRIVER=$(which geckodriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt, voice_gateway"
   wasm-chrome:
     runs-on: ubuntu-latest
@@ -132,5 +132,5 @@ jobs:
         run: |
           rustup target add wasm32-unknown-unknown
           curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-          cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.93" --force
+          cargo binstall --no-confirm wasm-bindgen-cli --version "0.2.95" --force
           CHROMEDRIVER=$(which chromedriver) cargo test --target wasm32-unknown-unknown --no-default-features --features="client, rt, voice_gateway"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,7 @@ dependencies = [
  "jsonwebtoken",
  "lazy_static",
  "log",
+ "pharos",
  "poem",
  "pubserve",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,9 +1171,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2931,9 +2931,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2942,9 +2942,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
@@ -2969,9 +2969,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2979,9 +2979,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2992,9 +2992,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "wasm-bindgen-test"
@@ -3024,9 +3024,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtimer"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f656cd8858a5164932d8a90f936700860976ec21eb00e0fe2aa8cab13f6b4cf"
+checksum = "bb4f099acbc1043cc752b91615b24b02d7f6fcd975bd781fed9f50b3c3e15bf7"
 dependencies = [
  "futures",
  "js-sys",
@@ -3038,9 +3038,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,12 +82,12 @@ getrandom = { version = "0.2.15", features = ["js"] }
 ws_stream_wasm = "0.7.4"
 pharos = "*" # This is a dependency of ws_stream_wasm, we are including it to interface with that library
 wasm-bindgen-futures = "0.4.43"
-wasmtimer = "0.2.0"
+wasmtimer = "0.4.0"
 
 [dev-dependencies]
 lazy_static = "1.5.0"
 wasm-bindgen-test = "0.3.43"
-wasm-bindgen = "0.2.93"
+wasm-bindgen = "0.2.95"
 simple_logger = { version = "5.0.0", default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
@@ -95,3 +95,7 @@ httptest = "0.16.1"
 
 [lints.rust]
 unexpected_cfgs = { level = "allow", check-cfg = ['cfg(tarpaulin_include)'] }
+
+# See https://github.com/whizsid/wasmtimer-rs/issues/18#issuecomment-2420144039
+[package.metadata.wasm-pack.profile.dev.wasm-bindgen]
+debug-js-glue = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ getrandom = { version = "0.2.15" }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.15", features = ["js"] }
 ws_stream_wasm = "0.7.4"
+pharos = "*" # This is a dependency of ws_stream_wasm, we are including it to interface with that library
 wasm-bindgen-futures = "0.4.43"
 wasmtimer = "0.2.0"
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,7 +5,7 @@
 //! Contains all the errors that can be returned by the library.
 use custom_error::custom_error;
 
-use crate::types::{MfaRequiredSchema, WebSocketEvent};
+use crate::types::{CloseCode, MfaRequiredSchema, VoiceCloseCode, WebSocketEvent};
 use chorus_macros::WebSocketEvent;
 
 custom_error! {
@@ -109,6 +109,32 @@ custom_error! {
     UnexpectedOpcodeReceived{opcode: u8} = "Received an opcode we weren't expecting to receive: {opcode}",
 }
 
+impl From<CloseCode> for GatewayError {
+    fn from(value: CloseCode) -> Self {
+        match value {
+            CloseCode::UnknownError => GatewayError::Unknown,
+            CloseCode::UnknownOpcode => GatewayError::UnknownOpcode,
+            CloseCode::DecodeError => GatewayError::Decode,
+            CloseCode::NotAuthenticated => GatewayError::NotAuthenticated,
+            CloseCode::AuthenticationFailed => GatewayError::AuthenticationFailed,
+            CloseCode::AlreadyAuthenticated => GatewayError::AlreadyAuthenticated,
+            CloseCode::InvalidSeq => GatewayError::InvalidSequenceNumber,
+            CloseCode::RateLimited => GatewayError::RateLimited,
+            CloseCode::SessionTimeout => GatewayError::SessionTimedOut,
+            // Note: this case is
+            // deprecated, it
+            // should never actually
+            // be received anymore
+            CloseCode::SessionNoLongerValid => GatewayError::SessionTimedOut,
+            CloseCode::InvalidShard => GatewayError::InvalidShard,
+            CloseCode::ShardingRequired => GatewayError::ShardingRequired,
+            CloseCode::InvalidApiVersion => GatewayError::InvalidAPIVersion,
+            CloseCode::InvalidIntents => GatewayError::InvalidIntents,
+            CloseCode::DisallowedIntents => GatewayError::DisallowedIntents,
+        }
+    }
+}
+
 custom_error! {
     /// Voice Gateway errors
     ///
@@ -125,7 +151,7 @@ custom_error! {
     AuthenticationFailed = "The token you sent in your identify payload is incorrect",
     AlreadyAuthenticated = "You sent more than one identify payload",
     SessionNoLongerValid = "Your session is no longer valid",
-    SessionTimeout = "Your session has timed out",
+    SessionTimedOut = "Your session has timed out",
     ServerNotFound = "We can't find the server you're trying to connect to",
     UnknownProtocol = "We didn't recognize the protocol you sent",
     Disconnected = "Channel was deleted, you were kicked, voice server changed, or the main gateway session was dropped. Should not reconnect.",
@@ -138,6 +164,25 @@ custom_error! {
 
     // Other misc errors
     UnexpectedOpcodeReceived{opcode: u8} = "Received an opcode we weren't expecting to receive: {opcode}",
+}
+
+impl From<VoiceCloseCode> for VoiceGatewayError {
+    fn from(value: VoiceCloseCode) -> Self {
+        match value {
+            VoiceCloseCode::UnknownOpcode => VoiceGatewayError::UnknownOpcode,
+            VoiceCloseCode::FailedToDecodePayload => VoiceGatewayError::FailedToDecodePayload,
+            VoiceCloseCode::NotAuthenticated => VoiceGatewayError::NotAuthenticated,
+            VoiceCloseCode::AuthenticationFailed => VoiceGatewayError::AuthenticationFailed,
+            VoiceCloseCode::AlreadyAuthenticated => VoiceGatewayError::AlreadyAuthenticated,
+            VoiceCloseCode::SessionTimeout => VoiceGatewayError::SessionTimedOut,
+            VoiceCloseCode::SessionNoLongerValid => VoiceGatewayError::SessionNoLongerValid,
+            VoiceCloseCode::ServerNotFound => VoiceGatewayError::ServerNotFound,
+            VoiceCloseCode::UnknownProtocol => VoiceGatewayError::UnknownProtocol,
+            VoiceCloseCode::DisconnectedChannelDeletedOrKicked => VoiceGatewayError::Disconnected,
+            VoiceCloseCode::VoiceServerCrashed => VoiceGatewayError::VoiceServerCrashed,
+            VoiceCloseCode::UnknownEncryptionMode => VoiceGatewayError::UnknownEncryptionMode,
+        }
+    }
 }
 
 custom_error! {

--- a/src/gateway/backends/tungstenite.rs
+++ b/src/gateway/backends/tungstenite.rs
@@ -10,7 +10,7 @@ use futures_util::{
 use tokio::net::TcpStream;
 use tokio_tungstenite::{
     connect_async_tls_with_config, connect_async_with_config,
-    tungstenite::{self, protocol::CloseFrame},
+    tungstenite::self,
     Connector, MaybeTlsStream, WebSocketStream,
 };
 use url::Url;

--- a/src/gateway/gateway.rs
+++ b/src/gateway/gateway.rs
@@ -342,7 +342,7 @@ impl Gateway {
 
         let Ok(gateway_payload) = msg.payload() else {
             warn!(
-                "Message unrecognised: {:?}, please open an issue on the chorus github",
+                "GW: Message unrecognised: {:?}, please open an issue on the chorus github",
                 msg.0
             );
             return;

--- a/src/gateway/message.rs
+++ b/src/gateway/message.rs
@@ -57,7 +57,7 @@ impl RawGatewayMessage {
 /// This will usually be a [GatewayReceivePayload].
 ///
 /// This struct is used internally when handling messages.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GatewayMessage(pub String);
 
 impl GatewayMessage {

--- a/src/gateway/message.rs
+++ b/src/gateway/message.rs
@@ -4,9 +4,26 @@
 
 use std::string::FromUtf8Error;
 
-use crate::types;
+use crate::types::{CloseCode, GatewayReceivePayload};
 
 use super::*;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+/// Defines a communication received from the gateway, being either an optionally compressed
+/// [RawGatewayMessage] or a [CloseCode].
+///
+/// Used only for a tungstenite gateway, since our underlying wasm backend handles close codes
+/// differently.
+pub(crate) enum GatewayCommunication {
+    Message(RawGatewayMessage),
+    Error(CloseCode),
+}
+
+impl From<RawGatewayMessage> for GatewayCommunication {
+    fn from(value: RawGatewayMessage) -> Self {
+        Self::Message(value)
+    }
+}
 
 /// Defines a raw gateway message, being either string json or bytes
 ///
@@ -36,42 +53,17 @@ impl RawGatewayMessage {
 }
 
 /// Represents a json message received from the gateway.
-/// This will be either a [types::GatewayReceivePayload], containing events, or a [GatewayError].
+///
+/// This will usually be a [GatewayReceivePayload].
+///
 /// This struct is used internally when handling messages.
 #[derive(Clone, Debug)]
 pub struct GatewayMessage(pub String);
 
 impl GatewayMessage {
-    /// Parses the message as an error;
-    /// Returns the error if successfully parsed, None if the message isn't an error
-    pub fn error(&self) -> Option<GatewayError> {
-        // Some error strings have dots on the end, which we don't care about
-        let processed_content = self.0.to_lowercase().replace('.', "");
-
-        match processed_content.as_str() {
-            "unknown error" | "4000" => Some(GatewayError::Unknown),
-            "unknown opcode" | "4001" => Some(GatewayError::UnknownOpcode),
-            "decode error" | "error while decoding payload" | "4002" => Some(GatewayError::Decode),
-            "not authenticated" | "4003" => Some(GatewayError::NotAuthenticated),
-            "authentication failed" | "4004" => Some(GatewayError::AuthenticationFailed),
-            "already authenticated" | "4005" => Some(GatewayError::AlreadyAuthenticated),
-            "invalid seq" | "4007" => Some(GatewayError::InvalidSequenceNumber),
-            "rate limited" | "4008" => Some(GatewayError::RateLimited),
-            "session timed out" | "4009" => Some(GatewayError::SessionTimedOut),
-            "invalid shard" | "4010" => Some(GatewayError::InvalidShard),
-            "sharding required" | "4011" => Some(GatewayError::ShardingRequired),
-            "invalid api version" | "4012" => Some(GatewayError::InvalidAPIVersion),
-            "invalid intent(s)" | "invalid intent" | "4013" => Some(GatewayError::InvalidIntents),
-            "disallowed intent(s)" | "disallowed intents" | "4014" => {
-                Some(GatewayError::DisallowedIntents)
-            }
-            _ => None,
-        }
-    }
-
     /// Parses the message as a payload;
     /// Returns a result of deserializing
-    pub fn payload(&self) -> Result<types::GatewayReceivePayload, serde_json::Error> {
+    pub fn payload(&self) -> Result<GatewayReceivePayload, serde_json::Error> {
         serde_json::from_str(&self.0)
     }
 
@@ -90,7 +82,6 @@ impl GatewayMessage {
         bytes: &[u8],
         inflate: &mut flate2::Decompress,
     ) -> Result<GatewayMessage, std::io::Error> {
-
         // Note: is there a better way to handle the size of this output buffer?
         //
         // This used to be 10, I measured it at 11.5, so a safe bet feels like 20

--- a/src/voice/gateway/backends/mod.rs
+++ b/src/voice/gateway/backends/mod.rs
@@ -7,4 +7,3 @@ pub mod tungstenite;
 
 #[cfg(all(target_arch = "wasm32", feature = "voice_gateway"))]
 pub mod wasm;
-

--- a/src/voice/gateway/backends/tungstenite.rs
+++ b/src/voice/gateway/backends/tungstenite.rs
@@ -2,7 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use crate::voice::gateway::VoiceGatewayMessage;
+use crate::types::VoiceCloseCode;
+use crate::voice::gateway::{VoiceGatewayCommunication, VoiceGatewayMessage};
 
 impl From<VoiceGatewayMessage> for tokio_tungstenite::tungstenite::Message {
     fn from(message: VoiceGatewayMessage) -> Self {
@@ -13,5 +14,30 @@ impl From<VoiceGatewayMessage> for tokio_tungstenite::tungstenite::Message {
 impl From<tokio_tungstenite::tungstenite::Message> for VoiceGatewayMessage {
     fn from(value: tokio_tungstenite::tungstenite::Message) -> Self {
         Self(value.to_string())
+    }
+}
+
+impl From<tokio_tungstenite::tungstenite::Message> for VoiceGatewayCommunication {
+    fn from(value: tokio_tungstenite::tungstenite::Message) -> Self {
+        match value {
+            tokio_tungstenite::tungstenite::Message::Text(text) => {
+                VoiceGatewayCommunication::Message(VoiceGatewayMessage(text))
+            }
+            tokio_tungstenite::tungstenite::Message::Close(close_frame) => {
+                if close_frame.is_none() {
+                    // Note: there is no unknown error. This case shouldn't happen, so I'm just
+                    // going to delegate it to this error
+                    return VoiceGatewayCommunication::Error(VoiceCloseCode::FailedToDecodePayload);
+                }
+
+                let close_code = u16::from(close_frame.unwrap().code);
+
+                VoiceGatewayCommunication::Error(
+                    VoiceCloseCode::try_from(close_code)
+                        .unwrap_or(VoiceCloseCode::FailedToDecodePayload),
+                )
+            }
+            _ => VoiceGatewayCommunication::Error(VoiceCloseCode::FailedToDecodePayload),
+        }
     }
 }

--- a/src/voice/gateway/backends/wasm.rs
+++ b/src/voice/gateway/backends/wasm.rs
@@ -2,8 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use ws_stream_wasm::WsMessage;
 use crate::voice::gateway::VoiceGatewayMessage;
+use ws_stream_wasm::WsMessage;
 
 impl From<VoiceGatewayMessage> for WsMessage {
     fn from(message: VoiceGatewayMessage) -> Self {
@@ -23,4 +23,3 @@ impl From<WsMessage> for VoiceGatewayMessage {
         }
     }
 }
-

--- a/src/voice/gateway/gateway.rs
+++ b/src/voice/gateway/gateway.rs
@@ -18,13 +18,16 @@ use crate::gateway::WebSocketBackend;
 use crate::{
     errors::VoiceGatewayError,
     types::{
-        VoiceGatewayReceivePayload, VoiceHelloData, WebSocketEvent, VOICE_BACKEND_VERSION,
-        VOICE_CLIENT_CONNECT_FLAGS, VOICE_CLIENT_CONNECT_PLATFORM, VOICE_CLIENT_DISCONNECT,
-        VOICE_HEARTBEAT, VOICE_HEARTBEAT_ACK, VOICE_HELLO, VOICE_IDENTIFY, VOICE_MEDIA_SINK_WANTS,
-        VOICE_READY, VOICE_RESUME, VOICE_SELECT_PROTOCOL, VOICE_SESSION_DESCRIPTION,
-        VOICE_SESSION_UPDATE, VOICE_SPEAKING, VOICE_SSRC_DEFINITION,
+        VoiceCloseCode, VoiceGatewayReceivePayload, VoiceHelloData, WebSocketEvent,
+        VOICE_BACKEND_VERSION, VOICE_CLIENT_CONNECT_FLAGS, VOICE_CLIENT_CONNECT_PLATFORM,
+        VOICE_CLIENT_DISCONNECT, VOICE_HEARTBEAT, VOICE_HEARTBEAT_ACK, VOICE_HELLO, VOICE_IDENTIFY,
+        VOICE_MEDIA_SINK_WANTS, VOICE_READY, VOICE_RESUME, VOICE_SELECT_PROTOCOL,
+        VOICE_SESSION_DESCRIPTION, VOICE_SESSION_UPDATE, VOICE_SPEAKING, VOICE_SSRC_DEFINITION,
     },
-    voice::gateway::{heartbeat::VoiceHeartbeatThreadCommunication, VoiceGatewayMessage},
+    voice::gateway::{
+        heartbeat::VoiceHeartbeatThreadCommunication, VoiceGatewayCommunication,
+        VoiceGatewayMessage,
+    },
 };
 
 use super::{events::VoiceEvents, heartbeat::VoiceHeartbeatHandler, VoiceGatewayHandle};
@@ -64,7 +67,20 @@ impl VoiceGateway {
         // Wait for the first hello and then spawn both tasks so we avoid nested tasks
         // This automatically spawns the heartbeat task, but from the main thread
         #[cfg(not(target_arch = "wasm32"))]
-        let msg: VoiceGatewayMessage = websocket_receive.next().await.unwrap().unwrap().into();
+        let msg: VoiceGatewayMessage = {
+            // Note: The tungstenite backend handles close codes as messages, while the ws_stream_wasm one handles them differently.
+            //
+            // Hence why wasm receives straight VoiceGatewayMessages, and tungstenite receives
+            // VoiceGatewayCommunications.
+            let communication: VoiceGatewayCommunication =
+                websocket_receive.next().await.unwrap().unwrap().into();
+
+            match communication {
+                VoiceGatewayCommunication::Message(message) => message,
+                VoiceGatewayCommunication::Error(error) => return Err(error.into()),
+            }
+        };
+
         #[cfg(target_arch = "wasm32")]
         let msg: VoiceGatewayMessage = websocket_receive.next().await.unwrap().into();
         let gateway_payload: VoiceGatewayReceivePayload = serde_json::from_str(&msg.0).unwrap();
@@ -102,11 +118,11 @@ impl VoiceGateway {
         // Now we can continuously check for messages in a different task, since we aren't going to receive another hello
         #[cfg(not(target_arch = "wasm32"))]
         tokio::task::spawn(async move {
-            gateway.gateway_listen_task().await;
+            gateway.gateway_listen_task_tungstenite().await;
         });
         #[cfg(target_arch = "wasm32")]
         wasm_bindgen_futures::spawn_local(async move {
-            gateway.gateway_listen_task().await;
+            gateway.gateway_listen_task_wasm().await;
         });
 
         Ok(VoiceGatewayHandle {
@@ -117,8 +133,9 @@ impl VoiceGateway {
         })
     }
 
-    /// The main gateway listener task;
-    pub async fn gateway_listen_task(&mut self) {
+    /// The main gateway listener task for a tungstenite based gateway;
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn gateway_listen_task_tungstenite(&mut self) {
         loop {
             let msg;
 
@@ -132,13 +149,75 @@ impl VoiceGateway {
                 }
             }
 
-            // PRETTYFYME: Remove inline conditional compiling
-            #[cfg(not(target_arch = "wasm32"))]
+            // Note: The tungstenite backend handles close codes as messages, while the ws_stream_wasm one handles them differently.
+            //
+            // Hence why wasm receives straight RawGatewayMessages, and tungstenite receives
+            // GatewayCommunications.
             if let Some(Ok(message)) = msg {
-                self.handle_message(message.into()).await;
+                let communication: VoiceGatewayCommunication = message.into();
+
+                match communication {
+                    VoiceGatewayCommunication::Message(message) => {
+                        self.handle_message(message).await
+                    }
+                    VoiceGatewayCommunication::Error(close_code) => {
+                        self.handle_close_code(close_code).await
+                    }
+                }
+
                 continue;
             }
-            #[cfg(target_arch = "wasm32")]
+
+            // We couldn't receive the next message or it was an error, something is wrong with the websocket, close
+            warn!("VGW: Websocket is broken, stopping gateway");
+            break;
+        }
+    }
+
+    /// The main gateway listener task for a wasm based gateway;
+    ///
+    /// Wasm handles close codes and events differently, and so we must change the listener logic a
+    /// bit
+    #[cfg(target_arch = "wasm32")]
+    async fn gateway_listen_task_wasm(&mut self) {
+        // Initiate the close event listener
+        let mut close_events = self
+            .websocket_receive
+            .1
+            .observe(pharos::Filter::Pointer(ws_stream_wasm::WsEvent::is_closed).into())
+            .await
+            .unwrap();
+
+        loop {
+            let msg;
+
+            tokio::select! {
+                 Ok(_) = self.kill_receive.recv() => {
+                      log::trace!("VGW: Closing listener task");
+                      break;
+                 }
+                 message = self.websocket_receive.0.next() => {
+                      msg = message;
+                 }
+                 maybe_event = close_events.next() => {
+                      if let Some(event) = maybe_event {
+                              match event {
+                                    ws_stream_wasm::WsEvent::Closed(closed_event) => {
+                                        let close_code = VoiceCloseCode::try_from(closed_event.code).unwrap_or(VoiceCloseCode::UnknownError);
+                                        self.handle_close_code(close_code).await;
+                                        break;
+                                    }
+                                    _ => unreachable!() // Should be impossible, we filtered close events
+                              }
+                      }
+                      continue;
+                }
+            }
+
+            // Note: The tungstenite backend handles close codes as messages, while the ws_stream_wasm one handles them as a seperate receiver.
+            //
+            // Hence why wasm receives VoiceGatewayMessages, and tungstenite receives
+            // VoiceGatewayCommunications.
             if let Some(message) = msg {
                 self.handle_message(message.into()).await;
                 continue;
@@ -154,6 +233,17 @@ impl VoiceGateway {
     async fn close(&mut self) {
         self.kill_send.send(()).unwrap();
         self.websocket_send.lock().await.close().await.unwrap();
+    }
+
+    /// Handles receiving a [VoiceCloseCode].
+    ///
+    /// Closes the connection and publishes an error event.
+    async fn handle_close_code(&mut self, code: VoiceCloseCode) {
+        let error = VoiceGatewayError::from(code);
+
+        warn!("VGW: Received error {:?}, connection will close..", error);
+        self.close().await;
+        self.events.lock().await.error.publish(error).await;
     }
 
     /// Deserializes and updates a dispatched event, when we already know its type;
@@ -179,16 +269,10 @@ impl VoiceGateway {
         }
 
         let Ok(gateway_payload) = msg.payload() else {
-            if let Some(error) = msg.error() {
-                warn!("GW: Received error {:?}, connection will close..", error);
-                self.close().await;
-                self.events.lock().await.error.publish(error).await;
-            } else {
-                warn!(
-                    "Message unrecognised: {:?}, please open an issue on the chorus github",
-                    msg.0
-                );
-            }
+            warn!(
+                "VGW: Message unrecognised: {:?}, please open an issue on the chorus github",
+                msg.0
+            );
             return;
         };
 

--- a/src/voice/gateway/message.rs
+++ b/src/voice/gateway/message.rs
@@ -2,42 +2,34 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use crate::{errors::VoiceGatewayError, types::VoiceGatewayReceivePayload};
+use crate::{errors::VoiceGatewayError, types::{VoiceGatewayReceivePayload, VoiceCloseCode}};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+/// Defines a communication received from the gateway, being either an optionally compressed
+/// [RawGatewayMessage] or a [CloseCode].
+///
+/// Used only for a tungstenite gateway, since our underlying wasm backend handles close codes
+/// differently.
+pub(crate) enum VoiceGatewayCommunication {
+    Message(VoiceGatewayMessage),
+    Error(VoiceCloseCode),
+}
+
+impl From<VoiceGatewayMessage> for VoiceGatewayCommunication {
+    fn from(value: VoiceGatewayMessage) -> Self {
+        Self::Message(value)
+    }
+}
 
 /// Represents a message received from the voice websocket connection.
 ///
-/// This will be either a [VoiceGatewayReceivePayload], containing voice gateway events, or a [VoiceGatewayError].
+/// This should be a [VoiceGatewayReceivePayload].
 ///
 /// This struct is used internally when handling messages.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VoiceGatewayMessage(pub String);
 
 impl VoiceGatewayMessage {
-    /// Parses the message as an error;
-    /// Returns the error if successfully parsed, None if the message isn't an error
-    pub fn error(&self) -> Option<VoiceGatewayError> {
-        // Some error strings have dots on the end, which we don't care about
-        let processed_content = self.0.to_lowercase().replace('.', "");
-
-        match processed_content.as_str() {
-            "unknown opcode" | "4001" => Some(VoiceGatewayError::UnknownOpcode),
-            "decode error" | "failed to decode payload" | "4002" => {
-                Some(VoiceGatewayError::FailedToDecodePayload)
-            }
-            "not authenticated" | "4003" => Some(VoiceGatewayError::NotAuthenticated),
-            "authentication failed" | "4004" => Some(VoiceGatewayError::AuthenticationFailed),
-            "already authenticated" | "4005" => Some(VoiceGatewayError::AlreadyAuthenticated),
-            "session is no longer valid" | "4006" => Some(VoiceGatewayError::SessionNoLongerValid),
-            "session timeout" | "4009" => Some(VoiceGatewayError::SessionTimedOut),
-            "server not found" | "4011" => Some(VoiceGatewayError::ServerNotFound),
-            "unknown protocol" | "4012" => Some(VoiceGatewayError::UnknownProtocol),
-            "disconnected" | "4014" => Some(VoiceGatewayError::Disconnected),
-            "voice server crashed" | "4015" => Some(VoiceGatewayError::VoiceServerCrashed),
-            "unknown encryption mode" | "4016" => Some(VoiceGatewayError::UnknownEncryptionMode),
-            _ => None,
-        }
-    }
-
     /// Parses the message as a payload;
     /// Returns a result of deserializing
     pub fn payload(&self) -> Result<VoiceGatewayReceivePayload, serde_json::Error> {

--- a/src/voice/gateway/message.rs
+++ b/src/voice/gateway/message.rs
@@ -28,7 +28,7 @@ impl VoiceGatewayMessage {
             "authentication failed" | "4004" => Some(VoiceGatewayError::AuthenticationFailed),
             "already authenticated" | "4005" => Some(VoiceGatewayError::AlreadyAuthenticated),
             "session is no longer valid" | "4006" => Some(VoiceGatewayError::SessionNoLongerValid),
-            "session timeout" | "4009" => Some(VoiceGatewayError::SessionTimeout),
+            "session timeout" | "4009" => Some(VoiceGatewayError::SessionTimedOut),
             "server not found" | "4011" => Some(VoiceGatewayError::ServerNotFound),
             "unknown protocol" | "4012" => Some(VoiceGatewayError::UnknownProtocol),
             "disconnected" | "4014" => Some(VoiceGatewayError::Disconnected),

--- a/src/voice/gateway/message.rs
+++ b/src/voice/gateway/message.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use crate::{errors::VoiceGatewayError, types::{VoiceGatewayReceivePayload, VoiceCloseCode}};
+use crate::types::{VoiceGatewayReceivePayload, VoiceCloseCode};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// Defines a communication received from the gateway, being either an optionally compressed

--- a/tests/gateway.rs
+++ b/tests/gateway.rs
@@ -144,14 +144,7 @@ async fn test_gateway_errors() {
         channel: error_send,
     });
 
-    bundle
-        .user
-        .gateway
-        .events
-        .lock()
-        .await
-        .error
-        .subscribe(observer);
+    gateway.events.lock().await.error.subscribe(observer);
 
     let mut identify = types::GatewayIdentifyPayload::common();
     identify.token = bundle.user.token.clone();

--- a/tests/gateway.rs
+++ b/tests/gateway.rs
@@ -103,10 +103,10 @@ async fn test_gateway_authenticate() {
     common::teardown(bundle).await
 }
 
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+//#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+//#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
 /// Tests establishing a connection and receiving errors
-async fn test_gateway_errors() {
+/*async fn test_gateway_errors() {
     let bundle = common::setup().await;
 
     let gateway: GatewayHandle = Gateway::spawn(&bundle.urls.wss, GatewayOptions::default())
@@ -143,7 +143,7 @@ async fn test_gateway_errors() {
     }
 
     common::teardown(bundle).await
-}
+}*/
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]

--- a/tests/gateway.rs
+++ b/tests/gateway.rs
@@ -103,10 +103,10 @@ async fn test_gateway_authenticate() {
     common::teardown(bundle).await
 }
 
-//#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
-//#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
 /// Tests establishing a connection and receiving errors
-/*async fn test_gateway_errors() {
+async fn test_gateway_errors() {
     let bundle = common::setup().await;
 
     let gateway: GatewayHandle = Gateway::spawn(&bundle.urls.wss, GatewayOptions::default())
@@ -126,8 +126,7 @@ async fn test_gateway_authenticate() {
 
     gateway.send_identify(identify.clone()).await;
 
-    // Wait a bit, then identify again, so we should receive already authenticated
-    sleep(Duration::from_secs(2)).await;
+    // Identify again, so we should receive already authenticated
     gateway.send_identify(identify).await;
 
     tokio::select! {
@@ -143,7 +142,7 @@ async fn test_gateway_authenticate() {
     }
 
     common::teardown(bundle).await
-}*/
+}
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]


### PR DESCRIPTION
also introduces a test for receiving the close codes. 

Differentiates the wasm and tungstenite gateways a bit more.

The same thing should be done for the voice gateway, I'll likely add it to this pr if the mod to the normal gateway is okay