### PR TITLE
Client properties API

### DIFF
--- a/src/api/auth/mod.rs
+++ b/src/api/auth/mod.rs
@@ -25,7 +25,7 @@ impl Instance {
     pub async fn login_with_token(&mut self, token: &str) -> ChorusResult<ChorusUser> {
         let mut user = ChorusUser::shell(Arc::new(RwLock::new(self.clone())), token).await;
 
-		  user.update_with_login_data(token.to_string(), None).await?;
+        user.update_with_login_data(token.to_string(), None).await?;
 
         Ok(user)
     }

--- a/src/api/auth/register.rs
+++ b/src/api/auth/register.rs
@@ -8,7 +8,7 @@ use reqwest::Client;
 use serde_json::to_string;
 
 use crate::gateway::{Gateway, GatewayHandle};
-use crate::types::{GatewayIdentifyPayload, User};
+use crate::types::{ClientProperties, GatewayIdentifyPayload, User};
 use crate::{
     errors::ChorusResult,
     instance::{ChorusUser, Instance, Token},
@@ -28,12 +28,12 @@ impl Instance {
     ) -> ChorusResult<ChorusUser> {
         let endpoint_url = self.urls.api.clone() + "/auth/register";
         let chorus_request = ChorusRequest {
-            request: Client::new()
-                .post(endpoint_url)
-                .body(to_string(&register_schema).unwrap())
-                .header("Content-Type", "application/json"),
+            request: Client::new().post(endpoint_url).json(&register_schema),
             limit_type: LimitType::AuthRegister,
-        };
+        }
+        // Note: yes, this is still sent even for login and register
+        .with_client_properties(&ClientProperties::default());
+
         // We do not have a user yet, and the UserRateLimits will not be affected by a login
         // request (since register is an instance wide limit), which is why we are just cloning
         // the instances' limits to pass them on as user_rate_limits later.

--- a/src/api/channels/channels.rs
+++ b/src/api/channels/channels.rs
@@ -21,18 +21,15 @@ impl Channel {
     /// # Reference
     /// See <https://discord-userdoccers.vercel.app/resources/channel#get-channel>
     pub async fn get(user: &mut ChorusUser, channel_id: Snowflake) -> ChorusResult<Channel> {
-        let chorus_request = ChorusRequest::new(
-            http::Method::GET,
-            &format!(
+        let chorus_request = ChorusRequest {
+            request: Client::new().get(format!(
                 "{}/channels/{}",
                 user.belongs_to.read().unwrap().urls.api.clone(),
                 channel_id
-            ),
-            None,
-            None,
-            Some(user),
-            LimitType::Channel(channel_id),
-        );
+            )),
+            limit_type: LimitType::Channel(channel_id),
+        }
+        .with_headers_for(user);
 
         chorus_request.deserialize_response::<Channel>(user).await
     }
@@ -55,14 +52,12 @@ impl Channel {
             self.id,
         );
 
-        let request = ChorusRequest::new(
-            http::Method::DELETE,
-            &url,
-            None,
-            audit_log_reason.as_deref(),
-            Some(user),
-            LimitType::Channel(self.id),
-        );
+        let request = ChorusRequest {
+            request: Client::new().delete(url),
+            limit_type: LimitType::Channel(self.id),
+        }
+        .with_maybe_audit_log_reason(audit_log_reason)
+        .with_headers_for(user);
 
         request.handle_request_as_result(user).await
     }
@@ -94,14 +89,12 @@ impl Channel {
             channel_id
         );
 
-        let request = ChorusRequest::new(
-            http::Method::PATCH,
-            &url,
-            Some(to_string(&modify_data).unwrap()),
-            audit_log_reason.as_deref(),
-            Some(user),
-            LimitType::Channel(channel_id),
-        );
+        let request = ChorusRequest {
+            request: Client::new().patch(url).json(&modify_data),
+            limit_type: LimitType::Channel(channel_id),
+        }
+        .with_maybe_audit_log_reason(audit_log_reason)
+        .with_headers_for(user);
 
         request.deserialize_response::<Channel>(user).await
     }
@@ -126,14 +119,12 @@ impl Channel {
             channel_id
         );
 
-        let mut chorus_request = ChorusRequest::new(
-            http::Method::GET,
-            &url,
-            None,
-            None,
-            Some(user),
-            Default::default(),
-        );
+        let mut chorus_request = ChorusRequest {
+            request: Client::new().get(url),
+            limit_type: Default::default(),
+        }
+        .with_headers_for(user);
+
         chorus_request.request = chorus_request.request.query(&range);
 
         chorus_request
@@ -151,22 +142,22 @@ impl Channel {
         user: &mut ChorusUser,
         add_channel_recipient_schema: Option<AddChannelRecipientSchema>,
     ) -> ChorusResult<()> {
-        let mut request = Client::new()
-            .put(format!(
-                "{}/channels/{}/recipients/{}",
-                user.belongs_to.read().unwrap().urls.api,
-                self.id,
-                recipient_id
-            ))
-            .header("Authorization", user.token())
-            .header("Content-Type", "application/json");
+        let mut request = Client::new().put(format!(
+            "{}/channels/{}/recipients/{}",
+            user.belongs_to.read().unwrap().urls.api,
+            self.id,
+            recipient_id
+        ));
+
         if let Some(schema) = add_channel_recipient_schema {
-            request = request.body(to_string(&schema).unwrap());
+            request = request.json(&schema);
         }
+
         ChorusRequest {
             request,
             limit_type: LimitType::Channel(self.id),
         }
+        .with_headers_for(user)
         .handle_request_as_result(user)
         .await
     }
@@ -187,14 +178,11 @@ impl Channel {
             recipient_id
         );
 
-        let request = ChorusRequest::new(
-            http::Method::DELETE,
-            &url,
-            None,
-            None,
-            Some(user),
-            LimitType::Channel(self.id),
-        );
+        let request = ChorusRequest {
+            request: Client::new().delete(url),
+            limit_type: LimitType::Channel(self.id),
+        }
+        .with_headers_for(user);
 
         request.handle_request_as_result(user).await
     }
@@ -215,14 +203,11 @@ impl Channel {
             guild_id
         );
 
-        let request = ChorusRequest::new(
-            http::Method::PATCH,
-            &url,
-            Some(to_string(&schema).unwrap()),
-            None,
-            Some(user),
-            LimitType::Guild(guild_id),
-        );
+        let request = ChorusRequest {
+            request: Client::new().patch(url).json(&schema),
+            limit_type: LimitType::Guild(guild_id),
+        }
+        .with_headers_for(user);
 
         request.handle_request_as_result(user).await
     }

--- a/src/api/channels/reactions.rs
+++ b/src/api/channels/reactions.rs
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use reqwest::Client;
+
 use crate::{
     errors::ChorusResult,
     instance::ChorusUser,
@@ -31,14 +33,11 @@ impl ReactionMeta {
             self.message_id
         );
 
-        let request = ChorusRequest::new(
-            http::Method::DELETE,
-            &url,
-            None,
-            None,
-            Some(user),
-            LimitType::Channel(self.channel_id),
-        );
+        let request = ChorusRequest {
+            request: Client::new().delete(url),
+            limit_type: LimitType::Channel(self.channel_id),
+        }
+        .with_headers_for(user);
 
         request.handle_request_as_result(user).await
     }
@@ -59,14 +58,11 @@ impl ReactionMeta {
             emoji
         );
 
-        let request = ChorusRequest::new(
-            http::Method::GET,
-            &url,
-            None,
-            None,
-            Some(user),
-            LimitType::Channel(self.channel_id),
-        );
+        let request = ChorusRequest {
+            request: Client::new().get(url),
+            limit_type: LimitType::Channel(self.channel_id),
+        }
+        .with_headers_for(user);
 
         request.deserialize_response::<Vec<PublicUser>>(user).await
     }
@@ -89,14 +85,11 @@ impl ReactionMeta {
             emoji
         );
 
-        let request = ChorusRequest::new(
-            http::Method::DELETE,
-            &url,
-            None,
-            None,
-            Some(user),
-            LimitType::Channel(self.channel_id),
-        );
+        let request = ChorusRequest {
+            request: Client::new().delete(url),
+            limit_type: LimitType::Channel(self.channel_id),
+        }
+        .with_headers_for(user);
 
         request.handle_request_as_result(user).await
     }
@@ -122,14 +115,11 @@ impl ReactionMeta {
             emoji
         );
 
-        let request = ChorusRequest::new(
-            http::Method::PUT,
-            &url,
-            None,
-            None,
-            Some(user),
-            LimitType::Channel(self.channel_id),
-        );
+        let request = ChorusRequest {
+            request: Client::new().put(url),
+            limit_type: LimitType::Channel(self.channel_id),
+        }
+        .with_headers_for(user);
 
         request.handle_request_as_result(user).await
     }
@@ -150,14 +140,11 @@ impl ReactionMeta {
             emoji
         );
 
-        let request = ChorusRequest::new(
-            http::Method::DELETE,
-            &url,
-            None,
-            None,
-            Some(user),
-            LimitType::Channel(self.channel_id),
-        );
+        let request = ChorusRequest {
+            request: Client::new().delete(url),
+            limit_type: LimitType::Channel(self.channel_id),
+        }
+        .with_headers_for(user);
 
         request.handle_request_as_result(user).await
     }
@@ -186,14 +173,11 @@ impl ReactionMeta {
             user_id
         );
 
-        let request = ChorusRequest::new(
-            http::Method::DELETE,
-            &url,
-            None,
-            None,
-            Some(user),
-            LimitType::Channel(self.channel_id),
-        );
+        let request = ChorusRequest {
+            request: Client::new().delete(url),
+            limit_type: LimitType::Channel(self.channel_id),
+        }
+        .with_headers_for(user);
 
         request.handle_request_as_result(user).await
     }

--- a/src/api/guilds/member.rs
+++ b/src/api/guilds/member.rs
@@ -27,10 +27,13 @@ impl types::GuildMember {
             guild_id,
             member_id
         );
+
         let chorus_request = ChorusRequest {
-            request: Client::new().get(url).header("Authorization", user.token()),
+            request: Client::new().get(url),
             limit_type: LimitType::Guild(guild_id),
-        };
+        }
+        .with_headers_for(user);
+
         chorus_request
             .deserialize_response::<GuildMember>(user)
             .await
@@ -55,13 +58,13 @@ impl types::GuildMember {
             member_id,
             role_id
         );
+
         let chorus_request = ChorusRequest {
-            request: Client::new()
-                .put(url)
-                .header("Authorization", user.token())
-                .header("Content-Type", "application/json"),
+            request: Client::new().put(url),
             limit_type: LimitType::Guild(guild_id),
-        };
+        }
+        .with_headers_for(user);
+
         chorus_request.handle_request_as_result(user).await
     }
 
@@ -84,12 +87,13 @@ impl types::GuildMember {
             member_id,
             role_id
         );
+
         let chorus_request = ChorusRequest {
-            request: Client::new()
-                .delete(url)
-                .header("Authorization", user.token()),
+            request: Client::new().delete(url),
             limit_type: LimitType::Guild(guild_id),
-        };
+        }
+        .with_headers_for(user);
+
         chorus_request.handle_request_as_result(user).await
     }
 }

--- a/src/api/guilds/roles.rs
+++ b/src/api/guilds/roles.rs
@@ -28,15 +28,16 @@ impl types::RoleObject {
             user.belongs_to.read().unwrap().urls.api,
             guild_id
         );
+
         let chorus_request = ChorusRequest {
-            request: Client::new().get(url).header("Authorization", user.token()),
+            request: Client::new().get(url),
             limit_type: LimitType::Guild(guild_id),
-        };
-        let roles = chorus_request
+        }
+        .with_headers_for(user);
+
+        chorus_request
             .deserialize_response::<Vec<RoleObject>>(user)
             .await
-            .unwrap();
-        Ok(roles)
     }
 
     /// Retrieves a single role for a given guild.
@@ -54,10 +55,13 @@ impl types::RoleObject {
             guild_id,
             role_id
         );
+
         let chorus_request = ChorusRequest {
-            request: Client::new().get(url).header("Authorization", user.token()),
+            request: Client::new().get(url),
             limit_type: LimitType::Guild(guild_id),
-        };
+        }
+        .with_headers_for(user);
+
         chorus_request
             .deserialize_response::<RoleObject>(user)
             .await
@@ -79,19 +83,13 @@ impl types::RoleObject {
             user.belongs_to.read().unwrap().urls.api,
             guild_id
         );
-        let body = to_string::<RoleCreateModifySchema>(&role_create_schema).map_err(|e| {
-            ChorusError::FormCreation {
-                error: e.to_string(),
-            }
-        })?;
+
         let chorus_request = ChorusRequest {
-            request: Client::new()
-                .post(url)
-                .header("Authorization", user.token())
-                .header("Content-Type", "application/json")
-                .body(body),
+            request: Client::new().post(url).json(&role_create_schema),
             limit_type: LimitType::Guild(guild_id),
-        };
+        }
+        .with_headers_for(user);
+
         chorus_request
             .deserialize_response::<RoleObject>(user)
             .await
@@ -113,18 +111,13 @@ impl types::RoleObject {
             user.belongs_to.read().unwrap().urls.api,
             guild_id
         );
-        let body =
-            to_string(&role_position_update_schema).map_err(|e| ChorusError::FormCreation {
-                error: e.to_string(),
-            })?;
+
         let chorus_request = ChorusRequest {
-            request: Client::new()
-                .patch(url)
-                .header("Authorization", user.token())
-                .header("Content-Type", "application/json")
-                .body(body),
+            request: Client::new().patch(url).json(&role_position_update_schema),
             limit_type: LimitType::Guild(guild_id),
-        };
+        }
+        .with_headers_for(user);
+
         chorus_request
             .deserialize_response::<RoleObject>(user)
             .await
@@ -148,19 +141,13 @@ impl types::RoleObject {
             guild_id,
             role_id
         );
-        let body = to_string::<RoleCreateModifySchema>(&role_create_schema).map_err(|e| {
-            ChorusError::FormCreation {
-                error: e.to_string(),
-            }
-        })?;
+
         let chorus_request = ChorusRequest {
-            request: Client::new()
-                .patch(url)
-                .header("Authorization", user.token())
-                .header("Content-Type", "application/json")
-                .body(body),
+            request: Client::new().patch(url).json(&role_create_schema),
             limit_type: LimitType::Guild(guild_id),
-        };
+        }
+        .with_headers_for(user);
+
         chorus_request
             .deserialize_response::<RoleObject>(user)
             .await
@@ -183,14 +170,13 @@ impl types::RoleObject {
             role_id
         );
 
-        let request = ChorusRequest::new(
-            http::Method::DELETE,
-            &url,
-            None,
-            audit_log_reason.as_deref(),
-            Some(user),
-            LimitType::Guild(guild_id),
-        );
+        let request = ChorusRequest {
+            request: Client::new().delete(url),
+            limit_type: LimitType::Guild(guild_id),
+        }
+        .with_maybe_audit_log_reason(audit_log_reason)
+        .with_headers_for(user);
+
         request.handle_request_as_result(user).await
     }
 }

--- a/src/api/users/channels.rs
+++ b/src/api/users/channels.rs
@@ -23,12 +23,10 @@ impl ChorusUser {
             self.belongs_to.read().unwrap().urls.api
         );
         ChorusRequest {
-            request: Client::new()
-                .get(url)
-                .header("Authorization", self.token())
-                .header("Content-Type", "application/json"),
+            request: Client::new().get(url),
             limit_type: LimitType::Global,
         }
+        .with_headers_for(self)
         .deserialize_response::<Vec<Channel>>(self)
         .await
     }
@@ -49,13 +47,10 @@ impl ChorusUser {
             self.belongs_to.read().unwrap().urls.api
         );
         ChorusRequest {
-            request: Client::new()
-                .post(url)
-                .header("Authorization", self.token())
-                .header("Content-Type", "application/json")
-                .body(to_string(&create_private_channel_schema).unwrap()),
+            request: Client::new().post(url).json(&create_private_channel_schema),
             limit_type: LimitType::Global,
         }
+        .with_headers_for(self)
         .deserialize_response::<Channel>(self)
         .await
     }

--- a/src/api/users/connections.rs
+++ b/src/api/users/connections.rs
@@ -41,15 +41,15 @@ impl ChorusUser {
                 self.belongs_to.read().unwrap().urls.api,
                 connection_type_string
             ))
-            // Note: ommiting this header causes a 401 Unauthorized,
-            // even though discord.sex mentions it as unauthenticated
-            .header("Authorization", self.token())
             .query(&query_parameters);
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(self);
+        // Note: ommiting authorization causes a 401 Unauthorized,
+        // even though discord.sex mentions it as unauthenticated
 
         chorus_request
             .deserialize_response::<AuthorizeConnectionReturn>(self)
@@ -81,13 +81,13 @@ impl ChorusUser {
                 self.belongs_to.read().unwrap().urls.api,
                 connection_type_string
             ))
-            .header("Authorization", self.token())
             .json(&json_schema);
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(self);
 
         chorus_request.deserialize_response(self).await
     }
@@ -111,13 +111,13 @@ impl ChorusUser {
                 self.belongs_to.read().unwrap().urls.api,
                 connection_account_id
             ))
-            .header("Authorization", self.token())
             .json(&json_schema);
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(self);
 
         chorus_request.deserialize_response(self).await
     }
@@ -169,18 +169,17 @@ impl ChorusUser {
         &mut self,
         domain: &String,
     ) -> ChorusResult<CreateDomainConnectionReturn> {
-        let request = Client::new()
-            .post(format!(
-                "{}/users/@me/connections/domain/{}",
-                self.belongs_to.read().unwrap().urls.api,
-                domain
-            ))
-            .header("Authorization", self.token());
+        let request = Client::new().post(format!(
+            "{}/users/@me/connections/domain/{}",
+            self.belongs_to.read().unwrap().urls.api,
+            domain
+        ));
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(self);
 
         let result = chorus_request
             .deserialize_response::<Connection>(self)
@@ -217,17 +216,16 @@ impl ChorusUser {
     /// # Reference
     /// See <https://docs.discord.sex/resources/user#get-user-connections>
     pub async fn get_connections(&mut self) -> ChorusResult<Vec<Connection>> {
-        let request = Client::new()
-            .get(format!(
-                "{}/users/@me/connections",
-                self.belongs_to.read().unwrap().urls.api,
-            ))
-            .header("Authorization", self.token());
+        let request = Client::new().get(format!(
+            "{}/users/@me/connections",
+            self.belongs_to.read().unwrap().urls.api,
+        ));
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(self);
 
         chorus_request.deserialize_response(self).await
     }
@@ -245,19 +243,18 @@ impl ChorusUser {
             .expect("Failed to serialize connection type!")
             .replace('"', "");
 
-        let request = Client::new()
-            .post(format!(
-                "{}/users/@me/connections/{}/{}/refresh",
-                self.belongs_to.read().unwrap().urls.api,
-                connection_type_string,
-                connection_account_id
-            ))
-            .header("Authorization", self.token());
+        let request = Client::new().post(format!(
+            "{}/users/@me/connections/{}/{}/refresh",
+            self.belongs_to.read().unwrap().urls.api,
+            connection_type_string,
+            connection_account_id
+        ));
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(self);
 
         chorus_request.handle_request_as_result(self).await
     }
@@ -286,13 +283,13 @@ impl ChorusUser {
                 connection_type_string,
                 connection_account_id
             ))
-            .header("Authorization", self.token())
             .json(&json_schema);
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(self);
 
         chorus_request.deserialize_response(self).await
     }
@@ -310,19 +307,18 @@ impl ChorusUser {
             .expect("Failed to serialize connection type!")
             .replace('"', "");
 
-        let request = Client::new()
-            .delete(format!(
-                "{}/users/@me/connections/{}/{}",
-                self.belongs_to.read().unwrap().urls.api,
-                connection_type_string,
-                connection_account_id
-            ))
-            .header("Authorization", self.token());
+        let request = Client::new().delete(format!(
+            "{}/users/@me/connections/{}/{}",
+            self.belongs_to.read().unwrap().urls.api,
+            connection_type_string,
+            connection_account_id
+        ));
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(self);
 
         chorus_request.handle_request_as_result(self).await
     }
@@ -342,19 +338,18 @@ impl ChorusUser {
             .expect("Failed to serialize connection type!")
             .replace('"', "");
 
-        let request = Client::new()
-            .get(format!(
-                "{}/users/@me/connections/{}/{}/access-token",
-                self.belongs_to.read().unwrap().urls.api,
-                connection_type_string,
-                connection_account_id
-            ))
-            .header("Authorization", self.token());
+        let request = Client::new().get(format!(
+            "{}/users/@me/connections/{}/{}/access-token",
+            self.belongs_to.read().unwrap().urls.api,
+            connection_type_string,
+            connection_account_id
+        ));
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(self);
 
         chorus_request
             .deserialize_response::<GetConnectionAccessTokenReturn>(self)
@@ -373,18 +368,17 @@ impl ChorusUser {
         &mut self,
         connection_account_id: &String,
     ) -> ChorusResult<Vec<ConnectionSubreddit>> {
-        let request = Client::new()
-            .get(format!(
-                "{}/users/@me/connections/reddit/{}/subreddits",
-                self.belongs_to.read().unwrap().urls.api,
-                connection_account_id
-            ))
-            .header("Authorization", self.token());
+        let request = Client::new().get(format!(
+            "{}/users/@me/connections/reddit/{}/subreddits",
+            self.belongs_to.read().unwrap().urls.api,
+            connection_account_id
+        ));
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(self);
 
         chorus_request.deserialize_response(self).await
     }

--- a/src/api/users/mfa.rs
+++ b/src/api/users/mfa.rs
@@ -32,13 +32,13 @@ impl ChorusUser {
                 "{}/users/@me/mfa/totp/enable",
                 self.belongs_to.read().unwrap().urls.api
             ))
-            .header("Authorization", self.token())
             .json(&schema);
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(self);
 
         let response: EnableTotpMfaResponse = chorus_request.deserialize_response(self).await?;
 
@@ -61,18 +61,17 @@ impl ChorusUser {
     /// # Reference
     /// See <https://docs.discord.sex/resources/user#disable-totp-mfa>
     pub async fn disable_totp_mfa(&mut self) -> ChorusResult<Token> {
-        let request = Client::new()
-            .post(format!(
-                "{}/users/@me/mfa/totp/disable",
-                self.belongs_to.read().unwrap().urls.api
-            ))
-            .header("Authorization", self.token());
+        let request = Client::new().post(format!(
+            "{}/users/@me/mfa/totp/disable",
+            self.belongs_to.read().unwrap().urls.api
+        ));
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
         }
-        .with_maybe_mfa(&self.mfa_token);
+        .with_maybe_mfa(&self.mfa_token)
+        .with_headers_for(self);
 
         let response: Token = chorus_request.deserialize_response(self).await?;
 
@@ -98,14 +97,14 @@ impl ChorusUser {
                 "{}/users/@me/mfa/sms/enable",
                 self.belongs_to.read().unwrap().urls.api
             ))
-            .header("Authorization", self.token())
             .json(&schema);
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
         }
-        .with_maybe_mfa(&self.mfa_token);
+        .with_maybe_mfa(&self.mfa_token)
+        .with_headers_for(self);
 
         chorus_request.handle_request_as_result(self).await
     }
@@ -125,14 +124,14 @@ impl ChorusUser {
                 "{}/users/@me/mfa/sms/disable",
                 self.belongs_to.read().unwrap().urls.api
             ))
-            .header("Authorization", self.token())
             .json(&schema);
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
         }
-        .with_maybe_mfa(&self.mfa_token);
+        .with_maybe_mfa(&self.mfa_token)
+        .with_headers_for(self);
 
         chorus_request.handle_request_as_result(self).await
     }
@@ -143,17 +142,16 @@ impl ChorusUser {
     /// # Reference
     /// See <https://docs.discord.sex/resources/user#get-webauthn-authenticators>
     pub async fn get_webauthn_authenticators(&mut self) -> ChorusResult<Vec<MfaAuthenticator>> {
-        let request = Client::new()
-            .get(format!(
-                "{}/users/@me/mfa/webauthn/credentials",
-                self.belongs_to.read().unwrap().urls.api
-            ))
-            .header("Authorization", self.token());
+        let request = Client::new().get(format!(
+            "{}/users/@me/mfa/webauthn/credentials",
+            self.belongs_to.read().unwrap().urls.api
+        ));
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(self);
 
         chorus_request.deserialize_response(self).await
     }
@@ -177,18 +175,17 @@ impl ChorusUser {
     pub async fn begin_webauthn_authenticator_creation(
         &mut self,
     ) -> ChorusResult<BeginWebAuthnAuthenticatorCreationReturn> {
-        let request = Client::new()
-            .post(format!(
-                "{}/users/@me/mfa/webauthn/credentials",
-                self.belongs_to.read().unwrap().urls.api
-            ))
-            .header("Authorization", self.token());
+        let request = Client::new().post(format!(
+            "{}/users/@me/mfa/webauthn/credentials",
+            self.belongs_to.read().unwrap().urls.api
+        ));
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
         }
-        .with_maybe_mfa(&self.mfa_token);
+        .with_maybe_mfa(&self.mfa_token)
+        .with_headers_for(self);
 
         chorus_request.deserialize_response(self).await
     }
@@ -221,14 +218,14 @@ impl ChorusUser {
                 "{}/users/@me/mfa/webauthn/credentials",
                 self.belongs_to.read().unwrap().urls.api
             ))
-            .header("Authorization", self.token())
             .json(&schema);
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
         }
-        .with_maybe_mfa(&self.mfa_token);
+        .with_maybe_mfa(&self.mfa_token)
+        .with_headers_for(self);
 
         chorus_request.deserialize_response(self).await
     }
@@ -256,14 +253,14 @@ impl ChorusUser {
                 self.belongs_to.read().unwrap().urls.api,
                 authenticator_id
             ))
-            .header("Authorization", self.token())
             .json(&schema);
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
         }
-        .with_maybe_mfa(&self.mfa_token);
+        .with_maybe_mfa(&self.mfa_token)
+        .with_headers_for(self);
 
         chorus_request.deserialize_response(self).await
     }
@@ -287,19 +284,18 @@ impl ChorusUser {
         &mut self,
         authenticator_id: Snowflake,
     ) -> ChorusResult<()> {
-        let request = Client::new()
-            .delete(format!(
-                "{}/users/@me/mfa/webauthn/credentials/{}",
-                self.belongs_to.read().unwrap().urls.api,
-                authenticator_id
-            ))
-            .header("Authorization", self.token());
+        let request = Client::new().delete(format!(
+            "{}/users/@me/mfa/webauthn/credentials/{}",
+            self.belongs_to.read().unwrap().urls.api,
+            authenticator_id
+        ));
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
         }
-        .with_maybe_mfa(&self.mfa_token);
+        .with_maybe_mfa(&self.mfa_token)
+        .with_headers_for(self);
 
         chorus_request.handle_request_as_result(self).await
     }
@@ -323,13 +319,13 @@ impl ChorusUser {
                 "{}/auth/verify/view-backup-codes-challenge",
                 self.belongs_to.read().unwrap().urls.api,
             ))
-            .header("Authorization", self.token())
             .json(&schema);
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(self);
 
         chorus_request.deserialize_response(self).await
     }
@@ -359,13 +355,13 @@ impl ChorusUser {
                 "{}/users/@me/mfa/codes-verification",
                 self.belongs_to.read().unwrap().urls.api,
             ))
-            .header("Authorization", self.token())
             .json(&schema);
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(self);
 
         chorus_request.deserialize_response(self).await
     }

--- a/src/api/users/relationships.rs
+++ b/src/api/users/relationships.rs
@@ -30,9 +30,10 @@ impl ChorusUser {
             user_id
         );
         let chorus_request = ChorusRequest {
-            request: Client::new().get(url).header("Authorization", self.token()),
+            request: Client::new().get(url),
             limit_type: LimitType::Global,
-        };
+        }
+        .with_headers_for(self);
         chorus_request
             .deserialize_response::<Vec<types::PublicUser>>(self)
             .await
@@ -48,9 +49,10 @@ impl ChorusUser {
             self.belongs_to.read().unwrap().urls.api
         );
         let chorus_request = ChorusRequest {
-            request: Client::new().get(url).header("Authorization", self.token()),
+            request: Client::new().get(url),
             limit_type: LimitType::Global,
-        };
+        }
+        .with_headers_for(self);
         chorus_request
             .deserialize_response::<Vec<types::Relationship>>(self)
             .await
@@ -68,15 +70,11 @@ impl ChorusUser {
             "{}/users/@me/relationships",
             self.belongs_to.read().unwrap().urls.api
         );
-        let body = to_string(&schema).unwrap();
         let chorus_request = ChorusRequest {
-            request: Client::new()
-                .post(url)
-                .header("Authorization", self.token())
-                .header("Content-Type", "application/json")
-                .body(body),
+            request: Client::new().post(url).json(&schema),
             limit_type: LimitType::Global,
-        };
+        }
+        .with_headers_for(self);
         chorus_request.handle_request_as_result(self).await
     }
 
@@ -93,14 +91,14 @@ impl ChorusUser {
             RelationshipType::None => {
                 let chorus_request = ChorusRequest {
                     request: Client::new()
-                        .delete(format!("{}/users/@me/relationships/{}", api_url, user_id))
-                        .header("Authorization", self.token()),
+                        .delete(format!("{}/users/@me/relationships/{}", api_url, user_id)),
                     limit_type: LimitType::Global,
-                };
+                }
+                .with_headers_for(self);
                 chorus_request.handle_request_as_result(self).await
             }
             RelationshipType::Friends | RelationshipType::Incoming | RelationshipType::Outgoing => {
-                let body = CreateUserRelationshipSchema {
+                let schema = CreateUserRelationshipSchema {
                     relationship_type: None, // Selecting 'None' here will accept an incoming FR or send a new FR.
                     from_friend_suggestion: None,
                     friend_token: None,
@@ -108,14 +106,14 @@ impl ChorusUser {
                 let chorus_request = ChorusRequest {
                     request: Client::new()
                         .put(format!("{}/users/@me/relationships/{}", api_url, user_id))
-                        .header("Authorization", self.token())
-                        .body(to_string(&body).unwrap()),
+                        .json(&schema),
                     limit_type: LimitType::Global,
-                };
+                }
+                .with_headers_for(self);
                 chorus_request.handle_request_as_result(self).await
             }
             RelationshipType::Blocked => {
-                let body = CreateUserRelationshipSchema {
+                let schema = CreateUserRelationshipSchema {
                     relationship_type: Some(RelationshipType::Blocked),
                     from_friend_suggestion: None,
                     friend_token: None,
@@ -123,10 +121,10 @@ impl ChorusUser {
                 let chorus_request = ChorusRequest {
                     request: Client::new()
                         .put(format!("{}/users/@me/relationships/{}", api_url, user_id))
-                        .header("Authorization", self.token())
-                        .body(to_string(&body).unwrap()),
+                        .json(&schema),
                     limit_type: LimitType::Global,
-                };
+                }
+                .with_headers_for(self);
                 chorus_request.handle_request_as_result(self).await
             }
             RelationshipType::Suggestion | RelationshipType::Implicit => Ok(()),
@@ -144,11 +142,10 @@ impl ChorusUser {
             user_id
         );
         let chorus_request = ChorusRequest {
-            request: Client::new()
-                .delete(url)
-                .header("Authorization", self.token()),
+            request: Client::new().delete(url),
             limit_type: LimitType::Global,
-        };
+        }
+        .with_headers_for(self);
         chorus_request.handle_request_as_result(self).await
     }
 }

--- a/src/api/users/users.rs
+++ b/src/api/users/users.rs
@@ -109,15 +109,14 @@ impl ChorusUser {
                 "{}/users/@me",
                 self.belongs_to.read().unwrap().urls.api
             ))
-            .body(to_string(&modify_schema).unwrap())
-            .header("Authorization", self.token())
-            .header("Content-Type", "application/json");
+            .json(&modify_schema);
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
         }
-        .with_maybe_mfa(&self.mfa_token);
+        .with_maybe_mfa(&self.mfa_token)
+        .with_headers_for(self);
 
         chorus_request.deserialize_response::<User>(self).await
     }
@@ -139,14 +138,14 @@ impl ChorusUser {
                 "{}/users/@me/disable",
                 self.belongs_to.read().unwrap().urls.api
             ))
-            .header("Authorization", self.token())
             .json(&schema);
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
         }
-        .with_maybe_mfa(&self.mfa_token);
+        .with_maybe_mfa(&self.mfa_token)
+        .with_headers_for(self);
 
         chorus_request.handle_request_as_result(self).await
     }
@@ -166,14 +165,14 @@ impl ChorusUser {
                 "{}/users/@me/delete",
                 self.belongs_to.read().unwrap().urls.api
             ))
-            .header("Authorization", self.token())
             .json(&schema);
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
         }
-        .with_maybe_mfa(&self.mfa_token);
+        .with_maybe_mfa(&self.mfa_token)
+        .with_headers_for(self);
 
         chorus_request.handle_request_as_result(self).await
     }
@@ -226,16 +225,15 @@ impl ChorusUser {
     /// # Reference
     /// See <https://docs.discord.sex/resources/user#modify-user-email>
     pub async fn initiate_email_change(&mut self) -> ChorusResult<()> {
-        let request = Client::new()
-            .put(format!(
-                "{}/users/@me/email",
-                self.belongs_to.read().unwrap().urls.api
-            ))
-            .header("Authorization", self.token());
+        let request = Client::new().put(format!(
+            "{}/users/@me/email",
+            self.belongs_to.read().unwrap().urls.api
+        ));
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(self);
         chorus_request.handle_request_as_result(self).await
     }
 
@@ -261,12 +259,12 @@ impl ChorusUser {
                 "{}/users/@me/email/verify-code",
                 self.belongs_to.read().unwrap().urls.api
             ))
-            .header("Authorization", self.token())
             .json(&schema);
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(self);
         chorus_request
             .deserialize_response::<VerifyUserEmailChangeResponse>(self)
             .await
@@ -287,17 +285,16 @@ impl ChorusUser {
     /// # Reference
     /// See <https://docs.discord.sex/resources/user#get-pomelo-suggestions>
     pub async fn get_pomelo_suggestions(&mut self) -> ChorusResult<String> {
-        let request = Client::new()
-            .get(format!(
-                "{}/users/@me/pomelo-suggestions",
-                self.belongs_to.read().unwrap().urls.api
-            ))
-            .header("Authorization", self.token());
+        let request = Client::new().get(format!(
+            "{}/users/@me/pomelo-suggestions",
+            self.belongs_to.read().unwrap().urls.api
+        ));
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(self);
         chorus_request
             .deserialize_response::<GetPomeloSuggestionsReturn>(self)
             .await
@@ -319,7 +316,6 @@ impl ChorusUser {
                 "{}/users/@me/pomelo-attempt",
                 self.belongs_to.read().unwrap().urls.api
             ))
-            .header("Authorization", self.token())
             // FIXME: should we create a type for this?
             .body(format!(r#"{{ "username": {:?} }}"#, username))
             .header("Content-Type", "application/json");
@@ -327,7 +323,8 @@ impl ChorusUser {
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(self);
         chorus_request
             .deserialize_response::<GetPomeloEligibilityReturn>(self)
             .await
@@ -359,7 +356,6 @@ impl ChorusUser {
                 "{}/users/@me/pomelo",
                 self.belongs_to.read().unwrap().urls.api
             ))
-            .header("Authorization", self.token())
             // FIXME: should we create a type for this?
             .body(format!(r#"{{ "username": {:?} }}"#, username))
             .header("Content-Type", "application/json");
@@ -367,7 +363,8 @@ impl ChorusUser {
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(self);
 
         let result = chorus_request.deserialize_response::<User>(self).await;
 
@@ -397,13 +394,13 @@ impl ChorusUser {
                 "{}/users/@me/mentions",
                 self.belongs_to.read().unwrap().urls.api
             ))
-            .header("Authorization", self.token())
             .query(&query_parameters);
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(self);
 
         chorus_request
             .deserialize_response::<Vec<crate::types::Message>>(self)
@@ -420,18 +417,17 @@ impl ChorusUser {
     /// # Reference
     /// See <https://docs.discord.sex/resources/user#delete-recent-mention>
     pub async fn delete_recent_mention(&mut self, message_id: Snowflake) -> ChorusResult<()> {
-        let request = Client::new()
-            .delete(format!(
-                "{}/users/@me/mentions/{}",
-                self.belongs_to.read().unwrap().urls.api,
-                message_id
-            ))
-            .header("Authorization", self.token());
+        let request = Client::new().delete(format!(
+            "{}/users/@me/mentions/{}",
+            self.belongs_to.read().unwrap().urls.api,
+            message_id
+        ));
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(self);
 
         chorus_request.handle_request_as_result(self).await
     }
@@ -446,17 +442,16 @@ impl ChorusUser {
     /// # Reference
     /// See <https://docs.discord.sex/resources/user#get-user-harvest>
     pub async fn get_harvest(&mut self) -> ChorusResult<Option<Harvest>> {
-        let request = Client::new()
-            .get(format!(
-                "{}/users/@me/harvest",
-                self.belongs_to.read().unwrap().urls.api,
-            ))
-            .header("Authorization", self.token());
+        let request = Client::new().get(format!(
+            "{}/users/@me/harvest",
+            self.belongs_to.read().unwrap().urls.api,
+        ));
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(self);
 
         // Manual handling, because a 204 with no harvest is a success state
         // TODO: Maybe make this a method on ChorusRequest if we need it a lot
@@ -523,13 +518,13 @@ impl ChorusUser {
                 "{}/users/@me/harvest",
                 self.belongs_to.read().unwrap().urls.api,
             ))
-            .header("Authorization", self.token())
             .json(&schema);
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(self);
 
         chorus_request.deserialize_response(self).await
     }
@@ -542,17 +537,16 @@ impl ChorusUser {
     /// # Reference
     /// See <https://docs.discord.sex/resources/user#get-user-notes>
     pub async fn get_user_notes(&mut self) -> ChorusResult<HashMap<Snowflake, String>> {
-        let request = Client::new()
-            .get(format!(
-                "{}/users/@me/notes",
-                self.belongs_to.read().unwrap().urls.api,
-            ))
-            .header("Authorization", self.token());
+        let request = Client::new().get(format!(
+            "{}/users/@me/notes",
+            self.belongs_to.read().unwrap().urls.api,
+        ));
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(self);
 
         chorus_request.deserialize_response(self).await
     }
@@ -595,17 +589,16 @@ impl ChorusUser {
     /// # Reference
     /// See <https://docs.discord.sex/resources/user#get-user-affinities>
     pub async fn get_user_affinities(&mut self) -> ChorusResult<UserAffinities> {
-        let request = Client::new()
-            .get(format!(
-                "{}/users/@me/affinities/users",
-                self.belongs_to.read().unwrap().urls.api,
-            ))
-            .header("Authorization", self.token());
+        let request = Client::new().get(format!(
+            "{}/users/@me/affinities/users",
+            self.belongs_to.read().unwrap().urls.api,
+        ));
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(self);
 
         chorus_request.deserialize_response(self).await
     }
@@ -615,17 +608,16 @@ impl ChorusUser {
     /// # Reference
     /// See <https://docs.discord.sex/resources/user#get-guild-affinities>
     pub async fn get_guild_affinities(&mut self) -> ChorusResult<GuildAffinities> {
-        let request = Client::new()
-            .get(format!(
-                "{}/users/@me/affinities/guilds",
-                self.belongs_to.read().unwrap().urls.api,
-            ))
-            .header("Authorization", self.token());
+        let request = Client::new().get(format!(
+            "{}/users/@me/affinities/guilds",
+            self.belongs_to.read().unwrap().urls.api,
+        ));
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(self);
 
         chorus_request.deserialize_response(self).await
     }
@@ -641,17 +633,16 @@ impl ChorusUser {
     /// # Reference
     /// See <https://docs.discord.sex/resources/user#get-user-premium-usage>
     pub async fn get_premium_usage(&mut self) -> ChorusResult<PremiumUsage> {
-        let request = Client::new()
-            .get(format!(
-                "{}/users/@me/premium-usage",
-                self.belongs_to.read().unwrap().urls.api,
-            ))
-            .header("Authorization", self.token());
+        let request = Client::new().get(format!(
+            "{}/users/@me/premium-usage",
+            self.belongs_to.read().unwrap().urls.api,
+        ));
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(self);
 
         chorus_request.deserialize_response(self).await
     }
@@ -664,17 +655,16 @@ impl ChorusUser {
     /// # Notes
     /// As of 2024/08/18, Spacebar does not yet implement this endpoint.
     pub async fn get_burst_credits(&mut self) -> ChorusResult<BurstCreditsInfo> {
-        let request = Client::new()
-            .get(format!(
-                "{}/users/@me/burst-credits",
-                self.belongs_to.read().unwrap().urls.api,
-            ))
-            .header("Authorization", self.token());
+        let request = Client::new().get(format!(
+            "{}/users/@me/burst-credits",
+            self.belongs_to.read().unwrap().urls.api,
+        ));
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(self);
 
         chorus_request.deserialize_response(self).await
     }
@@ -688,13 +678,12 @@ impl User {
     pub async fn get_current(user: &mut ChorusUser) -> ChorusResult<User> {
         let url_api = user.belongs_to.read().unwrap().urls.api.clone();
         let url = format!("{}/users/@me", url_api);
-        let request = reqwest::Client::new()
-            .get(url)
-            .header("Authorization", user.token());
+        let request = reqwest::Client::new().get(url);
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::Global,
-        };
+        }
+        .with_headers_for(user);
         chorus_request.deserialize_response::<User>(user).await
     }
 
@@ -705,13 +694,12 @@ impl User {
     pub async fn get(user: &mut ChorusUser, id: Snowflake) -> ChorusResult<PublicUser> {
         let url_api = user.belongs_to.read().unwrap().urls.api.clone();
         let url = format!("{}/users/{}", url_api, id);
-        let request = reqwest::Client::new()
-            .get(url)
-            .header("Authorization", user.token());
+        let request = reqwest::Client::new().get(url);
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::Global,
-        };
+        }
+        .with_headers_for(user);
         chorus_request
             .deserialize_response::<PublicUser>(user)
             .await
@@ -742,9 +730,7 @@ impl User {
     ) -> ChorusResult<PublicUser> {
         let url_api = user.belongs_to.read().unwrap().urls.api.clone();
         let url = format!("{}/users/username/{username}", url_api);
-        let mut request = reqwest::Client::new()
-            .get(url)
-            .header("Authorization", user.token());
+        let mut request = reqwest::Client::new().get(url);
 
         if let Some(some_discriminator) = discriminator {
             request = request.query(&[("discriminator", some_discriminator)]);
@@ -753,7 +739,8 @@ impl User {
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::Global,
-        };
+        }
+        .with_headers_for(user);
         chorus_request
             .deserialize_response::<PublicUser>(user)
             .await
@@ -765,13 +752,13 @@ impl User {
     /// See <https://luna.gitlab.io/discord-unofficial-docs/docs/user_settings.html#get-usersmesettings>
     pub async fn get_settings(user: &mut ChorusUser) -> ChorusResult<UserSettings> {
         let url_api = user.belongs_to.read().unwrap().urls.api.clone();
-        let request: reqwest::RequestBuilder = Client::new()
-            .get(format!("{}/users/@me/settings", url_api))
-            .header("Authorization", user.token());
+        let request: reqwest::RequestBuilder =
+            Client::new().get(format!("{}/users/@me/settings", url_api));
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::Global,
-        };
+        }
+        .with_headers_for(user);
         chorus_request
             .deserialize_response::<UserSettings>(user)
             .await
@@ -797,13 +784,13 @@ impl User {
         let url_api = user.belongs_to.read().unwrap().urls.api.clone();
         let request: reqwest::RequestBuilder = Client::new()
             .get(format!("{}/users/{}/profile", url_api, id))
-            .header("Authorization", user.token())
             .query(&query_parameters);
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::Global,
-        };
+        }
+        .with_headers_for(user);
         chorus_request
             .deserialize_response::<UserProfile>(user)
             .await
@@ -822,12 +809,12 @@ impl User {
         let url_api = user.belongs_to.read().unwrap().urls.api.clone();
         let request: reqwest::RequestBuilder = Client::new()
             .patch(format!("{}/users/@me/profile", url_api))
-            .header("Authorization", user.token())
             .json(&schema);
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::Global,
-        };
+        }
+        .with_headers_for(user);
         chorus_request
             .deserialize_response::<UserProfileMetadata>(user)
             .await
@@ -844,18 +831,17 @@ impl User {
         user: &mut ChorusUser,
         target_user_id: Snowflake,
     ) -> ChorusResult<UserNote> {
-        let request = Client::new()
-            .get(format!(
-                "{}/users/@me/notes/{}",
-                user.belongs_to.read().unwrap().urls.api,
-                target_user_id
-            ))
-            .header("Authorization", user.token());
+        let request = Client::new().get(format!(
+            "{}/users/@me/notes/{}",
+            user.belongs_to.read().unwrap().urls.api,
+            target_user_id
+        ));
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(user);
 
         chorus_request.deserialize_response(user).await
     }
@@ -879,13 +865,13 @@ impl User {
                 user.belongs_to.read().unwrap().urls.api,
                 target_user_id
             ))
-            .header("Authorization", user.token())
             .json(&schema);
 
         let chorus_request = ChorusRequest {
             request,
             limit_type: LimitType::default(),
-        };
+        }
+        .with_headers_for(user);
 
         chorus_request.handle_request_as_result(user).await
     }

--- a/src/ratelimiter.rs
+++ b/src/ratelimiter.rs
@@ -13,7 +13,10 @@ use serde_json::from_str;
 use crate::{
     errors::{ChorusError, ChorusResult},
     instance::ChorusUser,
-    types::{types::subconfigs::limits::rates::RateLimits, Limit, LimitType, LimitsConfiguration, MfaRequiredSchema},
+    types::{
+        types::subconfigs::limits::rates::RateLimits, Limit, LimitType, LimitsConfiguration,
+        MfaRequiredSchema,
+    },
 };
 
 /// Chorus' request struct. This struct is used to send rate-limited requests to the Spacebar server.
@@ -34,7 +37,7 @@ impl ChorusRequest {
     ///     * [`http::Method::DELETE`]
     ///     * [`http::Method::PATCH`]
     ///     * [`http::Method::HEAD`]
-    #[allow(unused_variables)] 
+    #[allow(unused_variables)]
     pub fn new(
         method: http::Method,
         url: &str,
@@ -83,8 +86,13 @@ impl ChorusRequest {
                 bucket: format!("{:?}", self.limit_type),
             });
         }
+
+        let request = self
+            .request
+            .header("User-Agent", user.client_properties.user_agent.clone().0);
+
         let client = user.belongs_to.read().unwrap().client.clone();
-        let result = match client.execute(self.request.build().unwrap()).await {
+        let result = match client.execute(request.build().unwrap()).await {
             Ok(result) => {
                 log::trace!("Request successful: {:?}", result);
                 result

--- a/src/ratelimiter.rs
+++ b/src/ratelimiter.rs
@@ -532,6 +532,56 @@ impl ChorusRequest {
         };
         Ok(object)
     }
+
+    /// Adds an audit log reason to the request.
+    ///
+    /// Sets the X-Audit-Log-Reason header
+    pub(crate) fn with_audit_log_reason(self, reason: String) -> ChorusRequest {
+        let mut request = self;
+
+        request.request = request.request.header("X-Audit-Log-Reason", reason);
+        request
+    }
+
+    /// Adds an audit log reason to the request, if it is [Some]
+    ///
+    /// Sets the X-Audit-Log-Reason header
+    pub(crate) fn with_maybe_audit_log_reason(self, reason: Option<String>) -> ChorusRequest {
+        if let Some(reason_some) = reason {
+            return self.with_audit_log_reason(reason_some);
+        }
+
+        self
+    }
+
+    /// Adds an authorization token to the request.
+    ///
+    /// Sets the Authorization header
+    pub(crate) fn with_authorization(self, token: &String) -> ChorusRequest {
+        let mut request = self;
+
+        request.request = request.request.header("Authorization", token);
+        request
+    }
+
+    /// Adds authorization for a [ChorusUser] to the request.
+    ///
+    /// Sets the Authorization header
+    pub(crate) fn with_authorization_for(self, user: &ChorusUser) -> ChorusRequest {
+        self.with_authorization(&user.token)
+    }
+
+    /// Adds user-specific headers for a [ChorusUser] to the request.
+    ///
+    /// Adds authorization and telemetry; for specific details see
+    /// [Self::with_authorization_for] and [Self::with_client_properties_for]
+    ///
+    /// If a route you're adding involves authorization as the user, you
+    /// should likely use this method.
+    pub(crate) fn with_headers_for(self, user: &ChorusUser) -> ChorusRequest {
+        self.with_authorization_for(user)
+            .with_client_properties_for(user)
+    }
 }
 
 enum LimitOrigin {

--- a/src/ratelimiter.rs
+++ b/src/ratelimiter.rs
@@ -28,53 +28,6 @@ pub struct ChorusRequest {
 }
 
 impl ChorusRequest {
-    /// Makes a new [`ChorusRequest`].
-    /// # Arguments
-    /// * `method` - The HTTP method to use. Must be one of the following:
-    ///     * [`http::Method::GET`]
-    ///     * [`http::Method::POST`]
-    ///     * [`http::Method::PUT`]
-    ///     * [`http::Method::DELETE`]
-    ///     * [`http::Method::PATCH`]
-    ///     * [`http::Method::HEAD`]
-    #[allow(unused_variables)]
-    pub fn new(
-        method: http::Method,
-        url: &str,
-        body: Option<String>,
-        audit_log_reason: Option<&str>,
-        chorus_user: Option<&mut ChorusUser>,
-        limit_type: LimitType,
-    ) -> ChorusRequest {
-        let request = Client::new();
-        let mut request = match method {
-            http::Method::GET => request.get(url),
-            http::Method::POST => request.post(url),
-            http::Method::PUT => request.put(url),
-            http::Method::DELETE => request.delete(url),
-            http::Method::PATCH => request.patch(url),
-            http::Method::HEAD => request.head(url),
-            _ => panic!("Illegal state: Method not supported."),
-        };
-        if let Some(user) = chorus_user {
-            request = request.header("Authorization", user.token());
-        }
-        if let Some(body) = body {
-            // ONCE TOLD ME THE WORLD WAS GONNA ROLL ME
-            request = request
-                .body(body)
-                .header("Content-Type", "application/json");
-        }
-        if let Some(reason) = audit_log_reason {
-            request = request.header("X-Audit-Log-Reason", reason);
-        }
-
-        ChorusRequest {
-            request,
-            limit_type,
-        }
-    }
-
     /// Sends a [`ChorusRequest`]. Checks if the user is rate limited, and if not, sends the request.
     /// If the user is not rate limited and the instance has rate limits enabled, it will update the
     /// rate limits.

--- a/src/types/events/identify.rs
+++ b/src/types/events/identify.rs
@@ -2,16 +2,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use crate::types::events::WebSocketEvent;
+use crate::types::{events::WebSocketEvent, ClientProperties};
 use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
 
 use super::GatewayIdentifyPresenceUpdate;
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, WebSocketEvent)]
 pub struct GatewayIdentifyPayload {
     pub token: String,
-    pub properties: GatewayIdentifyConnectionProps,
+    pub properties: ClientProperties,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub compress: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -37,24 +36,17 @@ impl Default for GatewayIdentifyPayload {
 }
 
 impl GatewayIdentifyPayload {
-    /// Uses the most common, 25% data along with client capabilities
+    /// Uses the most common data along with client capabilities
     ///
-    /// Basically pretends to be an official client on Windows 10, with Chrome 113.0.0.0
+    /// Basically pretends to be an official client on Windows 10
     pub fn common() -> Self {
         Self {
-            token: "".to_string(),
-            properties: GatewayIdentifyConnectionProps::default(),
-            compress: Some(false),
-            large_threshold: None,
-            shard: None,
-            presence: None,
-            intents: None,
+            properties: ClientProperties::default(),
             capabilities: Some(8189),
+            ..Self::default()
         }
     }
-}
 
-impl GatewayIdentifyPayload {
     /// Creates an identify payload with the same default capabilities as the official client
     pub fn default_w_client_capabilities() -> Self {
         Self {
@@ -72,107 +64,3 @@ impl GatewayIdentifyPayload {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, WebSocketEvent)]
-#[serde_as]
-pub struct GatewayIdentifyConnectionProps {
-    /// Almost always sent
-    ///
-    /// ex: "Linux", "Windows", "Mac OS X"
-    ///
-    /// ex (mobile): "Windows Mobile", "iOS", "Android", "BlackBerry"
-    #[serde(default)]
-    pub os: String,
-    /// Almost always sent
-    ///
-    /// ex: "Firefox", "Chrome", "Opera Mini", "Opera", "Blackberry", "Facebook Mobile", "Chrome iOS", "Mobile Safari", "Safari", "Android Chrome", "Android Mobile", "Edge", "Konqueror", "Internet Explorer", "Mozilla", "Discord Client"
-    #[serde(default)]
-    pub browser: String,
-    /// Sometimes not sent, acceptable to be ""
-    ///
-    /// Speculation:
-    /// Only sent for mobile devices
-    ///
-    /// ex: "BlackBerry", "Windows Phone", "Android", "iPhone", "iPad", ""
-    #[serde_as(as = "NoneAsEmptyString")]
-    pub device: Option<String>,
-    /// Almost always sent, most commonly en-US
-    ///
-    /// ex: "en-US"
-    #[serde(default)]
-    pub system_locale: String,
-    /// Almost always sent
-    ///
-    /// ex: any user agent, most common is "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36"
-    #[serde(default)]
-    pub browser_user_agent: String,
-    /// Almost always sent
-    ///
-    /// ex: "113.0.0.0"
-    #[serde(default)]
-    pub browser_version: String,
-    /// Sometimes not sent, acceptable to be ""
-    ///
-    /// ex: "10" (For os = "Windows")
-    #[serde_as(as = "NoneAsEmptyString")]
-    pub os_version: Option<String>,
-    /// Sometimes not sent, acceptable to be ""
-    #[serde_as(as = "NoneAsEmptyString")]
-    pub referrer: Option<String>,
-    /// Sometimes not sent, acceptable to be ""
-    #[serde_as(as = "NoneAsEmptyString")]
-    pub referring_domain: Option<String>,
-    /// Sometimes not sent, acceptable to be ""
-    #[serde_as(as = "NoneAsEmptyString")]
-    pub referrer_current: Option<String>,
-    /// Almost always sent, most commonly "stable"
-    #[serde(default)]
-    pub release_channel: String,
-    /// Almost always sent, identifiable if default is 0, should be around 199933
-    #[serde(default)]
-    pub client_build_number: u64,
-    //pub client_event_source: Option<?>
-}
-
-impl Default for GatewayIdentifyConnectionProps {
-    /// Uses the most common, 25% data
-    fn default() -> Self {
-        Self::common()
-    }
-}
-
-impl GatewayIdentifyConnectionProps {
-    /// Returns a minimal, least data possible default
-    fn minimal() -> Self {
-        Self {
-            os: String::new(),
-            browser: String::new(),
-            device: None,
-            system_locale: String::from("en-US"),
-            browser_user_agent: String::new(),
-            browser_version: String::new(),
-            os_version: None,
-            referrer: None,
-            referring_domain: None,
-            referrer_current: None,
-            release_channel: String::from("stable"),
-            client_build_number: 0,
-        }
-    }
-
-    /// Returns the most common connection props so we can't be tracked
-    pub fn common() -> Self {
-        Self {
-            // See https://www.useragents.me/#most-common-desktop-useragents
-            // 25% of the web
-            //default.browser_user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36".to_string();
-            browser: String::from("Chrome"),
-            browser_version: String::from("126.0.0.0"),
-            system_locale: String::from("en-US"),
-            os: String::from("Windows"),
-            os_version: Some(String::from("10")),
-            client_build_number: 222963,
-            release_channel: String::from("stable"),
-            ..Self::minimal()
-        }
-    }
-}

--- a/src/types/events/identify.rs
+++ b/src/types/events/identify.rs
@@ -31,7 +31,16 @@ pub struct GatewayIdentifyPayload {
 
 impl Default for GatewayIdentifyPayload {
     fn default() -> Self {
-        Self::common()
+        Self {
+            token: String::new(),
+            properties: ClientProperties::default(),
+            compress: None,
+            large_threshold: None,
+            shard: None,
+            presence: None,
+            intents: None,
+            capabilities: None,
+        }
     }
 }
 
@@ -63,4 +72,3 @@ impl GatewayIdentifyPayload {
         }
     }
 }
-

--- a/src/types/interfaces/client_properties.rs
+++ b/src/types/interfaces/client_properties.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use base64::Engine;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
@@ -355,6 +356,13 @@ impl ClientProperties {
     pub fn common() -> Self {
         Self::common_desktop_windows()
     }
+
+    /// Encodes self to base64, for the X-Super-Properties header
+    pub fn to_base64(&self) -> String {
+        let as_json = serde_json::to_string(self).unwrap();
+
+        base64::prelude::BASE64_STANDARD.encode(as_json)
+    }
 }
 
 /// The operating system the client is running on.
@@ -664,7 +672,7 @@ impl Default for ClientBrowser {
 /// See <https://docs.discord.sex/reference#browser-type>
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(transparent)]
-pub struct ClientUserAgent(String);
+pub struct ClientUserAgent(pub(crate) String);
 
 impl From<String> for ClientUserAgent {
     fn from(value: String) -> Self {
@@ -792,7 +800,7 @@ impl Default for ClientUserAgent {
 ///
 /// # Reference
 /// See <https://docs.discord.sex/reference#client-properties-structure>
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, Copy, Clone, PartialEq, Eq)]
 #[serde(transparent)]
 pub struct ClientBuildNumber(u64);
 

--- a/src/types/interfaces/client_properties.rs
+++ b/src/types/interfaces/client_properties.rs
@@ -1,0 +1,941 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[serde_as]
+/// Tracking information for the current client, which is sent to
+/// the discord servers in every gateway connection and http api request.
+///
+/// This includes data about the os, distribution, browser, client, device
+/// and even window manager the user is running.
+///
+/// Chorus by default uses the most common data possible, pretending to be
+/// an official client.
+///
+/// Note that these values are (for now) written into the source code, meaning that
+/// older version of the crate will be less effective.
+///
+/// Unless a user of the library specifically goes out of their way to implement
+/// it, chorus never sends real tracking data.
+///
+/// # Why?
+///
+/// You may ask, why would a library such as chorus even implement this?
+///
+/// There are two main reasons:
+///
+/// ## 1. Identifiability
+///
+/// Not sending tracking data at all makes users of software built with chorus
+/// stick out like a sore thumb; it screams "I am using a 3rd party client".
+///
+/// Ideally, users of chorus-based software would blend in with users of the
+/// official clients.
+///
+/// ## 2. Anti-abuse systems
+///
+/// Sadly, tracking data is also the most common way distinguish between real users
+/// and poorly made self-bots abusing the user api.
+///
+/// # Profiles
+///
+/// Chorus contains a bunch of premade profiles:
+/// - [ClientProperties::minimal]
+/// - [ClientProperties::common_desktop_windows] - the most common data for a desktop client on
+/// windows - this is also the profile used by default ([ClientProperties::default])
+/// - [ClientProperties::common_web_windows] - the most common settings for a web client on windows
+/// - [ClientProperties::common_desktop_mac_os] - the most common settings for a desktop client on macos
+/// - [ClientProperties::common_desktop_linux] - the most common settings for a desktop client on linux
+///
+/// If you wish to create your own profile, please use `..ClientProperties::minimal()` instead of `..ClientProperties::default()` for unset fields.
+///
+/// # Reference
+/// See <https://docs.discord.sex/reference#client-properties>
+pub struct ClientProperties {
+    /// Always sent, must be provided
+    ///
+    /// See [ClientOs] for more details
+    #[serde(default)]
+    pub os: ClientOs,
+
+    /// Always sent, must be provided
+    ///
+    /// Can also be an empty string
+    ///
+    /// See [ClientOsVersion] for more details
+    #[serde(default)]
+    pub os_version: ClientOsVersion,
+
+    /// The operating system SDK version
+    ///
+    /// Not required
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub os_sdk_version: Option<String>,
+
+    /// The operating system architecture
+    ///
+    /// e.g. "x64" or "arm64"
+    ///
+    /// Not required
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub os_arch: Option<String>,
+
+    /// The architecture of the desktop app
+    ///
+    /// e.g. "x64" or "arm64"
+    ///
+    /// Not required
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_arch: Option<String>,
+
+    /// Always sent, must be provided
+    ///
+    /// Also includes desktop clients, not just web browsers
+    ///
+    /// See [ClientBrowser] for more details
+    #[serde(default)]
+    pub browser: ClientBrowser,
+
+    /// Always sent, must be provided
+    ///
+    /// May be an empty string for mobile clients
+    ///
+    /// See [ClientUserAgent] for more details
+    #[serde(default)]
+    #[serde(rename = "browser_user_agent")]
+    pub user_agent: ClientUserAgent,
+
+    /// Always sent, must be provided
+    ///
+    /// ex: "130.0.0.0"
+    #[serde(default)]
+    pub browser_version: String,
+
+    /// Always sent, must be provided
+    ///
+    /// Current is ~ 355624
+    ///
+    /// See [ClientBuildNumber] for more details
+    #[serde(default)]
+    pub client_build_number: ClientBuildNumber,
+
+    /// The native metadata version of the desktop client, if using the new update system.
+    #[serde(default)]
+    pub native_build_number: Option<u64>,
+
+    /// The mobile client version
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_version: Option<String>,
+
+    /// The alternate event source this request originated from
+    ///
+    /// # Reference
+    /// See <https://docs.discord.sex/reference#client-event-source>
+    #[serde(default)]
+    pub client_event_source: Option<String>,
+
+    /// The release channel of the desktop / web client
+    ///
+    /// See [ClientReleaseChannel] for more details
+    #[serde(default)]
+    pub release_channel: ClientReleaseChannel,
+
+    /// Always sent, must be provided
+    ///
+    /// most commonly "en-US" ([ClientSystemLocale::en_us])
+    ///
+    /// See [ClientSystemLocale] for more details
+    #[serde(default)]
+    pub system_locale: ClientSystemLocale,
+
+    /// Sometimes not sent, acceptable to be an empty string
+    ///
+    /// Speculation:
+    /// Only sent for mobile devices
+    ///
+    /// ex: "BlackBerry", "Windows Phone", "Android", "iPhone", "iPad", ""
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub device: Option<String>,
+
+    /// A unique identifier for the mobile device,
+    /// (random UUID on android, IdentifierForVendor on iOS)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub device_vendor_id: Option<String>,
+
+    /// The linux window manager running the client.
+    ///
+    /// Acquired by the official client as
+    /// (env.XDG_CURRENT_DESKTOP ?? "unknown" + "," + env.GDMSESSION ?? "unknown")
+    ///
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub window_manager: Option<String>,
+
+    /// The linux distribution running the client.
+    ///
+    /// Acquired by the official client as the output of lsb_release -ds
+    ///
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub distro: Option<String>,
+
+    /// The url that referred the user to the client
+    ///
+    /// Sent as an empty string if there is no referrer
+    #[serde_as(as = "NoneAsEmptyString")]
+    pub referrer: Option<String>,
+
+    /// Same as referrer, but for the current session
+    ///
+    /// Sent as an empty string if there is no referrer
+    #[serde_as(as = "NoneAsEmptyString")]
+    pub referrer_current: Option<String>,
+
+    /// The domain of the url that referred the user to the client
+    ///
+    /// Sent as an empty string if there is no referrer
+    #[serde_as(as = "NoneAsEmptyString")]
+    pub referring_domain: Option<String>,
+
+    /// Same as referring_domain but for the current session
+    ///
+    /// Sent as an empty string if there is no referrer
+    #[serde_as(as = "NoneAsEmptyString")]
+    pub referring_domain_current: Option<String>,
+
+    /// The search engine which referred the user to the client.
+    ///
+    /// Common values are "google", "bing", "yahoo" and "duckduckgo"
+    ///
+    /// # Reference
+    /// See <https://docs.discord.sex/reference#search-engine>
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub search_engine: Option<String>,
+
+    /// Same as search_engine, but for the current session
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub search_engine_current: Option<String>,
+
+    /// Whether the client has modifications, e.g. BetterDiscord
+    ///
+    /// Note that these modifications usually don't make themselves known
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub has_client_mods: Option<bool>,
+}
+
+impl Default for ClientProperties {
+    /// Uses the most common, data
+    fn default() -> Self {
+        Self::common()
+    }
+}
+
+impl ClientProperties {
+    /// Returns a minimal, least data possible default
+    ///
+    /// If creating your own profile, use `..Self::minimal()` instead of `..Self::default()`
+    pub fn minimal() -> Self {
+        Self {
+            os: ClientOs::custom(String::new()),
+            os_version: ClientOsVersion::custom(String::new()),
+            browser: ClientBrowser::custom(String::new()),
+            system_locale: ClientSystemLocale::en_us(),
+            user_agent: ClientUserAgent::custom(String::new()),
+            browser_version: String::new(),
+            release_channel: ClientReleaseChannel::stable(),
+            client_build_number: ClientBuildNumber::custom(0),
+            os_sdk_version: None,
+            os_arch: None,
+            app_arch: None,
+            native_build_number: None,
+            client_version: None,
+            device: None,
+            device_vendor_id: None,
+            window_manager: None,
+            distro: None,
+            referrer: None,
+            referrer_current: None,
+            referring_domain: None,
+            referring_domain_current: None,
+            search_engine: None,
+            search_engine_current: None,
+            has_client_mods: None,
+            client_event_source: None,
+        }
+    }
+
+    /// Returns the most common properties for desktop web on windows
+    ///
+    /// Currently chrome 131.0.0 on windows 10
+    ///
+    /// See <https://www.useragents.me/#most-common-desktop-useragents>
+    pub fn common_web_windows() -> Self {
+        // 24% of the web
+        Self {
+            os: ClientOs::windows(),
+            os_version: ClientOsVersion::common_windows(),
+            browser: ClientBrowser::chrome_desktop(),
+            browser_version: String::from("131.0.0"),
+            user_agent: ClientUserAgent::common_web_windows(),
+            system_locale: ClientSystemLocale::en_us(),
+            client_build_number: ClientBuildNumber::latest(),
+            release_channel: ClientReleaseChannel::stable(),
+            has_client_mods: Some(false),
+            ..Self::minimal()
+        }
+    }
+
+    /// Returns the most common properties for the desktop client on windows
+    ///
+    /// See <https://www.useragents.me/#most-common-desktop-useragents>
+    pub fn common_desktop_windows() -> Self {
+        Self {
+            os: ClientOs::windows(),
+            os_version: ClientOsVersion::common_windows(),
+            browser: ClientBrowser::discord_desktop(),
+            browser_version: String::from("130.0.0"),
+            user_agent: ClientUserAgent::common_desktop_windows(),
+            system_locale: ClientSystemLocale::en_us(),
+            client_build_number: ClientBuildNumber::latest(),
+            os_arch: Some(String::from("x64")),
+            app_arch: Some(String::from("x64")),
+            has_client_mods: Some(false),
+            release_channel: ClientReleaseChannel::stable(),
+            ..Self::minimal()
+        }
+    }
+
+    /// Returns the most common properties for the desktop client on mac os
+    ///
+    /// See <https://www.useragents.me/#most-common-desktop-useragents>
+    pub fn common_desktop_mac_os() -> Self {
+        Self {
+            os: ClientOs::mac_os(),
+            os_version: ClientOsVersion::common_mac_os(),
+            browser: ClientBrowser::discord_desktop(),
+            browser_version: String::from("130.0.0"),
+            user_agent: ClientUserAgent::common_desktop_macos(),
+            system_locale: ClientSystemLocale::en_us(),
+            client_build_number: ClientBuildNumber::latest(),
+            os_arch: Some(String::from("arm64")),
+            app_arch: Some(String::from("arm64")),
+            has_client_mods: Some(false),
+            release_channel: ClientReleaseChannel::stable(),
+            ..Self::minimal()
+        }
+    }
+
+    /// Returns the most common properties for the desktop client on linux
+    ///
+    /// See <https://www.useragents.me/#most-common-desktop-useragents>
+    pub fn common_desktop_linux() -> Self {
+        Self {
+            os: ClientOs::linux(),
+            os_version: ClientOsVersion::latest_linux(),
+            browser: ClientBrowser::discord_desktop(),
+            browser_version: String::from("130.0.0"),
+            user_agent: ClientUserAgent::common_desktop_windows(),
+            system_locale: ClientSystemLocale::en_us(),
+            client_build_number: ClientBuildNumber::latest(),
+            os_arch: Some(String::from("x64")),
+            app_arch: Some(String::from("x64")),
+            has_client_mods: Some(false),
+            release_channel: ClientReleaseChannel::stable(),
+            ..Self::minimal()
+        }
+    }
+
+    /// Returns the most common properties to reduce tracking, currently pretends to be a desktop client on Windows 10
+    pub fn common() -> Self {
+        Self::common_desktop_windows()
+    }
+}
+
+/// The operating system the client is running on.
+///
+/// # Notes
+/// This is used for [ClientProperties]
+///
+/// # Reference
+/// See <https://docs.discord.sex/reference#operating-system-type>
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[serde(transparent)]
+pub struct ClientOs(String);
+
+impl From<String> for ClientOs {
+    fn from(value: String) -> Self {
+        ClientOs(value)
+    }
+}
+
+impl From<ClientOs> for String {
+    fn from(value: ClientOs) -> Self {
+        value.0
+    }
+}
+
+impl ClientOs {
+    pub fn android() -> ClientOs {
+        ClientOs(String::from("Android"))
+    }
+
+    pub fn blackberry() -> ClientOs {
+        ClientOs(String::from("BlackBerry"))
+    }
+
+    pub fn mac_os() -> ClientOs {
+        ClientOs(String::from("Mac OS X"))
+    }
+
+    pub fn ios() -> ClientOs {
+        ClientOs(String::from("iOS"))
+    }
+
+    pub fn linux() -> ClientOs {
+        ClientOs(String::from("Linux"))
+    }
+
+    pub fn windows_mobile() -> ClientOs {
+        ClientOs(String::from("Windows Mobile"))
+    }
+
+    pub fn windows() -> ClientOs {
+        ClientOs(String::from("Windows"))
+    }
+
+    /// The most common os, currently Windows
+    pub fn common() -> ClientOs {
+        Self::windows()
+    }
+
+    pub fn custom(value: String) -> ClientOs {
+        value.into()
+    }
+}
+
+impl Default for ClientOs {
+    fn default() -> Self {
+        ClientOs::common()
+    }
+}
+
+/// The operating system version the client is running on.
+///
+/// For windows, this is 10, 11, ...
+///
+/// For linux, this is the kernel version
+///
+/// For android, this is the sdk version
+///
+/// # Notes
+/// This is used for [ClientProperties]
+///
+/// # Reference
+/// See <https://docs.discord.sex/reference#client-properties-structure>
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[serde(transparent)]
+pub struct ClientOsVersion(String);
+
+impl From<String> for ClientOsVersion {
+    fn from(value: String) -> Self {
+        ClientOsVersion(value)
+    }
+}
+
+impl From<ClientOsVersion> for String {
+    fn from(value: ClientOsVersion) -> Self {
+        value.0
+    }
+}
+
+impl ClientOsVersion {
+    /// The latest os version for [ClientOs::android]
+    // See https://apilevels.com/ and https://telemetrydeck.com/survey/android/Android/sdkVersions/
+    pub fn latest_android() -> ClientOsVersion {
+        ClientOsVersion(String::from("35"))
+    }
+
+    /// The currently most common os version for [ClientOs::android]
+    // See https://apilevels.com/ and https://telemetrydeck.com/survey/android/Android/sdkVersions/
+    pub fn common_android() -> ClientOsVersion {
+        ClientOsVersion(String::from("34"))
+    }
+
+    /// The latest os version for [ClientOs::mac_os]
+    // See https://en.wikipedia.org/wiki/MacOS_version_history and https://www.statista.com/statistics/944559/worldwide-macos-version-market-share/
+    pub fn latest_mac_os() -> ClientOsVersion {
+        ClientOsVersion(String::from("15"))
+    }
+
+    /// The currently most common os version for [ClientOs::mac_os]
+    // See https://en.wikipedia.org/wiki/MacOS_version_history and https://www.statista.com/statistics/944559/worldwide-macos-version-market-share/
+    pub fn common_mac_os() -> ClientOsVersion {
+        ClientOsVersion(String::from("10.15"))
+    }
+
+    /// The latest os version for [ClientOs::ios]
+    // See https://en.wikipedia.org/wiki/IOS_version_history and https://gs.statcounter.com/ios-version-market-share/
+    pub fn latest_ios() -> ClientOsVersion {
+        ClientOsVersion(String::from("18.2"))
+    }
+
+    /// The currently most common os version for [ClientOs::ios]
+    // See https://en.wikipedia.org/wiki/IOS_version_history and https://gs.statcounter.com/ios-version-market-share/
+    pub fn common_ios() -> ClientOsVersion {
+        ClientOsVersion(String::from("17.6"))
+    }
+
+    /// The latest os version for [ClientOs::linux]
+    // See https://en.wikipedia.org/wiki/Linux_kernel_version_history
+    pub fn latest_linux() -> ClientOsVersion {
+        ClientOsVersion(String::from("6.12.7"))
+    }
+
+    // Note: I couldn't find which is the most commonly used
+
+    /// The latest os version for [ClientOs::windows]
+    // See https://en.wikipedia.org/wiki/List_of_Microsoft_Windows_versions and https://gs.statcounter.com/os-version-market-share/windows/desktop/worldwide
+    pub fn latest_windows() -> ClientOsVersion {
+        ClientOsVersion(String::from("11"))
+    }
+
+    /// The currently most common os version for [ClientOs::windows]
+    // See https://en.wikipedia.org/wiki/List_of_Microsoft_Windows_versions and https://gs.statcounter.com/os-version-market-share/windows/desktop/worldwide
+    pub fn common_windows() -> ClientOsVersion {
+        ClientOsVersion(String::from("10"))
+    }
+
+    pub fn custom(value: String) -> ClientOsVersion {
+        value.into()
+    }
+}
+
+// Empty string by default
+impl Default for ClientOsVersion {
+    fn default() -> Self {
+        ClientOsVersion::custom(String::new())
+    }
+}
+
+/// The browser the client is running on.
+///
+/// This also includes the desktop clients.
+///
+/// # Notes
+/// This is used for [ClientProperties]
+///
+/// # Reference
+/// See <https://docs.discord.sex/reference#browser-type>
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[serde(transparent)]
+pub struct ClientBrowser(String);
+
+impl From<String> for ClientBrowser {
+    fn from(value: String) -> Self {
+        ClientBrowser(value)
+    }
+}
+
+impl From<ClientBrowser> for String {
+    fn from(value: ClientBrowser) -> Self {
+        value.0
+    }
+}
+
+impl ClientBrowser {
+    /// The official discord client, on desktop
+    pub fn discord_desktop() -> ClientBrowser {
+        ClientBrowser(String::from("Discord Client"))
+    }
+
+    /// The official discord client, on android
+    pub fn discord_android() -> ClientBrowser {
+        ClientBrowser(String::from("Discord Android"))
+    }
+
+    /// The official discord client, on ios
+    pub fn discord_ios() -> ClientBrowser {
+        ClientBrowser(String::from("Discord iOS"))
+    }
+
+    /// The official discord client, on e.g. consoles, Xbox
+    pub fn discord_embedded() -> ClientBrowser {
+        ClientBrowser(String::from("Discord Embedded"))
+    }
+
+    pub fn chrome_android() -> ClientBrowser {
+        ClientBrowser(String::from("Android Chrome"))
+    }
+
+    pub fn chrome_ios() -> ClientBrowser {
+        ClientBrowser(String::from("Chrome iOS"))
+    }
+
+    pub fn chrome_desktop() -> ClientBrowser {
+        ClientBrowser(String::from("Chrome"))
+    }
+
+    /// Generic android web browser
+    pub fn generic_android() -> ClientBrowser {
+        ClientBrowser(String::from("Android Mobile"))
+    }
+
+    /// Blackberry web browser
+    pub fn blackberry() -> ClientBrowser {
+        ClientBrowser(String::from("BlackBerry"))
+    }
+
+    /// Legacy microsoft edge
+    ///
+    /// Probably shouldn't be used
+    pub fn edge() -> ClientBrowser {
+        ClientBrowser(String::from("Edge"))
+    }
+
+    /// Facebook mobile browser
+    pub fn facebook_mobile() -> ClientBrowser {
+        ClientBrowser(String::from("Facebook Mobile"))
+    }
+
+    pub fn firefox() -> ClientBrowser {
+        ClientBrowser(String::from("Firefox"))
+    }
+
+    pub fn internet_explorer() -> ClientBrowser {
+        ClientBrowser(String::from("Internet Explorer"))
+    }
+
+    pub fn kde_konqueror() -> ClientBrowser {
+        ClientBrowser(String::from("Konqueror"))
+    }
+
+    pub fn safari_ios() -> ClientBrowser {
+        ClientBrowser(String::from("Mobile Safari"))
+    }
+
+    pub fn safari_desktop() -> ClientBrowser {
+        ClientBrowser(String::from("Safari"))
+    }
+
+    /// Generic Mozilla-like browser
+    pub fn generic_mozilla() -> ClientBrowser {
+        ClientBrowser(String::from("Mozilla"))
+    }
+
+    pub fn opera() -> ClientBrowser {
+        ClientBrowser(String::from("Opera"))
+    }
+
+    pub fn opera_mini() -> ClientBrowser {
+        ClientBrowser(String::from("Opera Mini"))
+    }
+
+    /// The most common web browser, currently chrome on desktop
+    // See https://en.wikipedia.org/wiki/Usage_share_of_web_browsers
+    pub fn common() -> ClientBrowser {
+        Self::chrome_desktop()
+    }
+
+    pub fn custom(value: String) -> ClientBrowser {
+        value.into()
+    }
+}
+
+impl Default for ClientBrowser {
+    fn default() -> Self {
+        ClientBrowser::common()
+    }
+}
+
+/// The user agent of the browser the client is running on.
+///
+/// May be blank on mobile clients
+///
+/// # Notes
+/// This is used for [ClientProperties]
+///
+/// # Reference
+/// See <https://docs.discord.sex/reference#browser-type>
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[serde(transparent)]
+pub struct ClientUserAgent(String);
+
+impl From<String> for ClientUserAgent {
+    fn from(value: String) -> Self {
+        ClientUserAgent(value)
+    }
+}
+
+impl From<ClientUserAgent> for String {
+    fn from(value: ClientUserAgent) -> Self {
+        value.0
+    }
+}
+
+impl ClientUserAgent {
+    /// Returns the most common user agent used for the web client on windows
+    ///
+    /// Currently Chrome 131.0.0 on Windows 10, 24% of the web
+    ///
+    /// See <https://www.useragents.me/#most-common-desktop-useragents>
+    pub fn common_web_windows() -> ClientUserAgent {
+        ClientUserAgent(String::from("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.3"))
+    }
+
+    /// Returns the most common user agent used on Android web
+    ///
+    /// Currently Chrome 131.0.0 on android
+    ///
+    /// See <https://www.useragents.me/#most-common-mobile-useragents>
+    pub fn common_web_android() -> ClientUserAgent {
+        ClientUserAgent(String::from("Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Mobile Safari/537.3"))
+    }
+
+    /// Returns the most common user agent used for the ios web
+    ///
+    /// Currently Safari on ios 18.1.1
+    ///
+    /// See <https://www.useragents.me/#most-common-mobile-useragents>
+    pub fn common_web_ios() -> ClientUserAgent {
+        ClientUserAgent(String::from("Mozilla/5.0 (iPhone; CPU iPhone OS 18_1_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.1.1 Mobile/15E148 Safari/604."))
+    }
+
+    /// Returns the most common user agent used for the Mac os web client
+    ///
+    /// Currently Safari 17.6 on Mac os 10.15.7
+    ///
+    /// See <https://www.useragents.me/#most-common-mobile-useragents>
+    pub fn common_web_mac_os() -> ClientUserAgent {
+        ClientUserAgent(String::from("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Safari/605.1.1"))
+    }
+
+    /// Returns the most common user agent used for the Linux web client
+    ///
+    /// Currently Chrome 131.0.0 on Linux
+    ///
+    /// See <https://www.useragents.me/#most-common-desktop-useragents>
+    pub fn common_web_linux() -> ClientUserAgent {
+        ClientUserAgent(String::from("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"))
+    }
+
+    /// Returns the most common user agent used for the desktop client on Windows
+    ///
+    /// (this is mostly a guess, since we can't get statistics from discord themselves)
+    ///
+    /// Desktop useragents look similar to ones on Chrome;
+    /// this behaves like Windows 10 on Chrome 130.0.0.0
+    ///
+    /// See <https://www.useragents.me/#most-common-desktop-useragents>
+    pub fn common_desktop_windows() -> ClientUserAgent {
+        ClientUserAgent(String::from("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36"))
+    }
+
+    /// Returns the most common user agent used for the desktop client on macos
+    ///
+    /// (this is mostly a guess, since we can't get statistics from discord themselves)
+    ///
+    /// Desktop useragents look similar to ones on Chrome;
+    /// this behaves like a Mac 10.15.7 running Chrome 130.0.0.0
+    ///
+    /// See <https://www.useragents.me/#most-common-desktop-useragents>
+    pub fn common_desktop_macos() -> ClientUserAgent {
+        ClientUserAgent(String::from("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36"))
+    }
+
+    /// Returns the most common user agent used for the desktop client on linux
+    ///
+    /// (this is mostly a guess, since we can't get statistics from discord themselves)
+    ///
+    /// Desktop useragents look similar to ones on Chrome;
+    /// this behaves like Linux running Chrome 130.0.0.0
+    ///
+    /// See <https://www.useragents.me/#most-common-desktop-useragents>
+    pub fn common_desktop_linux() -> ClientUserAgent {
+        ClientUserAgent(String::from("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36"))
+    }
+
+    /// Returns the most common user agent used for the web client
+    ///
+    /// Currently Chrome 131.0.0 on Windows 10, 24% of the web
+    ///
+    /// See <https://www.useragents.me/#most-common-desktop-useragents>
+    pub fn common_web() -> ClientUserAgent {
+        Self::common_web_windows()
+    }
+
+    /// Returns the most common user agent
+    pub fn common() -> ClientUserAgent {
+        Self::common_desktop_windows()
+    }
+
+    pub fn custom(value: String) -> ClientUserAgent {
+        value.into()
+    }
+}
+
+impl Default for ClientUserAgent {
+    fn default() -> Self {
+        ClientUserAgent::common()
+    }
+}
+
+/// The build number of the client we are running.
+///
+/// # Notes
+/// This is used for [ClientProperties]
+///
+/// # Reference
+/// See <https://docs.discord.sex/reference#client-properties-structure>
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[serde(transparent)]
+pub struct ClientBuildNumber(u64);
+
+impl From<u64> for ClientBuildNumber {
+    fn from(value: u64) -> Self {
+        ClientBuildNumber(value)
+    }
+}
+
+impl From<ClientBuildNumber> for u64 {
+    fn from(value: ClientBuildNumber) -> Self {
+        value.0
+    }
+}
+
+impl ClientBuildNumber {
+    pub fn latest() -> ClientBuildNumber {
+        355624.into()
+    }
+
+    pub fn custom(value: u64) -> ClientBuildNumber {
+        value.into()
+    }
+}
+
+impl Default for ClientBuildNumber {
+    fn default() -> Self {
+        ClientBuildNumber::latest()
+    }
+}
+
+/// The release channel of the official client we are running on.
+///
+/// The main channels are
+/// - [Self::stable]
+/// - [Self::ptb] (public test build)
+/// - [Self::canary] (alpha test build)
+///
+/// The desktop client has an additional [Self::development] channel, which follows
+/// the [Self::canary] channel but is not recommended, as it can be broken or unstable at any time.
+///
+/// For more information about the main channels, see <https://support.discord.com/hc/en-us/articles/360035675191-Discord-Testing-Clients>
+///
+/// # Notes
+/// This is used for [ClientProperties]
+///
+/// # Reference
+/// See <https://docs.discord.sex/topics/client-distribution#desktop-release-channel> and <https://docs.discord.sex/topics/client-distribution#web-release-channel>
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[serde(transparent)]
+pub struct ClientReleaseChannel(String);
+
+impl From<String> for ClientReleaseChannel {
+    fn from(value: String) -> Self {
+        ClientReleaseChannel(value)
+    }
+}
+
+impl From<ClientReleaseChannel> for String {
+    fn from(value: ClientReleaseChannel) -> Self {
+        value.0
+    }
+}
+
+impl ClientReleaseChannel {
+    /// Stable web / desktop channel
+    pub fn stable() -> ClientReleaseChannel {
+        ClientReleaseChannel::custom(String::from("stable"))
+    }
+
+    /// Public test build web / desktop channel
+    pub fn ptb() -> ClientReleaseChannel {
+        ClientReleaseChannel::custom(String::from("ptb"))
+    }
+
+    /// Alpha test build web channel
+    pub fn canary() -> ClientReleaseChannel {
+        ClientReleaseChannel::custom(String::from("canary"))
+    }
+
+    /// Alpha test build desktop only channel, can be unstable or broken
+    pub fn development() -> ClientReleaseChannel {
+        ClientReleaseChannel::custom(String::from("development"))
+    }
+
+    /// The most commonly used release channel, currently stable
+    pub fn common() -> ClientReleaseChannel {
+        Self::stable()
+    }
+
+    pub fn custom(value: String) -> ClientReleaseChannel {
+        value.into()
+    }
+}
+
+impl Default for ClientReleaseChannel {
+    fn default() -> Self {
+        ClientReleaseChannel::common()
+    }
+}
+
+/// The locale ([IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag)) of the system
+/// running the client.
+///
+/// # Notes
+/// This is used for [ClientProperties]
+///
+/// # Reference
+/// See <https://docs.discord.sex/reference#client-properties-structure>
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[serde(transparent)]
+pub struct ClientSystemLocale(String);
+
+impl From<String> for ClientSystemLocale {
+    fn from(value: String) -> Self {
+        ClientSystemLocale(value)
+    }
+}
+
+impl From<ClientSystemLocale> for String {
+    fn from(value: ClientSystemLocale) -> Self {
+        value.0
+    }
+}
+
+impl ClientSystemLocale {
+    /// The en-US locale
+    pub fn en_us() -> ClientSystemLocale {
+        ClientSystemLocale(String::from("en-US"))
+    }
+
+    /// The most commonly used system locale, currently en-US
+    pub fn common() -> ClientSystemLocale {
+        Self::en_us()
+    }
+
+    pub fn custom(value: String) -> ClientSystemLocale {
+        value.into()
+    }
+}
+
+impl Default for ClientSystemLocale {
+    fn default() -> Self {
+        ClientSystemLocale::common()
+    }
+}

--- a/src/types/interfaces/client_properties.rs
+++ b/src/types/interfaces/client_properties.rs
@@ -47,7 +47,7 @@ use crate::{instance::ChorusUser, ratelimiter::ChorusRequest};
 ///
 /// # Disabling
 ///
-/// By setting [ClientProperties.send_telemetry_headers] to false, it is possible to disable
+/// By setting [ClientProperties::send_telemetry_headers] to false, it is possible to disable
 /// sending these properties via headers in the HTTP API.
 ///
 /// (Sending them via the gateway is required, since it is a non-optional field in the schema)

--- a/src/types/interfaces/mod.rs
+++ b/src/types/interfaces/mod.rs
@@ -8,9 +8,11 @@ pub use connected_account::*;
 pub use guild_welcome_screen::*;
 pub use interaction::*;
 pub use status::*;
+pub use client_properties::*;
 
 mod activity;
 mod connected_account;
 mod guild_welcome_screen;
 mod interaction;
 mod status;
+mod client_properties;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -52,6 +52,7 @@ impl TestBundle {
     }
     pub(crate) async fn clone_user_without_gateway(&self) -> ChorusUser {
         ChorusUser {
+			   client_properties: Default::default(),
             belongs_to: self.user.belongs_to.clone(),
             token: self.user.token.clone(),
             mfa_token: None,


### PR DESCRIPTION
Implements a new approach to client properties from #584 

Each `ChorusUser` now has its own `ClientProperties` struct, which contains telemetry data sent when identifying with the gateway and with every request to the HTTP API. 

This also means every request includes three new headers: `X-Super-Properties` (the entire `ClientProperties` encoded in base 64), `X-Discord-Locale` (which is copied from `ClientProperties.system_locale`) and `X-Debug-Options` (which is set to a hard-coded value of `bugReporterEnabled`)

Internally this also removes the old api `ChorusRequest::new` in favor of `ChorusRequest {}`, along with refactoring how headers are set on all routes