### PR TITLE
Fix some gateway deserialization errors

### DIFF
--- a/src/gateway/events.rs
+++ b/src/gateway/events.rs
@@ -72,6 +72,7 @@ pub struct Message {
     pub reaction_remove_emoji: Publisher<types::MessageReactionRemoveEmoji>,
     pub recent_mention_delete: Publisher<types::RecentMentionDelete>,
     pub ack: Publisher<types::MessageACK>,
+    pub last_messages: Publisher<types::LastMessages>,
 }
 
 #[derive(Default, Debug)]

--- a/src/gateway/handle.rs
+++ b/src/gateway/handle.rs
@@ -8,7 +8,7 @@ use log::*;
 use std::fmt::Debug;
 
 use super::{events::Events, *};
-use crate::types::{self, Composite, Shared};
+use crate::types::{self, Composite, Opcode, Shared};
 
 /// Represents a handle to a Gateway connection.
 ///
@@ -105,70 +105,90 @@ impl GatewayHandle {
         object
     }
 
-    /// Sends an identify event to the gateway
+    /// Sends an identify event ([types::GatewayIdentifyPayload]) to the gateway
     pub async fn send_identify(&self, to_send: types::GatewayIdentifyPayload) {
         let to_send_value = serde_json::to_value(&to_send).unwrap();
 
         trace!("GW: Sending Identify..");
 
-        self.send_json_event(GATEWAY_IDENTIFY, to_send_value).await;
+        self.send_json_event(Opcode::Identify as u8, to_send_value).await;
     }
 
-    /// Sends a resume event to the gateway
+    /// Sends a resume event ([types::GatewayResume]) to the gateway
     pub async fn send_resume(&self, to_send: types::GatewayResume) {
         let to_send_value = serde_json::to_value(&to_send).unwrap();
 
         trace!("GW: Sending Resume..");
 
-        self.send_json_event(GATEWAY_RESUME, to_send_value).await;
+        self.send_json_event(Opcode::Resume as u8, to_send_value).await;
     }
 
-    /// Sends an update presence event to the gateway
+    /// Sends an update presence event ([types::UpdatePresence]) to the gateway
     pub async fn send_update_presence(&self, to_send: types::UpdatePresence) {
         let to_send_value = serde_json::to_value(&to_send).unwrap();
 
         trace!("GW: Sending Update Presence..");
 
-        self.send_json_event(GATEWAY_UPDATE_PRESENCE, to_send_value)
+        self.send_json_event(Opcode::PresenceUpdate as u8, to_send_value)
             .await;
     }
 
-    /// Sends a request guild members to the server
+    /// Sends a request guild members ([types::GatewayRequestGuildMembers]) to the server
     pub async fn send_request_guild_members(&self, to_send: types::GatewayRequestGuildMembers) {
         let to_send_value = serde_json::to_value(&to_send).unwrap();
 
         trace!("GW: Sending Request Guild Members..");
 
-        self.send_json_event(GATEWAY_REQUEST_GUILD_MEMBERS, to_send_value)
+        self.send_json_event(Opcode::RequestGuildMembers as u8, to_send_value)
             .await;
     }
 
-    /// Sends an update voice state to the server
+    /// Sends an update voice state ([types::UpdateVoiceState]) to the server
     pub async fn send_update_voice_state(&self, to_send: types::UpdateVoiceState) {
         let to_send_value = serde_json::to_value(to_send).unwrap();
 
         trace!("GW: Sending Update Voice State..");
 
-        self.send_json_event(GATEWAY_UPDATE_VOICE_STATE, to_send_value)
+        self.send_json_event(Opcode::VoiceStateUpdate as u8, to_send_value)
             .await;
     }
 
-    /// Sends a call sync to the server
+    /// Sends a call sync ([types::CallSync]) to the server
     pub async fn send_call_sync(&self, to_send: types::CallSync) {
         let to_send_value = serde_json::to_value(to_send).unwrap();
 
         trace!("GW: Sending Call Sync..");
 
-        self.send_json_event(GATEWAY_CALL_SYNC, to_send_value).await;
+        self.send_json_event(Opcode::CallConnect as u8, to_send_value).await;
     }
 
-    /// Sends a Lazy Request
+	 /// Sends a request call connect event (aka [types::CallSync]) to the server
+	 ///
+	 /// # Notes
+	 /// Alias of [Self::send_call_sync]
+    pub async fn send_request_call_connect(&self, to_send: types::CallSync) {
+		 self.send_call_sync(to_send).await
+    }
+
+    /// Sends a Lazy Request ([types::LazyRequest]) to the server
     pub async fn send_lazy_request(&self, to_send: types::LazyRequest) {
         let to_send_value = serde_json::to_value(&to_send).unwrap();
 
         trace!("GW: Sending Lazy Request..");
 
-        self.send_json_event(GATEWAY_LAZY_REQUEST, to_send_value)
+        self.send_json_event(Opcode::GuildSubscriptions as u8, to_send_value)
+            .await;
+    }
+
+	 /// Sends a Request Last Messages ([types::RequestLastMessages]) to the server
+	 ///
+	 /// The server should respond with a [types::LastMessages] event
+    pub async fn send_request_last_messages(&self, to_send: types::RequestLastMessages) {
+        let to_send_value = serde_json::to_value(&to_send).unwrap();
+
+        trace!("GW: Sending Request Last Messages..");
+
+        self.send_json_event(Opcode::RequestLastMessages as u8, to_send_value)
             .await;
     }
 

--- a/src/gateway/heartbeat.rs
+++ b/src/gateway/heartbeat.rs
@@ -23,13 +23,13 @@ use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::task;
 
 use super::*;
-use crate::types;
+use crate::types::{self, Opcode};
 
 /// The amount of time we wait for a heartbeat ack before resending our heartbeat in ms
 pub const HEARTBEAT_ACK_TIMEOUT: u64 = 2000;
 
 /// Handles sending heartbeats to the gateway in another thread
-#[allow(dead_code)] // FIXME: Remove this, once HeartbeatHandler is used
+#[allow(dead_code)] // FIXME: Remove this, once HeartbeatHandler is "used"
 #[derive(Debug)]
 pub(super) struct HeartbeatHandler {
     /// How ofter heartbeats need to be sent at a minimum
@@ -98,11 +98,11 @@ impl HeartbeatHandler {
 
                     if let Some(op_code) = communication.op_code {
                         match op_code {
-                            GATEWAY_HEARTBEAT => {
+                            Opcode::Heartbeat => {
                                 // As per the api docs, if the server sends us a Heartbeat, that means we need to respond with a heartbeat immediately
                                 should_send = true;
                             }
-                            GATEWAY_HEARTBEAT_ACK => {
+                            Opcode::HeartbeatAck => {
                                 // The server received our heartbeat
                                 last_heartbeat_acknowledged = true;
                             }
@@ -120,7 +120,7 @@ impl HeartbeatHandler {
                 trace!("GW: Sending Heartbeat..");
 
                 let heartbeat = types::GatewayHeartbeat {
-                    op: GATEWAY_HEARTBEAT,
+                    op: (Opcode::Heartbeat as u8),
                     d: last_seq_number,
                 };
 
@@ -147,7 +147,7 @@ impl HeartbeatHandler {
 #[derive(Clone, Copy, Debug)]
 pub(super) struct HeartbeatThreadCommunication {
     /// The opcode for the communication we received, if relevant
-    pub(super) op_code: Option<u8>,
+    pub(super) op_code: Option<Opcode>,
     /// The sequence number we got from discord, if any
     pub(super) sequence_number: Option<u64>,
 }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -20,61 +20,13 @@ pub use message::*;
 pub use options::*;
 
 use crate::errors::GatewayError;
-use crate::types::{Opcode, Snowflake};
+use crate::types::Snowflake;
 
 use std::any::Any;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
 use tokio::sync::Mutex;
-
-// Gateway opcodes
-/// Opcode received when the server dispatches a [crate::types::WebSocketEvent]
-const GATEWAY_DISPATCH: u8 = Opcode::Dispatch as u8;
-/// Opcode sent when sending a heartbeat
-const GATEWAY_HEARTBEAT: u8 = Opcode::Heartbeat as u8;
-/// Opcode sent to initiate a session
-///
-/// See [types::GatewayIdentifyPayload]
-const GATEWAY_IDENTIFY: u8 = Opcode::Identify as u8;
-/// Opcode sent to update our presence
-///
-/// See [types::GatewayUpdatePresence]
-const GATEWAY_UPDATE_PRESENCE: u8 = Opcode::PresenceUpdate as u8;
-/// Opcode sent to update our state in vc
-///
-/// Like muting, deafening, leaving, joining..
-///
-/// See [types::UpdateVoiceState]
-const GATEWAY_UPDATE_VOICE_STATE: u8 = Opcode::VoiceStateUpdate as u8;
-/// Opcode sent to resume a session
-///
-/// See [types::GatewayResume]
-const GATEWAY_RESUME: u8 = Opcode::Resume as u8;
-/// Opcode received to tell the client to reconnect
-const GATEWAY_RECONNECT: u8 = Opcode::Reconnect as u8;
-/// Opcode sent to request guild member data
-///
-/// See [types::GatewayRequestGuildMembers]
-const GATEWAY_REQUEST_GUILD_MEMBERS: u8 = Opcode::RequestGuildMembers as u8;
-/// Opcode received to tell the client their token / session is invalid
-const GATEWAY_INVALID_SESSION: u8 = Opcode::InvalidSession as u8;
-/// Opcode received when initially connecting to the gateway, starts our heartbeat
-///
-/// See [types::HelloData]
-const GATEWAY_HELLO: u8 = Opcode::Hello as u8;
-/// Opcode received to acknowledge a heartbeat
-const GATEWAY_HEARTBEAT_ACK: u8 = Opcode::HeartbeatAck as u8;
-/// Opcode sent to get the voice state of users in a given DM/group channel
-///
-/// See [types::CallSync]
-const GATEWAY_CALL_SYNC: u8 = Opcode::CallConnect as u8;
-/// Opcode sent to get data for a server (Lazy Loading request)
-///
-/// Sent by the official client when switching to a server
-///
-/// See [types::LazyRequest]
-const GATEWAY_LAZY_REQUEST: u8 = Opcode::GuildSync as u8;
 
 pub type ObservableObject = dyn Send + Sync + Any;
 

--- a/src/types/entities/relationship.rs
+++ b/src/types/entities/relationship.rs
@@ -9,7 +9,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 use crate::errors::ChorusError;
 use crate::types::{Shared, Snowflake};
 
-use super::{arc_rwlock_ptr_eq, PublicUser};
+use super::{option_arc_rwlock_ptr_eq, PublicUser};
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
@@ -25,7 +25,11 @@ pub struct Relationship {
     pub nickname: Option<String>,
     #[cfg_attr(feature = "sqlx", sqlx(skip))] // Can be derived from the user id
     /// The target user
-    pub user: Shared<PublicUser>,
+    ///
+    /// Note: on Discord.com, this is not sent in select places, such as READY payload.
+    ///
+    /// In such a case, you should refer to the id field and seperately fetch the user's data
+    pub user: Option<Shared<PublicUser>>,
     /// When the user requested a relationship
     pub since: Option<DateTime<Utc>>,
 }
@@ -36,7 +40,7 @@ impl PartialEq for Relationship {
         self.id == other.id
             && self.relationship_type == other.relationship_type
             && self.nickname == other.nickname
-            && arc_rwlock_ptr_eq(&self.user, &other.user)
+            && option_arc_rwlock_ptr_eq(&self.user, &other.user)
             && self.since == other.since
     }
 }

--- a/src/types/events/call.rs
+++ b/src/types/events/call.rs
@@ -11,32 +11,42 @@ use chorus_macros::WebSocketEvent;
 /// Officially Undocumented;
 /// Is sent to a client by the server to signify a new call being created;
 ///
-/// Ex: {"t":"CALL_CREATE","s":2,"op":0,"d":{"voice_states":[],"ringing":[],"region":"milan","message_id":"1107187514906775613","embedded_activities":[],"channel_id":"837609115475771392"}}
+/// # Reference
+/// See <https://docs.discord.sex/topics/gateway-events#call-create>
 pub struct CallCreate {
-    pub voice_states: Vec<VoiceState>,
-    /// Seems like a vec of channel ids
-    pub ringing: Vec<String>,
-    pub region: String,
-    // milan
-    pub message_id: Snowflake,
-    /// What is this?
-    pub embedded_activities: Vec<serde_json::Value>,
+    /// Id of the private channel this call is in
     pub channel_id: Snowflake,
+    /// Id of the messsage which created the call
+    pub message_id: Snowflake,
+
+    /// The IDs of users that are being rung to join the call
+    pub ringing: Vec<Snowflake>,
+
+    // milan
+    pub region: String,
+
+    /// The voice states of the users already in the call
+    pub voice_states: Vec<VoiceState>,
+    // What is this?
+    //pub embedded_activities: Vec<serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq, Eq, WebSocketEvent)]
-/// Officially Undocumented;
-/// Updates the client on which calls are ringing, along with a specific call?;
+/// Updates the client when metadata about a call changes.
 ///
-/// Ex: {"t":"CALL_UPDATE","s":5,"op":0,"d":{"ringing":["837606544539254834"],"region":"milan","message_id":"1107191540234846308","guild_id":null,"channel_id":"837609115475771392"}}
+/// # Reference
+/// See <https://docs.discord.sex/topics/gateway-events#call-update>
 pub struct CallUpdate {
-    /// Seems like a vec of channel ids
-    pub ringing: Vec<Snowflake>,
-    pub region: String,
-    // milan
-    pub message_id: Snowflake,
-    pub guild_id: Option<Snowflake>,
+    /// Id of the private channel this call is in
     pub channel_id: Snowflake,
+    /// Id of the messsage which created the call
+    pub message_id: Snowflake,
+
+    /// The IDs of users that are being rung to join the call
+    pub ringing: Vec<Snowflake>,
+
+    // milan
+    pub region: String,
 }
 
 #[derive(
@@ -52,11 +62,14 @@ pub struct CallUpdate {
     PartialOrd,
     Ord,
 )]
-/// Officially Undocumented;
-/// Deletes a ringing call;
-/// Ex: {"t":"CALL_DELETE","s":8,"op":0,"d":{"channel_id":"837609115475771392"}}
+/// Sent when a call is deleted, or becomes unavailable due to an outage.
+///
+/// # Reference
+/// See <https://docs.discord.sex/topics/gateway-events#call-delete>
 pub struct CallDelete {
     pub channel_id: Snowflake,
+	 /// Whether the call is unavailable due to an outage
+	 pub unavailable: Option<bool>,
 }
 
 #[derive(
@@ -72,10 +85,13 @@ pub struct CallDelete {
     PartialOrd,
     Ord,
 )]
-/// Officially Undocumented;
-/// See <https://unofficial-discord-docs.vercel.app/gateway/op13>;
+/// Used to request a private channel's pre-existing call data,
+/// created before the connection was established.
 ///
-/// Ex: {"op":13,"d":{"channel_id":"837609115475771392"}}
+/// Fires a [CallCreate] event if a call is found.
+///
+/// # Reference
+/// See <https://docs.discord.sex/topics/gateway-events#request-call-connect>;
 pub struct CallSync {
     pub channel_id: Snowflake,
 }

--- a/src/types/events/guild.rs
+++ b/src/types/events/guild.rs
@@ -244,7 +244,7 @@ pub struct GuildMembersChunk {
     pub chunk_index: u16,
     pub chunk_count: u16,
     pub not_found: Option<Vec<Snowflake>>,
-    pub presences: Option<PresenceUpdate>,
+    pub presences: Option<Vec<PresenceUpdate>>,
     pub nonce: Option<String>,
 }
 

--- a/src/types/events/lazy_request.rs
+++ b/src/types/events/lazy_request.rs
@@ -28,6 +28,6 @@ pub struct LazyRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub members: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub channels: Option<HashMap<String, Vec<Vec<u64>>>>,
+    pub channels: Option<HashMap<Snowflake, Vec<Vec<u64>>>>,
 }
 

--- a/src/types/events/lazy_request.rs
+++ b/src/types/events/lazy_request.rs
@@ -20,6 +20,7 @@ use super::WebSocketEvent;
 ///
 /// {"op":14,"d":{"guild_id":"848582562217590824","typing":true,"activities":true,"threads":true}}
 pub struct LazyRequest {
+	 /// The guild id to request
     pub guild_id: Snowflake,
     pub typing: bool,
     pub activities: bool,

--- a/src/types/events/message.rs
+++ b/src/types/events/message.rs
@@ -178,3 +178,28 @@ pub struct MessageACK {
     pub flags: Option<serde_json::Value>,
     pub channel_id: Snowflake,
 }
+
+#[derive(Debug, Deserialize, Serialize, Default, Clone, WebSocketEvent)]
+/// Used to request the last messages from channels.
+///
+/// Fires a [LastMessages] events with up to 100 messages that match the request.
+///
+/// # Reference
+/// See <https://docs.discord.sex/topics/gateway-events#request-last-messages>
+pub struct RequestLastMessages {
+	/// The ID of the guild the channels are in
+	pub guild_id: Snowflake,
+	/// The IDs of the channels to request last messages for (max 100)
+	pub channel_ids: Vec<Snowflake>
+}
+
+#[derive(Debug, Deserialize, Serialize, Default, Clone, WebSocketEvent)]
+/// Sent as a response to [RequestLastMessages].
+///
+/// # Reference
+/// See <https://docs.discord.sex/topics/gateway-events#last-messages>
+pub struct LastMessages {
+	/// The ID of the guild the channels are in
+	pub guild_id: Snowflake,
+	pub messages: Vec<Message>
+}

--- a/src/types/events/presence.rs
+++ b/src/types/events/presence.rs
@@ -5,6 +5,7 @@
 use crate::types::{events::WebSocketEvent, UserStatus};
 use crate::types::{Activity, ClientStatusObject, PublicUser, Snowflake};
 use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DefaultOnNull};
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone, WebSocketEvent)]
 /// Sent by the client to update its status and presence;
@@ -19,6 +20,7 @@ pub struct UpdatePresence {
     pub afk: bool,
 }
 
+#[serde_as]
 #[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq, WebSocketEvent)]
 /// Received to tell the client that a user updated their presence / status. If you are looking for
 /// the PresenceUpdate used in the IDENTIFY gateway event, see
@@ -30,7 +32,8 @@ pub struct PresenceUpdate {
     #[serde(default)]
     pub guild_id: Option<Snowflake>,
     pub status: UserStatus,
-    #[serde(default)]
+	 // This will just result in an empty array, I guess we could also use option
+    #[serde_as(deserialize_as = "DefaultOnNull")]
     pub activities: Vec<Activity>,
     pub client_status: ClientStatusObject,
 }

--- a/src/types/events/presence.rs
+++ b/src/types/events/presence.rs
@@ -11,8 +11,8 @@ use serde_with::{serde_as, DefaultOnNull};
 /// Sent by the client to update its status and presence;
 /// See <https://discord.com/developers/docs/topics/gateway-events#update-presence>
 pub struct UpdatePresence {
-    /// Unix time of when the client went idle, or n
-    /// one if client is not idle.
+    /// Unix time of when the client went idle, or none
+	 /// if client is not idle.
     pub since: Option<u128>,
     /// the client's status (online, invisible, offline, dnd, idle..)
     pub status: UserStatus,

--- a/src/types/events/ready.rs
+++ b/src/types/events/ready.rs
@@ -254,7 +254,8 @@ pub struct ReadStateEntry {
     pub id: Snowflake,
     pub last_message_id: Option<Snowflake>,
     pub last_pin_timestamp: Option<DateTime<Utc>>,
-    pub last_viewed: Option<DateTime<Utc>>,
+	 /// A value that is incremented each time the read state is read
+    pub last_viewed: Option<u32>,
     // Temporary adding Option to fix Spacebar servers, they have mention count as a nullable
     pub mention_count: Option<u64>,
 }

--- a/src/types/events/ready.rs
+++ b/src/types/events/ready.rs
@@ -10,7 +10,8 @@ use serde::{Deserialize, Serialize};
 use crate::types::entities::{Guild, User};
 use crate::types::events::{Session, WebSocketEvent};
 use crate::types::{
-    Activity, Channel, ClientStatusObject, GuildMember, MfaAuthenticatorType, PresenceUpdate, Relationship, Snowflake, UserSettings, VoiceState
+    Activity, Channel, ClientStatusObject, GuildMember, MfaAuthenticatorType, PresenceUpdate,
+    Relationship, Snowflake, UserSettings, VoiceState,
 };
 use crate::{UInt32, UInt64, UInt8};
 
@@ -239,10 +240,12 @@ pub struct ReadState {
 )]
 /// Not documented even unofficially. Information about this type is likely to be partially incorrect.
 pub struct ReadStateEntry {
-    pub flags: u32,
+    /// Spacebar servers do not have flags in this entity at all (??)
+    pub flags: Option<u32>,
     pub id: Snowflake,
     pub last_message_id: Option<Snowflake>,
     pub last_pin_timestamp: Option<DateTime<Utc>>,
     pub last_viewed: Option<DateTime<Utc>>,
-    pub mention_count: u64,
+    // Temporary adding Option to fix Spacebar servers, they have mention count as a nullable
+    pub mention_count: Option<u64>,
 }

--- a/src/types/events/ready.rs
+++ b/src/types/events/ready.rs
@@ -90,12 +90,21 @@ pub struct GatewayReady {
     pub api_code_version: UInt8,
     #[serde(default)]
     /// User experiment rollouts for the user
+    ///
     /// TODO: Make User Experiments into own struct
-    pub experiments: Vec<String>,
+    // Note: this is a pain to parse! We need a way to parse arrays into structs via the index of
+    // their feilds
+    //
+    // ex: [4130837190, 0, 10, -1, 0, 1932, 0, 0]
+    // needs to be parsed into a struct with fields corresponding to the first, second.. value in
+    // the array
+    pub experiments: Vec<serde_json::value::Value>,
     #[serde(default)]
     /// Guild experiment rollouts for the user
+    ///
     /// TODO: Make Guild Experiments into own struct
-    pub guild_experiments: Vec<String>,
+    // Note: this is a pain to parse! See the above TODO
+    pub guild_experiments: Vec<serde_json::value::Value>,
     pub read_state: ReadState,
 }
 

--- a/src/types/events/request_members.rs
+++ b/src/types/events/request_members.rs
@@ -2,17 +2,43 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use crate::types::{events::WebSocketEvent, Snowflake};
+use crate::types::{events::WebSocketEvent, OneOrMoreSnowflakes};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize, Default, WebSocketEvent, Clone)]
-/// See <https://discord.com/developers/docs/topics/gateway-events#request-guild-members-request-guild-members-structure>
+#[derive(Debug, Deserialize, Serialize, WebSocketEvent, Clone)]
+/// Used to request members for a guild or a list of guilds.
+///
+/// Fires multiple [crate::types::events::GuildMembersChunk] events (each with up to 1000 members)
+/// until all members that match the request have been sent.
+///
+/// # Notes
+/// One of `query` or `user_ids` is required.
+///
+/// If `query` is set, `limit` is required (if requesting all members, set `limit` to 0)
+///
+/// # Reference
+/// See <https://docs.discord.sex/topics/gateway-events#request-guild-members>
 pub struct GatewayRequestGuildMembers {
-    pub guild_id: Snowflake,
+	 /// Id(s) of the guild(s) to get members for
+    pub guild_id: OneOrMoreSnowflakes,
+
+	 /// The user id(s) to request (0 - 100)
+    pub user_ids: Option<OneOrMoreSnowflakes>,
+
+	 /// String that the username / nickname starts with, or an empty string for all members
     pub query: Option<String>,
-    pub limit: u64,
+
+	 /// Maximum number of members to send matching the query (0 - 100)
+	 ///
+	 /// Must be 0 with an empty query
+    pub limit: u8,
+
+	 /// Whether to return the [Presence](crate::types::events::PresenceUpdate) of the matched
+	 /// members
     pub presences: Option<bool>,
-    // TODO: allow array
-    pub user_ids: Option<Snowflake>,
+
+	 /// Unique string to identify the received event for this specific request.
+	 ///
+	 /// Up to 32 bytes. If you send a longer nonce, it will be ignored
     pub nonce: Option<String>,
 }

--- a/src/types/events/request_members.rs
+++ b/src/types/events/request_members.rs
@@ -5,7 +5,7 @@
 use crate::types::{events::WebSocketEvent, OneOrMoreSnowflakes};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, Serialize, WebSocketEvent, Clone)]
+#[derive(Debug, Deserialize, Default, Serialize, WebSocketEvent, Clone)]
 /// Used to request members for a guild or a list of guilds.
 ///
 /// Fires multiple [crate::types::events::GuildMembersChunk] events (each with up to 1000 members)

--- a/src/types/utils/mod.rs
+++ b/src/types/utils/mod.rs
@@ -6,7 +6,7 @@
 pub use opcode::*;
 pub use regexes::*;
 pub use rights::Rights;
-pub use snowflake::Snowflake;
+pub use snowflake::{Snowflake, OneOrMoreSnowflakes};
 
 pub mod jwt;
 pub mod opcode;

--- a/src/types/utils/snowflake.rs
+++ b/src/types/utils/snowflake.rs
@@ -153,6 +153,14 @@ pub enum OneOrMoreSnowflakes {
 	More(Vec<Snowflake>)
 }
 
+// Note: allows us to have Default on the events
+// that use this type
+impl Default for OneOrMoreSnowflakes {
+    fn default() -> Self {
+        Snowflake::default().into()
+    }
+}
+
 impl Display for OneOrMoreSnowflakes {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		  match self {


### PR DESCRIPTION
See the commits; 
- Discord is messing with their api again, read states are a mystery
- Refactored the gateway to fully use the `Opcode` enum instead of constants (4ed68ce7a506d0354730b4b4f0b7d4267c5e2a50)
- Added Last Messages request and response (4ed68ce7a506d0354730b4b4f0b7d4267c5e2a50)
- Fixed a deserialization error related to `presences` in `GuildMembersChunk` being an array, not a single value (4baecf978415b680d5ef13061c24e5e363d19988)
- Fixed a deserialization error with deserializing `activities` in `PresenceUpdate` as an empty array when they are sent as `null` (1b201020e9dec23e2dfcd467e49c58b151d88e0e)
- Add type `OneOrMoreSnowflakes`, allow `GatewayRequestGuildMembers` to request multiple guild and user ids (644d3beb90bc1aedd2dd222cab199457d4dffddd, 85e922bc5039bd2af091b4a95d4b7f7d82ade7e2)
- Updated `LazyRequest` (op 14) to use the `Snowflake` type for ids instead of just `String` (61ac7d1465f2509bed01ddefc31228c31d893704)
- Fixed a deserialization error on discord.com related to experiments (they are not implemented yet, see #578) (7feb57186a8bb3f873cc4d5935280de0c8687511)
- Fixed a deserialization error on discord.com related to `last_viewed` in `ReadState` being a version / counter, not a `DateTime` (fb94afa390e41caeec3883d5feaf8aa6dc9b8985)