### PR TITLE
Add api for awaiting responses to gateway send events

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -105,6 +105,10 @@ custom_error! {
     CannotConnect{error: String} = "Cannot connect due to a websocket error: {error}",
     NonHelloOnInitiate{opcode: u8} = "Received non hello on initial gateway connection ({opcode}), something is definitely wrong",
 
+     // Errors for the in-place-events api
+     /// Server did not respond to our request in time
+     NoResponse = "Server did not respond in time",
+
     // Other misc errors
     UnexpectedOpcodeReceived{opcode: u8} = "Received an opcode we weren't expecting to receive: {opcode}",
 }

--- a/src/gateway/events.rs
+++ b/src/gateway/events.rs
@@ -51,6 +51,7 @@ pub struct Session {
     pub replace: Publisher<types::SessionsReplace>,
     pub reconnect: Publisher<types::GatewayReconnect>,
     pub invalid: Publisher<types::GatewayInvalidSession>,
+    pub resumed: Publisher<types::GatewayResumed>,
 }
 
 #[derive(Default, Debug)]

--- a/src/gateway/gateway.rs
+++ b/src/gateway/gateway.rs
@@ -118,7 +118,10 @@ impl Gateway {
             serde_json::from_str(&message.0).unwrap();
 
         if gateway_payload.op_code != (Opcode::Hello as u8) {
-			   warn!("GW: Received a non-hello opcode ({}) on gateway init", gateway_payload.op_code);
+            warn!(
+                "GW: Received a non-hello opcode ({}) on gateway init",
+                gateway_payload.op_code
+            );
             return Err(GatewayError::NonHelloOnInitiate {
                 opcode: gateway_payload.op_code,
             });
@@ -357,7 +360,7 @@ impl Gateway {
             return;
         }
 
-		  let op_code = op_code_res.unwrap();
+        let op_code = op_code_res.unwrap();
 
         match op_code {
             // An event was dispatched, we need to look at the gateway event name t
@@ -413,7 +416,6 @@ impl Gateway {
                                     }
                                 }
                             },)*
-                            "RESUMED" => (),
                             "SESSIONS_REPLACE" => {
                                 let json = gateway_payload.event_data.unwrap().get();
                                 let result: Result<Vec<types::Session>, serde_json::Error> = serde_json::from_str(json);
@@ -505,6 +507,7 @@ impl Gateway {
                     "RECENT_MENTION_DELETE" => message.recent_mention_delete,
                     "MESSAGE_ACK" => message.ack,
                     "PRESENCE_UPDATE" => user.presence_update, // TODO
+                          "RESUMED" => session.resumed,
                     "RELATIONSHIP_ADD" => relationship.add,
                     "RELATIONSHIP_REMOVE" => relationship.remove,
                     "STAGE_INSTANCE_CREATE" => stage_instance.create,

--- a/src/gateway/handle.rs
+++ b/src/gateway/handle.rs
@@ -142,27 +142,25 @@ impl GatewayHandle {
             .ready
             .subscribe(observer.clone());
 
-        loop {
-            tokio::select! {
-                  () = sleep(std::time::Duration::from_secs(5)) => {
-                      // Timeout
-                      self.events.lock().await.session.ready.unsubscribe(observer);
-                      return Err(GatewayError::NoResponse);
-                  }
-                  result = receiver => {
-                      match result {
-                          Ok(event) => {
-                              self.events.lock().await.session.ready.unsubscribe(observer);
-                              return Ok(event);
-                          }
-                          Err(e) => {
-                              warn!("Gateway in-place-events receive error: {:?}", e);
-                              self.events.lock().await.session.ready.unsubscribe(observer);
-                              return Err(GatewayError::Unknown);
-                          }
+        tokio::select! {
+              () = sleep(std::time::Duration::from_secs(5)) => {
+                  // Timeout
+                  self.events.lock().await.session.ready.unsubscribe(observer);
+                  return Err(GatewayError::NoResponse);
+              }
+              result = receiver => {
+                  match result {
+                      Ok(event) => {
+                          self.events.lock().await.session.ready.unsubscribe(observer);
+                          return Ok(event);
+                      }
+                      Err(e) => {
+                          warn!("Gateway in-place-events receive error: {:?}", e);
+                          self.events.lock().await.session.ready.unsubscribe(observer);
+                          return Err(GatewayError::Unknown);
                       }
                   }
-            }
+              }
         }
     }
 
@@ -198,27 +196,25 @@ impl GatewayHandle {
             .resumed
             .subscribe(observer.clone());
 
-        loop {
-            tokio::select! {
-                  () = sleep(std::time::Duration::from_secs(5)) => {
-                      // Timeout
-                      self.events.lock().await.session.resumed.unsubscribe(observer);
-                      return Err(GatewayError::NoResponse);
-                  }
-                  result = receiver => {
-                      match result {
-                          Ok(event) => {
-                              self.events.lock().await.session.resumed.unsubscribe(observer);
-                              return Ok(event);
-                          }
-                          Err(e) => {
-                              warn!("Gateway in-place-events receive error: {:?}", e);
-                              self.events.lock().await.session.resumed.unsubscribe(observer);
-                              return Err(GatewayError::Unknown);
-                          }
+        tokio::select! {
+              () = sleep(std::time::Duration::from_secs(5)) => {
+                  // Timeout
+                  self.events.lock().await.session.resumed.unsubscribe(observer);
+                  return Err(GatewayError::NoResponse);
+              }
+              result = receiver => {
+                  match result {
+                      Ok(event) => {
+                          self.events.lock().await.session.resumed.unsubscribe(observer);
+                          return Ok(event);
+                      }
+                      Err(e) => {
+                          warn!("Gateway in-place-events receive error: {:?}", e);
+                          self.events.lock().await.session.resumed.unsubscribe(observer);
+                          return Err(GatewayError::Unknown);
                       }
                   }
-            }
+              }
         }
     }
 
@@ -331,27 +327,25 @@ impl GatewayHandle {
             .state_update
             .subscribe(observer.clone());
 
-        loop {
-            tokio::select! {
-                  () = sleep(std::time::Duration::from_secs(1)) => {
-                      // Timeout
-                      self.events.lock().await.voice.state_update.unsubscribe(observer);
-                      return None;
-                  }
-                  result = receiver => {
-                      match result {
-                          Ok(event) => {
-                              self.events.lock().await.voice.state_update.unsubscribe(observer);
-                              return Some(event);
-                          }
-                          Err(e) => {
-                              warn!("Gateway in-place-events receive error: {:?}", e);
-                              self.events.lock().await.voice.state_update.unsubscribe(observer);
-                              return None;
-                          }
+        tokio::select! {
+              () = sleep(std::time::Duration::from_secs(1)) => {
+                  // Timeout
+                  self.events.lock().await.voice.state_update.unsubscribe(observer);
+                  return None;
+              }
+              result = receiver => {
+                  match result {
+                      Ok(event) => {
+                          self.events.lock().await.voice.state_update.unsubscribe(observer);
+                          return Some(event);
+                      }
+                      Err(e) => {
+                          warn!("Gateway in-place-events receive error: {:?}", e);
+                          self.events.lock().await.voice.state_update.unsubscribe(observer);
+                          return None;
                       }
                   }
-            }
+              }
         }
     }
 
@@ -415,27 +409,25 @@ impl GatewayHandle {
             .last_messages
             .subscribe(observer.clone());
 
-        loop {
-            tokio::select! {
-                  () = sleep(std::time::Duration::from_secs(5)) => {
-                      // Timeout
-                      self.events.lock().await.message.last_messages.unsubscribe(observer);
-                      return Err(GatewayError::NoResponse);
-                  }
-                  result = receiver => {
-                      match result {
-                          Ok(event) => {
-                              self.events.lock().await.message.last_messages.unsubscribe(observer);
-                              return Ok(event);
-                          }
-                          Err(e) => {
-                              warn!("Gateway in-place-events receive error: {:?}", e);
-                              self.events.lock().await.message.last_messages.unsubscribe(observer);
-                              return Err(GatewayError::Unknown);
-                          }
+        tokio::select! {
+              () = sleep(std::time::Duration::from_secs(5)) => {
+                  // Timeout
+                  self.events.lock().await.message.last_messages.unsubscribe(observer);
+                  return Err(GatewayError::NoResponse);
+              }
+              result = receiver => {
+                  match result {
+                      Ok(event) => {
+                          self.events.lock().await.message.last_messages.unsubscribe(observer);
+                          return Ok(event);
+                      }
+                      Err(e) => {
+                          warn!("Gateway in-place-events receive error: {:?}", e);
+                          self.events.lock().await.message.last_messages.unsubscribe(observer);
+                          return Err(GatewayError::Unknown);
                       }
                   }
-            }
+              }
         }
     }
 

--- a/src/gateway/handle.rs
+++ b/src/gateway/handle.rs
@@ -146,18 +146,18 @@ impl GatewayHandle {
               () = sleep(std::time::Duration::from_secs(5)) => {
                   // Timeout
                   self.events.lock().await.session.ready.unsubscribe(observer);
-                  return Err(GatewayError::NoResponse);
+                  Err(GatewayError::NoResponse)
               }
               result = receiver => {
                   match result {
                       Ok(event) => {
                           self.events.lock().await.session.ready.unsubscribe(observer);
-                          return Ok(event);
+                          Ok(event)
                       }
                       Err(e) => {
                           warn!("Gateway in-place-events receive error: {:?}", e);
                           self.events.lock().await.session.ready.unsubscribe(observer);
-                          return Err(GatewayError::Unknown);
+                          Err(GatewayError::Unknown)
                       }
                   }
               }
@@ -200,18 +200,18 @@ impl GatewayHandle {
               () = sleep(std::time::Duration::from_secs(5)) => {
                   // Timeout
                   self.events.lock().await.session.resumed.unsubscribe(observer);
-                  return Err(GatewayError::NoResponse);
+                  Err(GatewayError::NoResponse)
               }
               result = receiver => {
                   match result {
                       Ok(event) => {
                           self.events.lock().await.session.resumed.unsubscribe(observer);
-                          return Ok(event);
+                          Ok(event)
                       }
                       Err(e) => {
                           warn!("Gateway in-place-events receive error: {:?}", e);
                           self.events.lock().await.session.resumed.unsubscribe(observer);
-                          return Err(GatewayError::Unknown);
+                          Err(GatewayError::Unknown)
                       }
                   }
               }
@@ -331,18 +331,18 @@ impl GatewayHandle {
               () = sleep(std::time::Duration::from_secs(1)) => {
                   // Timeout
                   self.events.lock().await.voice.state_update.unsubscribe(observer);
-                  return None;
+                  None
               }
               result = receiver => {
                   match result {
                       Ok(event) => {
                           self.events.lock().await.voice.state_update.unsubscribe(observer);
-                          return Some(event);
+                          Some(event)
                       }
                       Err(e) => {
                           warn!("Gateway in-place-events receive error: {:?}", e);
                           self.events.lock().await.voice.state_update.unsubscribe(observer);
-                          return None;
+                          None
                       }
                   }
               }
@@ -413,18 +413,18 @@ impl GatewayHandle {
               () = sleep(std::time::Duration::from_secs(5)) => {
                   // Timeout
                   self.events.lock().await.message.last_messages.unsubscribe(observer);
-                  return Err(GatewayError::NoResponse);
+                  Err(GatewayError::NoResponse)
               }
               result = receiver => {
                   match result {
                       Ok(event) => {
                           self.events.lock().await.message.last_messages.unsubscribe(observer);
-                          return Ok(event);
+                          Ok(event)
                       }
                       Err(e) => {
                           warn!("Gateway in-place-events receive error: {:?}", e);
                           self.events.lock().await.message.last_messages.unsubscribe(observer);
-                          return Err(GatewayError::Unknown);
+                          Err(GatewayError::Unknown)
                       }
                   }
               }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -10,6 +10,7 @@ pub mod gateway;
 pub mod handle;
 pub mod heartbeat;
 pub mod message;
+pub mod observers;
 pub mod options;
 
 pub use backends::*;
@@ -17,6 +18,7 @@ pub use gateway::*;
 pub use handle::*;
 use heartbeat::*;
 pub use message::*;
+pub use observers::*;
 pub use options::*;
 
 use crate::errors::GatewayError;

--- a/src/gateway/observers.rs
+++ b/src/gateway/observers.rs
@@ -1,0 +1,106 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! Includes pre-made observers to use with gateway events
+
+use crate::types::WebSocketEvent;
+use async_trait::async_trait;
+use log::warn;
+use pubserve::Subscriber;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// Observes an event once and sends it via a [tokio::sync::oneshot] channel
+#[derive(Debug)]
+pub struct OneshotEventObserver<T>
+where
+    T: WebSocketEvent + Clone,
+{
+    pub sender: Mutex<Option<tokio::sync::oneshot::Sender<T>>>,
+}
+
+impl<T: WebSocketEvent + Clone> OneshotEventObserver<T> {
+    /// Creates a new [OneshotEventObserver] for the given event
+    ///
+    /// You must subscribe it to your gateway event; after receiving on the channel,
+    /// you should unsubscribe it if possible
+    pub fn new() -> (
+        Arc<OneshotEventObserver<T>>,
+        tokio::sync::oneshot::Receiver<T>,
+    ) {
+        let (sender, receiver) = tokio::sync::oneshot::channel();
+
+        let observer = Arc::new(OneshotEventObserver {
+            sender: Mutex::new(Some(sender)),
+        });
+
+        (observer, receiver)
+    }
+}
+
+#[async_trait]
+impl<T> Subscriber<T> for OneshotEventObserver<T>
+where
+    T: WebSocketEvent + Clone,
+{
+    async fn update(&self, message: &T) {
+        let mut lock = self.sender.lock().await;
+
+        if lock.is_none() {
+            warn!("OneshotEventObserver received event after closing channel!");
+            return;
+        }
+
+        let sender = lock.take().unwrap();
+
+        match sender.send(message.clone()) {
+            Ok(_) => {}
+            Err(e) => {
+                warn!("OneshotEventObserver failed to send event: {:?}", e);
+            }
+        }
+    }
+}
+
+/// Observes an event indefinitely and sends it via a [tokio::sync::broadcast] channel
+#[derive(Debug)]
+pub struct BroadcastEventObserver<T>
+where
+    T: WebSocketEvent + Clone,
+{
+    pub sender: tokio::sync::broadcast::Sender<T>,
+}
+
+impl<T: WebSocketEvent + Clone> BroadcastEventObserver<T> {
+    /// Creates a new [BroadcastEventObserver] for the given event
+    ///
+    /// You must subscribe it to your gateway event
+    pub fn new(
+        channel_size: usize,
+    ) -> (
+        Arc<BroadcastEventObserver<T>>,
+        tokio::sync::broadcast::Receiver<T>,
+    ) {
+        let (sender, receiver) = tokio::sync::broadcast::channel(channel_size);
+
+        let observer = Arc::new(BroadcastEventObserver { sender });
+
+        (observer, receiver)
+    }
+}
+
+#[async_trait]
+impl<T> Subscriber<T> for BroadcastEventObserver<T>
+where
+    T: WebSocketEvent + Clone,
+{
+    async fn update(&self, message: &T) {
+        match self.sender.send(message.clone()) {
+            Ok(_) => {}
+            Err(e) => {
+                warn!("BroadcastEventObserver failed to send event: {:?}", e);
+            }
+        }
+    }
+}

--- a/src/gateway/observers.rs
+++ b/src/gateway/observers.rs
@@ -29,12 +29,12 @@ use tokio::sync::Mutex;
 /// let result = receiver.await;
 ///
 /// match result {
-///	Ok(event) => {
-///		println!("Yay! we received the event!");
-///	}
-///	Err(e) => {
-///		println!("We sadly encountered an error: {:?}", e);
-///	}
+///   Ok(event) => {
+///      println!("Yay! we received the event!");
+///   }
+///   Err(e) => {
+///      println!("We sadly encountered an error: {:?}", e);
+///   }
 /// }
 ///
 /// // The observer has now served its purpose, unsubscribe it
@@ -58,19 +58,19 @@ use tokio::sync::Mutex;
 /// handle.events.lock().await.message.create.subscribe(observer.clone());
 ///
 /// tokio::select! {
-///	() = sleep(Duration::from_secs(10)) => {
-///		// No event happened in 10 seconds
-///	}
-///	result = receiver => {
-///		match result {
-///			Ok(event) => {
-///				println!("Yay! we received the event!");
-///			}
-///			Err(e) => {
-///				println!("We sadly encountered an error: {:?}", e);
-///			}
-///		}
-///	}
+///   () = sleep(Duration::from_secs(10)) => {
+///      // No event happened in 10 seconds
+///   }
+///   result = receiver => {
+///      match result {
+///         Ok(event) => {
+///            println!("Yay! we received the event!");
+///         }
+///         Err(e) => {
+///            println!("We sadly encountered an error: {:?}", e);
+///         }
+///      }
+///   }
 /// }
 ///
 /// // The observer has now served its purpose, unsubscribe it
@@ -145,17 +145,17 @@ where
 /// handle.events.lock().await.message.create.subscribe(observer.clone());
 ///
 /// loop {
-///	let result = receiver.recv().await;
+///   let result = receiver.recv().await;
 ///
-///	match result {
-///		Ok(event) => {
-///			println!("Yay! we received the event!");
-///		}
-///		Err(e) => {
-///			println!("We sadly encountered an error: {:?}", e);
-///			break;
-///		}
-///	}
+///   match result {
+///      Ok(event) => {
+///         println!("Yay! we received the event!");
+///      }
+///      Err(e) => {
+///         println!("We sadly encountered an error: {:?}", e);
+///         break;
+///      }
+///   }
 /// }
 ///
 /// // The observer has now served its purpose, unsubscribe it
@@ -180,21 +180,21 @@ where
 ///
 /// loop {
 ///   tokio::select! {
-///		() = sleep(Duration::from_secs(10)) => {
-///			println!("Waited for 10 seconds with no message, stopping");
-///			break;
-///		}
-///		result = receiver.recv() => {
-///			match result {
-///				Ok(event) => {
-///					println!("Yay! we received the event!");
-///				}
-///				Err(e) => {
-///					println!("We sadly encountered an error: {:?}", e);
-///					break;
-///				}
-///			}
-///		}
+///      () = sleep(Duration::from_secs(10)) => {
+///         println!("Waited for 10 seconds with no message, stopping");
+///         break;
+///      }
+///      result = receiver.recv() => {
+///         match result {
+///            Ok(event) => {
+///               println!("Yay! we received the event!");
+///            }
+///            Err(e) => {
+///               println!("We sadly encountered an error: {:?}", e);
+///               break;
+///            }
+///         }
+///      }
 ///   }
 /// }
 ///

--- a/src/types/events/request_members.rs
+++ b/src/types/events/request_members.rs
@@ -19,26 +19,30 @@ use serde::{Deserialize, Serialize};
 /// # Reference
 /// See <https://docs.discord.sex/topics/gateway-events#request-guild-members>
 pub struct GatewayRequestGuildMembers {
-	 /// Id(s) of the guild(s) to get members for
+    /// Id(s) of the guild(s) to get members for
     pub guild_id: OneOrMoreSnowflakes,
 
-	 /// The user id(s) to request (0 - 100)
+    /// The user id(s) to request (0 - 100)
     pub user_ids: Option<OneOrMoreSnowflakes>,
 
-	 /// String that the username / nickname starts with, or an empty string for all members
+    /// String that the username / nickname starts with, or an empty string for all members
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub query: Option<String>,
 
-	 /// Maximum number of members to send matching the query (0 - 100)
-	 ///
-	 /// Must be 0 with an empty query
-    pub limit: u8,
+    /// Maximum number of members to send matching the query (0 - 100)
+    ///
+    /// Must be 0 with an empty query
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u8>,
 
-	 /// Whether to return the [Presence](crate::types::events::PresenceUpdate) of the matched
-	 /// members
+    /// Whether to return the [Presence](crate::types::events::PresenceUpdate) of the matched
+    /// members
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub presences: Option<bool>,
 
-	 /// Unique string to identify the received event for this specific request.
-	 ///
-	 /// Up to 32 bytes. If you send a longer nonce, it will be ignored
+    /// Unique string to identify the received event for this specific request.
+    ///
+    /// Up to 32 bytes. If you send a longer nonce, it will be ignored
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub nonce: Option<String>,
 }

--- a/src/types/events/resume.rs
+++ b/src/types/events/resume.rs
@@ -5,10 +5,27 @@
 use crate::types::events::WebSocketEvent;
 use serde::{Deserialize, Serialize};
 
+/// Used to replay missed events when a disconnected client resumes.
+///
+/// # Reference
+/// See <https://docs.discord.sex/topics/gateway-events#resume>
 #[derive(Debug, Clone, Deserialize, Serialize, Default, WebSocketEvent)]
 pub struct GatewayResume {
     pub token: String,
+    /// Existing session id
     pub session_id: String,
+    /// Last sequence number received
     pub seq: String,
 }
 
+/// Sent in response to a [GatewayResume].
+///
+/// Signifies the end of event replaying.
+///
+/// # Reference
+/// See <https://docs.discord.sex/topics/gateway-events#resumed>
+#[derive(Debug, Clone, Deserialize, Serialize, Default, WebSocketEvent)]
+pub struct GatewayResumed {
+    #[serde(rename = "_trace")]
+    pub trace: Vec<String>,
+}


### PR DESCRIPTION
Adds some new methods to `GatewayHandle`:
- `identify`, which functions like `send_identify`, but waits to receive the response
- `resume`, which functions like `send_resume`, but waits to receive the response
- `request_guild_members`, which functions like `send_request_guild_members`, but waits to receive all `GuildMembersChunk`s
- `update_voice_state`, which functions like `send_update_voice_state`, but waits up to 1 second to receive a potential response
- `request_last_messages`, which functions like `send_request_last_messages`, but waits to receive the response

These work by creating a temporary observer, which sends the event through either a `tokio::sync::broadcast` or `tokio::sync::oneshot` channel. These two observer types are now also part of the public api as `BroadcastEventObserver<T>` and `OneshotEventObserver<T>`

It also adds `Events.session.resumed` and `GatewayResumed` for the `Resumed` dispatch event. I'm still not sure if resuming is practically possible, since you need to provide the last received sequence number