### PR TITLE
Add UserStatus variant "Unknown"

### DIFF
--- a/src/types/entities/user_settings.rs
+++ b/src/types/entities/user_settings.rs
@@ -21,6 +21,7 @@ pub enum UserStatus {
     Dnd,
     Idle,
     Invisible,
+    Unknown,
 }
 
 impl std::fmt::Display for UserStatus {
@@ -133,9 +134,7 @@ pub struct CustomStatus {
     pub text: Option<String>,
 }
 
-#[derive(
-    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, PartialOrd, Ord, Hash,
-)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Copy, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow, sqlx::Type))]
 pub struct FriendSourceFlags {
     pub all: bool,


### PR DESCRIPTION
According to the trusty <https://docs.discord.sex/resources/presence#status-type>, a UserStatus enum variant was missing.