### PR TITLE
Add user ignore api, update relationship entity

### DIFF
--- a/src/api/users/relationships.rs
+++ b/src/api/users/relationships.rs
@@ -10,8 +10,8 @@ use crate::{
     instance::ChorusUser,
     ratelimiter::ChorusRequest,
     types::{
-        self, CreateUserRelationshipSchema, FriendRequestSendSchema, LimitType, RelationshipType,
-        Snowflake,
+        self, BulkRemoveRelationshipsQuery, CreateUserRelationshipSchema, FriendRequestSendSchema,
+        LimitType, RelationshipType, Snowflake,
     },
 };
 
@@ -146,6 +146,78 @@ impl ChorusUser {
             limit_type: LimitType::Global,
         }
         .with_headers_for(self);
+        chorus_request.handle_request_as_result(self).await
+    }
+
+    /// Removes multiple relationships.
+    ///
+    /// # Reference
+    /// See <https://docs.discord.sex/resources/relationships#bulk-remove-relationships>
+    pub async fn bulk_remove_relationships(
+        &mut self,
+        query: Option<BulkRemoveRelationshipsQuery>,
+    ) -> ChorusResult<()> {
+        let query_parameters = if let Some(passed) = query {
+            passed.to_query()
+        } else {
+            Vec::new()
+        };
+
+        let url = format!(
+            "{}/users/@me/relationships",
+            self.belongs_to.read().unwrap().urls.api,
+        );
+        let chorus_request = ChorusRequest {
+            request: Client::new().delete(url).query(&query_parameters),
+            limit_type: LimitType::Global,
+        }
+        .with_headers_for(self);
+        chorus_request.handle_request_as_result(self).await
+    }
+
+    /// [Ignores](https://support.discord.com/hc/en-us/articles/28084948873623-How-to-Ignore-Users-on-Discord) a user.
+    ///
+    /// # Notes
+    /// As of 2025/03/16, Spacebar does not yet implement this endpoint.
+    ///
+    /// # Reference
+    /// See <https://docs.discord.sex/resources/relationships#ignore-user>
+    pub async fn ignore_user(&mut self, user_id: Snowflake) -> ChorusResult<()> {
+        let url = format!(
+            "{}/users/@me/relationships/{}/ignore",
+            self.belongs_to.read().unwrap().urls.api,
+            user_id
+        );
+
+        let chorus_request = ChorusRequest {
+            request: Client::new().put(url),
+            limit_type: LimitType::Global,
+        }
+        .with_headers_for(self);
+
+        chorus_request.handle_request_as_result(self).await
+    }
+
+    /// [Unignores](https://support.discord.com/hc/en-us/articles/28084948873623-How-to-Ignore-Users-on-Discord) a user.
+    ///
+    /// # Notes
+    /// As of 2025/03/16, Spacebar does not yet implement this endpoint.
+    ///
+    /// # Reference
+    /// See <https://docs.discord.sex/resources/relationships#unignore-user>
+    pub async fn unignore_user(&mut self, user_id: Snowflake) -> ChorusResult<()> {
+        let url = format!(
+            "{}/users/@me/relationships/{}/ignore",
+            self.belongs_to.read().unwrap().urls.api,
+            user_id
+        );
+
+        let chorus_request = ChorusRequest {
+            request: Client::new().delete(url),
+            limit_type: LimitType::Global,
+        }
+        .with_headers_for(self);
+
         chorus_request.handle_request_as_result(self).await
     }
 }

--- a/src/types/entities/relationship.rs
+++ b/src/types/entities/relationship.rs
@@ -13,16 +13,20 @@ use super::{option_arc_rwlock_ptr_eq, PublicUser};
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
-/// See <https://discord-userdoccers.vercel.app/resources/user#relationship-structure>
+/// # Reference
+/// See <https://docs.discord.sex/resources/relationships#relationship-structure>
 pub struct Relationship {
     /// The ID of the target user
     #[cfg_attr(feature = "sqlx", sqlx(rename = "to_id"))]
     pub id: Snowflake,
+
     #[serde(rename = "type")]
     #[cfg_attr(feature = "sqlx", sqlx(rename = "type"))]
     pub relationship_type: RelationshipType,
-    /// The nickname of the user in this relationship
+
+    /// The nickname of the user in this relationship (1 - 32 characters)
     pub nickname: Option<String>,
+
     #[cfg_attr(feature = "sqlx", sqlx(skip))] // Can be derived from the user id
     /// The target user
     ///
@@ -30,6 +34,28 @@ pub struct Relationship {
     ///
     /// In such a case, you should refer to the id field and seperately fetch the user's data
     pub user: Option<Shared<PublicUser>>,
+
+    #[serde(default)]
+    /// Whether the friend request was flagged as spam (false by default)
+    pub is_spam_request: Option<bool>,
+
+    #[serde(default)]
+    /// Whether the friend request was sent by a user without a mutual friend or small mutual guild
+    /// (false by default)
+    pub stranger_request: Option<bool>,
+
+    #[serde(default)]
+    /// Whether the target user has been ignored by the current user.
+    ///
+    /// Note: Spacebar does not implement this field (or ignoring users)
+    ///
+    /// When connected to a Spacebar instance, this field will always be false.
+    pub user_ignored: bool,
+
+    /// The ID of the application that created the relationship
+    #[serde(default)]
+    pub origin_application_id: Option<Snowflake>,
+
     /// When the user requested a relationship
     pub since: Option<DateTime<Utc>>,
 }
@@ -59,15 +85,17 @@ impl PartialEq for Relationship {
     Hash,
 )]
 #[repr(u8)]
-/// See <https://discord-userdoccers.vercel.app/resources/user#relationship-type>
+/// # Reference
+/// See <https://docs.discord.sex/resources/relationships#relationship-type>
 pub enum RelationshipType {
+    /// Deprecated
     Suggestion = 6,
     Implicit = 5,
     Outgoing = 4,
     Incoming = 3,
     Blocked = 2,
-    #[default]
     Friends = 1,
+    #[default]
     None = 0,
 }
 

--- a/src/types/schema/relationship.rs
+++ b/src/types/schema/relationship.rs
@@ -55,7 +55,10 @@ impl BulkRemoveRelationshipsQuery {
         let mut query = Vec::with_capacity(2);
 
         if let Some(relationship_type) = self.relationship_type {
-            query.push(("relationship_type", relationship_type.to_string()));
+            query.push((
+                "relationship_type",
+                serde_json::to_string(&relationship_type).unwrap(),
+            ));
         }
 
         if let Some(only_spam) = self.only_spam {

--- a/src/types/schema/relationship.rs
+++ b/src/types/schema/relationship.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::RelationshipType;
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct FriendRequestSendSchema {
     pub username: String,
     pub discriminator: Option<String>,
@@ -19,11 +19,49 @@ pub struct FriendRequestSendSchema {
 /// * from_friend_suggestion: Whether the relationship was created from a friend suggestion (default false)
 /// * friend_token: The friend token of the user to add a direct friend relationship to
 ///
-/// See: [https://discord-userdoccers.vercel.app/resources/user#create-user-relationship](https://discord-userdoccers.vercel.app/resources/user#create-user-relationship)
-#[derive(Deserialize, Serialize, Debug, Clone)]
+/// # Reference
+/// See <https://discord-userdoccers.vercel.app/resources/user#create-user-relationship>
+#[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq, Eq)]
 pub struct CreateUserRelationshipSchema {
     #[serde(rename = "type")]
     pub relationship_type: Option<RelationshipType>,
     pub from_friend_suggestion: Option<bool>,
     pub friend_token: Option<String>,
+}
+
+/// Optional query parameters for the
+/// [ChorusUser::bulk_remove_relationships](crate::instance::ChorusUser::bulk_remove_relationships)
+/// route.
+///
+/// # Reference
+/// See <https://docs.discord.sex/resources/relationships#bulk-remove-relationships>
+#[derive(Deserialize, Serialize, Debug, Copy, Default, Clone, PartialEq, Eq)]
+pub struct BulkRemoveRelationshipsQuery {
+    /// Remove relationships with this type (default [RelationshipType::Incoming], only
+    /// [RelationshipType::Incoming] is allowed.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub relationship_type: Option<RelationshipType>,
+
+    /// Whether to only remove relationships that were flagged as spam (false by default)
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub only_spam: Option<bool>,
+}
+
+impl BulkRemoveRelationshipsQuery {
+    /// Converts self to query string parameters
+    pub fn to_query(self) -> Vec<(&'static str, String)> {
+        let mut query = Vec::with_capacity(2);
+
+        if let Some(relationship_type) = self.relationship_type {
+            query.push(("relationship_type", relationship_type.to_string()));
+        }
+
+        if let Some(only_spam) = self.only_spam {
+            query.push(("only_spam", only_spam.to_string()));
+        }
+
+        query
+    }
 }


### PR DESCRIPTION
Note `user_ignored` does not exist on Spacebar; I think we can just default it to `false` if it does not exist

closes #601 

also: this breaks the symfonia relationship create migration