### PR TITLE
Update links to Discord Userdoccers

### DIFF
--- a/src/api/auth/login.rs
+++ b/src/api/auth/login.rs
@@ -49,7 +49,7 @@ impl Instance {
     /// Verifies a multi-factor authentication login
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/authentication#verify-mfa-login>
+    /// See <https://docs.discord.food/authentication#verify-mfa-login>
     pub async fn verify_mfa_login(
         &mut self,
         authenticator: MfaAuthenticationType,
@@ -92,7 +92,7 @@ impl Instance {
     /// Sends a multi-factor authentication code to the user's phone number
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/authentication#send-mfa-sms>
+    /// See <https://docs.discord.food/authentication#send-mfa-sms>
     // FIXME: This uses ChorusUser::shell, when it *really* shouldn't, but
     // there is no other way to send a ratelimited request
     pub async fn send_mfa_sms(

--- a/src/api/channels/channels.rs
+++ b/src/api/channels/channels.rs
@@ -19,7 +19,7 @@ impl Channel {
     /// Retrieves a channel from the server.
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/channel#get-channel>
+    /// See <https://docs.discord.food/resources/channel#get-channel>
     pub async fn get(user: &mut ChorusUser, channel_id: Snowflake) -> ChorusResult<Channel> {
         let chorus_request = ChorusRequest {
             request: Client::new().get(format!(
@@ -40,7 +40,7 @@ impl Channel {
     /// the [`MANAGE_THREADS`](crate::types::PermissionFlags::MANAGE_THREADS) permission if the channel is a thread.
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/channel#delete-channel>
+    /// See <https://docs.discord.food/resources/channel#delete-channel>
     pub async fn delete(
         self,
         audit_log_reason: Option<String>,
@@ -75,7 +75,7 @@ impl Channel {
     /// Otherwise, requires the [`MANAGE_THREADS`](crate::types::PermissionFlags::MANAGE_THREADS) permission. Requires the thread to have `archived` set to `false` or be set to `false` in the request.
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/channel#modify-channel>
+    /// See <https://docs.discord.food/resources/channel#modify-channel>
     pub async fn modify(
         &self,
         modify_data: ChannelModifySchema,
@@ -107,7 +107,7 @@ impl Channel {
     /// this method returns an empty list.
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/message#get-messages>
+    /// See <https://docs.discord.food/resources/message#get-messages>
     pub async fn messages(
         range: GetChannelMessagesSchema,
         channel_id: Snowflake,
@@ -135,7 +135,7 @@ impl Channel {
     /// Adds a recipient to a group DM.
     ///
     /// # Reference:
-    /// See <https://discord-userdoccers.vercel.app/resources/channel#add-channel-recipient>
+    /// See <https://docs.discord.food/resources/channel#add-channel-recipient>
     pub async fn add_channel_recipient(
         &self,
         recipient_id: Snowflake,
@@ -165,7 +165,7 @@ impl Channel {
     /// Removes a recipient from a group DM.
     ///
     /// # Reference:
-    /// See <https://discord-userdoccers.vercel.app/resources/channel#remove-channel-recipient>
+    /// See <https://docs.discord.food/resources/channel#remove-channel-recipient>
     pub async fn remove_channel_recipient(
         &self,
         recipient_id: Snowflake,
@@ -191,7 +191,7 @@ impl Channel {
     /// Only channels to be modified are required.
     ///
     /// # Reference:
-    /// See <https://discord-userdoccers.vercel.app/resources/channel#modify-guild-channel-positions>
+    /// See <https://docs.discord.food/resources/channel#modify-guild-channel-positions>
     pub async fn modify_positions(
         schema: Vec<ModifyChannelPositionsSchema>,
         guild_id: Snowflake,

--- a/src/api/channels/messages.rs
+++ b/src/api/channels/messages.rs
@@ -21,7 +21,7 @@ impl Message {
     /// Returns the sent message.
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/message#create-message>
+    /// See <https://docs.discord.food/resources/message#create-message>
     pub async fn send(
         user: &mut ChorusUser,
         channel_id: Snowflake,
@@ -92,7 +92,7 @@ impl Message {
     /// In this case, the method will return a [`ChorusError::InvalidResponse`] error.
     ///
     /// # Reference:
-    /// See <https://discord-userdoccers.vercel.app/resources/message#search-messages>
+    /// See <https://docs.discord.food/resources/message#search-messages>
     pub(crate) async fn search(
         endpoint: MessageSearchEndpoint,
         query: MessageSearchQuery,
@@ -157,7 +157,7 @@ impl Message {
 
     /// Returns all pinned messages in the channel as a Vector of message objects without the reactions key.
     /// # Reference:
-    /// See: <https://discord-userdoccers.vercel.app/resources/message#get-pinned-messages>
+    /// See: <https://docs.discord.food/resources/message#get-pinned-messages>
     pub async fn get_sticky(
         channel_id: Snowflake,
         user: &mut ChorusUser,
@@ -181,7 +181,7 @@ impl Message {
     /// The max pinned messages is 50.
     ///
     /// # Reference:
-    /// See: <https://discord-userdoccers.vercel.app/resources/message#pin-message>
+    /// See: <https://docs.discord.food/resources/message#pin-message>
     pub async fn sticky(
         channel_id: Snowflake,
         message_id: Snowflake,
@@ -205,7 +205,7 @@ impl Message {
 
     /// Unpins a message in a channel. Requires the `MANAGE_MESSAGES` permission. Returns a 204 empty response on success.
     /// # Reference:
-    /// See: <https://discord-userdoccers.vercel.app/resources/message#unpin-message>
+    /// See: <https://docs.discord.food/resources/message#unpin-message>
     pub async fn unsticky(
         channel_id: Snowflake,
         message_id: Snowflake,
@@ -230,7 +230,7 @@ impl Message {
     /// Returns a specific message object in the channel.
     /// If operating on a guild channel, this endpoint requires the `READ_MESSAGE_HISTORY` permission to be present on the current user.
     /// # Reference:
-    /// See: <https://discord-userdoccers.vercel.app/resources/message#get-message>
+    /// See: <https://docs.discord.food/resources/message#get-message>
     pub async fn get(
         channel_id: Snowflake,
         message_id: Snowflake,
@@ -254,7 +254,7 @@ impl Message {
 
     /// Posts a greet message to a channel. This endpoint requires the channel is a DM channel or you reply to a system message.
     /// # Reference:
-    /// See: <https://discord-userdoccers.vercel.app/resources/message#create-greet-message>
+    /// See: <https://docs.discord.food/resources/message#create-greet-message>
     pub async fn create_greet(
         channel_id: Snowflake,
         schema: CreateGreetMessage,
@@ -284,7 +284,7 @@ impl Message {
     /// Returns an optional token, which can be used as the new `ack` token for following `ack`s.
     ///
     /// # Reference:
-    /// See: <https://discord-userdoccers.vercel.app/resources/message#acknowledge-message>
+    /// See: <https://docs.discord.food/resources/message#acknowledge-message>
     pub async fn acknowledge(
         channel_id: Snowflake,
         message_id: Snowflake,
@@ -314,7 +314,7 @@ impl Message {
     /// or additionally the `MANAGE_MESSAGES` permission, for all other messages, to be present for the current user.
     ///
     /// # Reference:
-    /// See <https://discord-userdoccers.vercel.app/resources/message#crosspost-message>
+    /// See <https://docs.discord.food/resources/message#crosspost-message>
     pub async fn crosspost(
         channel_id: Snowflake,
         message_id: Snowflake,
@@ -337,7 +337,7 @@ impl Message {
     /// Hides a message from the feed of the guild the channel belongs to. Returns a 204 empty response on success.
     ///
     /// # Reference:
-    /// See <https://discord-userdoccers.vercel.app/resources/message#hide-message-from-guild-feed>
+    /// See <https://docs.discord.food/resources/message#hide-message-from-guild-feed>
     pub async fn hide_from_guild_feed(
         channel_id: Snowflake,
         message_id: Snowflake,
@@ -368,7 +368,7 @@ impl Message {
     /// without regard to whether or not an allowed_mentions was present in the request that originally created the message.
     ///
     /// # Reference:
-    /// See: <https://discord-userdoccers.vercel.app/resources/message#edit-message>
+    /// See: <https://docs.discord.food/resources/message#edit-message>
     pub async fn modify(
         channel_id: Snowflake,
         message_id: Snowflake,
@@ -424,7 +424,7 @@ impl Message {
     /// **This endpoint is not usable by user accounts.** (At least according to Discord.com. Spacebar behaviour may differ.)
     ///
     /// # Reference:
-    /// See: <https://discord-userdoccers.vercel.app/resources/message#bulk-delete-messages>
+    /// See: <https://docs.discord.food/resources/message#bulk-delete-messages>
     pub async fn bulk_delete(
         channel_id: Snowflake,
         messages: Vec<Snowflake>,
@@ -456,7 +456,7 @@ impl Message {
     /// Acknowledges the currently pinned messages in a channel. Returns a 204 empty response on success.
     ///
     /// # Reference:
-    /// See <https://discord-userdoccers.vercel.app/resources/message#acknowledge-pinned-messages>
+    /// See <https://docs.discord.food/resources/message#acknowledge-pinned-messages>
     pub async fn acknowledge_pinned(
         channel_id: Snowflake,
         user: &mut ChorusUser,
@@ -483,7 +483,7 @@ impl ChorusUser {
     /// Shorthand call for [`Message::send`]
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/message#create-message>
+    /// See <https://docs.discord.food/resources/message#create-message>
     pub async fn send_message(
         &mut self,
         message: MessageSendSchema,
@@ -503,7 +503,7 @@ impl Channel {
     /// In this case, the method will return a [`ChorusError::InvalidResponse`] error.
     ///
     /// # Reference:
-    /// See <https://discord-userdoccers.vercel.app/resources/message#search-messages>
+    /// See <https://docs.discord.food/resources/message#search-messages>
     pub async fn search_messages(
         channel_id: Snowflake,
         query: MessageSearchQuery,

--- a/src/api/channels/permissions.rs
+++ b/src/api/channels/permissions.rs
@@ -22,7 +22,7 @@ impl types::Channel {
     /// (unless you have a [`MANAGE_ROLES`](crate::types::PermissionFlags::MANAGE_ROLES) overwrite in the channel).
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/channel#modify-channel-permissions>
+    /// See <https://docs.discord.food/resources/channel#modify-channel-permissions>
     pub async fn modify_permissions(
         user: &mut ChorusUser,
         channel_id: Snowflake,
@@ -53,7 +53,7 @@ impl types::Channel {
     /// Requires the [`MANAGE_ROLES`](crate::types::PermissionFlags::MANAGE_ROLES) permission.
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/channel#delete-channel-permission>
+    /// See <https://docs.discord.food/resources/channel#delete-channel-permission>
     pub async fn delete_permission(
         user: &mut ChorusUser,
         channel_id: Snowflake,

--- a/src/api/guilds/guilds.rs
+++ b/src/api/guilds/guilds.rs
@@ -67,7 +67,7 @@ impl Guild {
     /// presence counts
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/guild#get-guild>
+    /// See <https://docs.discord.food/resources/guild#get-guild>
     pub async fn get(
         guild_id: Snowflake,
         with_counts: Option<bool>,
@@ -101,7 +101,7 @@ impl Guild {
     /// Fires off a [crate::types::GuildCreate] gateway event
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/guild#create-guild>
+    /// See <https://docs.discord.food/resources/guild#create-guild>
     pub async fn create(
         user: &mut ChorusUser,
         guild_create_schema: GuildCreateSchema,
@@ -129,7 +129,7 @@ impl Guild {
     /// This route requires MFA.
     ///
     /// # Reference
-    /// <https://discord-userdoccers.vercel.app/resources/guild#modify-guild>
+    /// <https://docs.discord.food/resources/guild#modify-guild>
     pub async fn modify(
         guild_id: Snowflake,
         schema: GuildModifySchema,
@@ -168,7 +168,7 @@ impl Guild {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#modify-guild-mfa-level>
+    /// See <https://docs.discord.food/resources/guild#modify-guild-mfa-level>
     pub async fn modify_mfa_level(
         guild_id: Snowflake,
         mfa_level: MFALevel,
@@ -204,7 +204,7 @@ impl Guild {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-ownership-transfer-code>
+    /// See <https://docs.discord.food/resources/guild#get-guild-ownership-transfer-code>
     pub async fn send_ownership_transfer_code(
         guild_id: Snowflake,
         user: &mut ChorusUser,
@@ -250,7 +250,7 @@ impl Guild {
     /// ```
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/guild#delete-guild>
+    /// See <https://docs.discord.food/resources/guild#delete-guild>
     pub async fn delete(user: &mut ChorusUser, guild_id: Snowflake) -> ChorusResult<()> {
         let url = format!(
             "{}/guilds/{}/delete",
@@ -276,7 +276,7 @@ impl Guild {
     /// This method is a wrapper for [Channel::create].
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/channel#create-guild-channel>
+    /// See <https://docs.discord.food/resources/channel#create-guild-channel>
     pub async fn create_channel(
         &self,
         user: &mut ChorusUser,
@@ -291,7 +291,7 @@ impl Guild {
     /// Doesn't include threads.
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/channel#get-guild-channels>
+    /// See <https://docs.discord.food/resources/channel#get-guild-channels>
     pub async fn channels(&self, user: &mut ChorusUser) -> ChorusResult<Vec<Channel>> {
         let chorus_request = ChorusRequest {
             request: Client::new().get(format!(
@@ -314,7 +314,7 @@ impl Guild {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-preview>
+    /// See <https://docs.discord.food/resources/guild#get-guild-preview>
     pub async fn get_preview(
         guild_id: Snowflake,
         user: &mut ChorusUser,
@@ -343,7 +343,7 @@ impl Guild {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-members-with-unusual-dm-activity>
+    /// See <https://docs.discord.food/resources/guild#get-guild-members-with-unusual-dm-activity>
     pub async fn get_members_with_unusual_dm_activity(
         guild_id: Snowflake,
         query: GetMembersWithUnusualDmActivitySchema,
@@ -371,7 +371,7 @@ impl Guild {
     /// GUILD_MEMBERS intent for applications
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-members>
+    /// See <https://docs.discord.food/resources/guild#get-guild-members>
     pub async fn get_members(
         guild_id: Snowflake,
         query: GetGuildMembersSchema,
@@ -404,7 +404,7 @@ impl Guild {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#query-guild-members>
+    /// See <https://docs.discord.food/resources/guild#query-guild-members>
     pub async fn query_members(
         guild_id: Snowflake,
         query: QueryGuildMembersSchema,
@@ -444,7 +444,7 @@ impl Guild {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-members-supplemental>
+    /// See <https://docs.discord.food/resources/guild#get-guild-members-supplemental>
     pub async fn search_members(
         guild_id: Snowflake,
         schema: SearchGuildMembersSchema,
@@ -527,7 +527,7 @@ impl Guild {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-members-supplemental>
+    /// See <https://docs.discord.food/resources/guild#get-guild-members-supplemental>
     pub async fn get_members_supplemental(
         guild_id: Snowflake,
         schema: GetGuildMembersSupplementalSchema,
@@ -553,7 +553,7 @@ impl Guild {
     /// Requires the [BAN_MEMBERS](crate::types::PermissionFlags::BAN_MEMBERS) permission.
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/guild#get-guild-bans>
+    /// See <https://docs.discord.food/resources/guild#get-guild-bans>
     pub async fn get_bans(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -588,7 +588,7 @@ impl Guild {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#search-guild-bans>
+    /// See <https://docs.discord.food/resources/guild#search-guild-bans>
     pub async fn search_bans(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -618,7 +618,7 @@ impl Guild {
     /// Requires the [BAN_MEMBERS](crate::types::PermissionFlags::BAN_MEMBERS) permission.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-ban>
+    /// See <https://docs.discord.food/resources/guild#get-guild-ban>
     pub async fn get_ban(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -647,7 +647,7 @@ impl Guild {
     /// Requires the [BAN_MEMBERS](crate::types::PermissionFlags::BAN_MEMBERS) permission.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#create-guild-ban>
+    /// See <https://docs.discord.food/resources/guild#create-guild-ban>
     pub async fn create_ban(
         guild_id: Snowflake,
         user_id: Snowflake,
@@ -681,7 +681,7 @@ impl Guild {
     /// This route requires MFA.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#bulk-guild-ban>
+    /// See <https://docs.discord.food/resources/guild#bulk-guild-ban>
     pub async fn bulk_create_ban(
         guild_id: Snowflake,
         audit_log_reason: Option<String>,
@@ -710,7 +710,7 @@ impl Guild {
     /// Requires the [BAN_MEMBERS](crate::types::PermissionFlags::BAN_MEMBERS) permission.
     ///
     /// # Reference:
-    /// See <https://discord-userdoccers.vercel.app/resources/guild#delete-guild-ban>
+    /// See <https://docs.discord.food/resources/guild#delete-guild-ban>
     pub async fn delete_ban(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -746,7 +746,7 @@ impl Guild {
     /// user with additional roles will not.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-prune>
+    /// See <https://docs.discord.food/resources/guild#get-guild-prune>
     pub async fn get_prune(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -782,7 +782,7 @@ impl Guild {
     /// user with additional roles will not.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#prune-guild>
+    /// See <https://docs.discord.food/resources/guild#prune-guild>
     pub async fn prune(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -810,7 +810,7 @@ impl Guild {
     /// Requires the [MANAGE_GUILD](crate::types::PermissionFlags::MANAGE_GUILD) permission.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-widget-settings>
+    /// See <https://docs.discord.food/resources/guild#get-guild-widget-settings>
     pub async fn get_widget_settings(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -837,7 +837,7 @@ impl Guild {
     /// Returns the updated object on success.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-widget-settings>
+    /// See <https://docs.discord.food/resources/guild#get-guild-widget-settings>
     pub async fn modify_widget(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -871,7 +871,7 @@ impl Guild {
     /// invite.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-widget>
+    /// See <https://docs.discord.food/resources/guild#get-guild-widget>
     pub async fn get_widget(
         instance: &mut Instance,
         guild_id: Snowflake,
@@ -896,7 +896,7 @@ impl Guild {
     /// (The guild must have the widget enabled.)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-widget-image>
+    /// See <https://docs.discord.food/resources/guild#get-guild-widget-image>
     pub async fn get_widget_image(
         instance: &mut Instance,
         guild_id: Snowflake,
@@ -954,7 +954,7 @@ impl Guild {
     /// Requires the [MANAGE_GUILD](crate::types::PermissionFlags::MANAGE_GUILD) permission.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-vanity-invite>
+    /// See <https://docs.discord.food/resources/guild#get-guild-vanity-invite>
     pub async fn get_vanity_invite(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -987,7 +987,7 @@ impl Guild {
     /// This route requires MFA.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#modify-guild-vanity-invite>
+    /// See <https://docs.discord.food/resources/guild#modify-guild-vanity-invite>
     pub async fn modify_vanity_invite(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1023,7 +1023,7 @@ impl Guild {
     /// full.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-member-verification>
+    /// See <https://docs.discord.food/resources/guild#get-guild-member-verification>
     pub async fn get_member_verification(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1051,7 +1051,7 @@ impl Guild {
     /// Returns the updated object.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#modify-guild-member-verification>
+    /// See <https://docs.discord.food/resources/guild#modify-guild-member-verification>
     pub async fn modify_member_verification(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1084,7 +1084,7 @@ impl Guild {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint. (Or join requests)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-join-requests>
+    /// See <https://docs.discord.food/resources/guild#get-guild-join-requests>
     pub async fn get_join_requests(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1114,7 +1114,7 @@ impl Guild {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint. (Or join requests)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-join-request>
+    /// See <https://docs.discord.food/resources/guild#get-guild-join-request>
     pub async fn get_join_request(
         user: &mut ChorusUser,
         request_id: Snowflake,
@@ -1141,7 +1141,7 @@ impl Guild {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint. (Or join requests)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-join-request-cooldown>
+    /// See <https://docs.discord.food/resources/guild#get-guild-join-request-cooldown>
     pub async fn get_join_request_cooldown(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1167,7 +1167,7 @@ impl Guild {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint. (Or join requests)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#create-guild-join-request>
+    /// See <https://docs.discord.food/resources/guild#create-guild-join-request>
     pub async fn create_join_request(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1194,7 +1194,7 @@ impl Guild {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint. (Or join requests)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#reset-guild-join-request>
+    /// See <https://docs.discord.food/resources/guild#reset-guild-join-request>
     pub async fn reset_join_request(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1220,7 +1220,7 @@ impl Guild {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint. (Or join requests)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#reset-guild-join-request>
+    /// See <https://docs.discord.food/resources/guild#reset-guild-join-request>
     pub async fn acknowledge_approved_join_request(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1251,7 +1251,7 @@ impl Guild {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint. (Or join requests)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#delete-guild-join-request>
+    /// See <https://docs.discord.food/resources/guild#delete-guild-join-request>
     pub async fn delete_join_request(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1313,7 +1313,7 @@ impl Guild {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint. (Or join requests)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#create-guild-join-request-interview>
+    /// See <https://docs.discord.food/resources/guild#create-guild-join-request-interview>
     pub async fn create_join_request_interview(
         user: &mut ChorusUser,
         request_id: Snowflake,
@@ -1343,7 +1343,7 @@ impl Guild {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint. (Or join requests)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#action-guild-join-request>
+    /// See <https://docs.discord.food/resources/guild#action-guild-join-request>
     pub async fn action_join_request(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1376,7 +1376,7 @@ impl Guild {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint. (Or join requests)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#action-guild-join-request-by-user>
+    /// See <https://docs.discord.food/resources/guild#action-guild-join-request-by-user>
     pub async fn action_join_request_by_user(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1409,7 +1409,7 @@ impl Guild {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint. (Or join requests)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#bulk-action-guild-join-requests>
+    /// See <https://docs.discord.food/resources/guild#bulk-action-guild-join-requests>
     pub async fn bulk_action_join_requests(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1436,7 +1436,7 @@ impl Guild {
     /// welcome screen is not yet enabled.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-welcome-screen>
+    /// See <https://docs.discord.food/resources/guild#get-guild-welcome-screen>
     pub async fn get_welcome_screen(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1461,7 +1461,7 @@ impl Guild {
     /// Requires the [MANAGE_GUILD](crate::types::PermissionFlags::MANAGE_GUILD) permission.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#modify-guild-welcome-screen>
+    /// See <https://docs.discord.food/resources/guild#modify-guild-welcome-screen>
     pub async fn modify_welcome_screen(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1492,7 +1492,7 @@ impl Guild {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint. (Or onboarding)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-onboarding>
+    /// See <https://docs.discord.food/resources/guild#get-guild-onboarding>
     pub async fn get_onboarding(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1527,7 +1527,7 @@ impl Guild {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint. (Or onboarding)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#modify-guild-onboarding>
+    /// See <https://docs.discord.food/resources/guild#modify-guild-onboarding>
     pub async fn modify_onboarding(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1560,7 +1560,7 @@ impl Guild {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-admin-community-eligibility>
+    /// See <https://docs.discord.food/resources/guild#get-admin-community-eligibility>
     pub async fn get_admin_community_eligibility(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1592,7 +1592,7 @@ impl Guild {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#join-admin-community>
+    /// See <https://docs.discord.food/resources/guild#join-admin-community>
     pub async fn join_admin_community(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1621,7 +1621,7 @@ impl Guild {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#join-wumpus-feedback-squad>
+    /// See <https://docs.discord.food/resources/guild#join-wumpus-feedback-squad>
     pub async fn join_wumpus_feedback_squad(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1648,7 +1648,7 @@ impl Channel {
     /// Requires the [MANAGE_CHANNELS](crate::types::PermissionFlags::MANAGE_CHANNELS) permission.
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/channel#create-guild-channel>
+    /// See <https://docs.discord.food/resources/channel#create-guild-channel>
     pub async fn create(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1685,7 +1685,7 @@ impl GuildJoinRequest {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint. (Or join requests)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-join-requests>
+    /// See <https://docs.discord.food/resources/guild#get-guild-join-requests>
     pub async fn get_all_for_guild(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1705,7 +1705,7 @@ impl GuildJoinRequest {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint. (Or join requests)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-join-request>
+    /// See <https://docs.discord.food/resources/guild#get-guild-join-request>
     pub async fn get(user: &mut ChorusUser, id: Snowflake) -> ChorusResult<GuildJoinRequest> {
         Guild::get_join_request(user, id).await
     }
@@ -1719,7 +1719,7 @@ impl GuildJoinRequest {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint. (Or join requests)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-join-request-cooldown>
+    /// See <https://docs.discord.food/resources/guild#get-guild-join-request-cooldown>
     pub async fn get_cooldown(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1735,7 +1735,7 @@ impl GuildJoinRequest {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint. (Or join requests)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#create-guild-join-request>
+    /// See <https://docs.discord.food/resources/guild#create-guild-join-request>
     pub async fn create(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1756,7 +1756,7 @@ impl GuildJoinRequest {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint. (Or join requests)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#action-guild-join-request>
+    /// See <https://docs.discord.food/resources/guild#action-guild-join-request>
     pub async fn action(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1778,7 +1778,7 @@ impl GuildJoinRequest {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint. (Or join requests)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#action-guild-join-request-by-user>
+    /// See <https://docs.discord.food/resources/guild#action-guild-join-request-by-user>
     pub async fn action_by_user(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1800,7 +1800,7 @@ impl GuildJoinRequest {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint. (Or join requests)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#bulk-action-guild-join-requests>
+    /// See <https://docs.discord.food/resources/guild#bulk-action-guild-join-requests>
     pub async fn bulk_action(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1823,7 +1823,7 @@ impl ChorusUser {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint. (Or join requests)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-join-requests>
+    /// See <https://docs.discord.food/resources/guild#get-guild-join-requests>
     pub async fn get_guild_join_requests(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1843,7 +1843,7 @@ impl ChorusUser {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint. (Or join requests)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-join-request>
+    /// See <https://docs.discord.food/resources/guild#get-guild-join-request>
     pub async fn get_guild_join_request(
         user: &mut ChorusUser,
         id: Snowflake,
@@ -1860,7 +1860,7 @@ impl ChorusUser {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint. (Or join requests)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-join-request-cooldown>
+    /// See <https://docs.discord.food/resources/guild#get-guild-join-request-cooldown>
     pub async fn get_guild_join_request_cooldown(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1876,7 +1876,7 @@ impl ChorusUser {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint. (Or join requests)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#create-guild-join-request>
+    /// See <https://docs.discord.food/resources/guild#create-guild-join-request>
     pub async fn create_guild_join_request(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1897,7 +1897,7 @@ impl ChorusUser {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint. (Or join requests)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#action-guild-join-request>
+    /// See <https://docs.discord.food/resources/guild#action-guild-join-request>
     pub async fn action_guild_join_request(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1919,7 +1919,7 @@ impl ChorusUser {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint. (Or join requests)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#action-guild-join-request-by-user>
+    /// See <https://docs.discord.food/resources/guild#action-guild-join-request-by-user>
     pub async fn action_guild_join_request_by_user(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -1941,7 +1941,7 @@ impl ChorusUser {
     /// As of 2025/03/13, Spacebar does not yet implement this endpoint. (Or join requests)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#bulk-action-guild-join-requests>
+    /// See <https://docs.discord.food/resources/guild#bulk-action-guild-join-requests>
     pub async fn bulk_action_guild_join_request(
         user: &mut ChorusUser,
         guild_id: Snowflake,

--- a/src/api/guilds/member.rs
+++ b/src/api/guilds/member.rs
@@ -21,7 +21,7 @@ impl Guild {
     /// Fetch a [GuildMember] object for the specified user.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-member>
+    /// See <https://docs.discord.food/resources/guild#get-guild-member>
     pub async fn get_member(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -53,7 +53,7 @@ impl Guild {
     /// of the guild with the [CREATE_INSTANT_INVITE](crate::types::PermissionFlags::CREATE_INSTANT_INVITE) permission.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#add-guild-member>
+    /// See <https://docs.discord.food/resources/guild#add-guild-member>
     pub async fn add_member(
         guild_id: Snowflake,
         user_id: Snowflake,
@@ -118,7 +118,7 @@ impl Guild {
     /// Requires the [KICK_MEMBERS](crate::types::PermissionFlags::KICK_MEMBERS) permission.
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/guild#remove-guild-member>
+    /// See <https://docs.discord.food/resources/guild#remove-guild-member>
     pub async fn remove_member(
         guild_id: Snowflake,
         member_id: Snowflake,
@@ -145,7 +145,7 @@ impl Guild {
     /// Returns the updated object on success.
     ///
     /// # Reference
-    /// <https://discord-userdoccers.vercel.app/resources/guild#modify-guild-member>
+    /// <https://docs.discord.food/resources/guild#modify-guild-member>
     pub async fn modify_member(
         guild_id: Snowflake,
         member_id: Snowflake,
@@ -175,7 +175,7 @@ impl Guild {
     /// Modifies the current user's member object in the guild.
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/guild#modify-current-guild-member>
+    /// See <https://docs.discord.food/resources/guild#modify-current-guild-member>
     pub async fn modify_current_member(
         guild_id: Snowflake,
         schema: ModifyCurrentGuildMemberSchema,
@@ -203,7 +203,7 @@ impl Guild {
     /// Modifies the current user's profile in the guild.
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/guild#modify-guild-member-profile>
+    /// See <https://docs.discord.food/resources/guild#modify-guild-member-profile>
     pub async fn modify_current_member_profile(
         guild_id: Snowflake,
         schema: ModifyGuildMemberProfileSchema,
@@ -231,7 +231,7 @@ impl Guild {
     /// Requires the [`MANAGE_ROLES`](crate::types::PermissionFlags::MANAGE_ROLES) permission.
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/guild#add-guild-member-role>
+    /// See <https://docs.discord.food/resources/guild#add-guild-member-role>
     pub async fn add_member_role(
         user: &mut ChorusUser,
         audit_log_reason: Option<String>,
@@ -262,7 +262,7 @@ impl Guild {
     /// Requires the [`MANAGE_ROLES`](crate::types::PermissionFlags::MANAGE_ROLES) permission.
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/guild#remove-guild-member-role>
+    /// See <https://docs.discord.food/resources/guild#remove-guild-member-role>
     pub async fn remove_member_role(
         user: &mut ChorusUser,
         audit_log_reason: Option<String>,
@@ -295,7 +295,7 @@ impl Guild {
     /// [RoleObject::get_all_member_counts](crate::types::RoleObject::get_all_member_counts)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-role-member-counts>
+    /// See <https://docs.discord.food/resources/guild#get-guild-role-member-counts>
     pub async fn get_role_member_counts(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -312,7 +312,7 @@ impl Guild {
     /// [RoleObject::get_all_member_counts](crate::types::RoleObject::get_all_member_counts)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-role-members>
+    /// See <https://docs.discord.food/resources/guild#get-guild-role-members>
     pub async fn get_role_members(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -332,7 +332,7 @@ impl Guild {
     /// [RoleObject::add_members](crate::types::RoleObject::add_members)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#add-guild-role-members>
+    /// See <https://docs.discord.food/resources/guild#add-guild-role-members>
     pub async fn add_role_members(
         user: &mut ChorusUser,
         audit_log_reason: Option<String>,
@@ -352,7 +352,7 @@ impl types::GuildMember {
     /// This is an alias of [Guild::get_member]
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-member>
+    /// See <https://docs.discord.food/resources/guild#get-guild-member>
     pub async fn get(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -372,7 +372,7 @@ impl types::GuildMember {
     /// This is an alias of [Guild::add_member]
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#add-guild-member>
+    /// See <https://docs.discord.food/resources/guild#add-guild-member>
     pub async fn add(
         guild_id: Snowflake,
         user_id: Snowflake,
@@ -390,7 +390,7 @@ impl types::GuildMember {
     /// This is an alias of [Guild::remove_member]
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/guild#remove-guild-member>
+    /// See <https://docs.discord.food/resources/guild#remove-guild-member>
     pub async fn remove(
         guild_id: Snowflake,
         member_id: Snowflake,
@@ -408,7 +408,7 @@ impl types::GuildMember {
     /// This is an alias of [Guild::modify_member]
     ///
     /// # Reference
-    /// <https://discord-userdoccers.vercel.app/resources/guild#modify-guild-member>
+    /// <https://docs.discord.food/resources/guild#modify-guild-member>
     pub async fn modify(
         guild_id: Snowflake,
         member_id: Snowflake,
@@ -425,7 +425,7 @@ impl types::GuildMember {
     /// This is an alias of [Guild::modify_current_member]
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/guild#modify-current-guild-member>
+    /// See <https://docs.discord.food/resources/guild#modify-current-guild-member>
     pub async fn modify_current(
         guild_id: Snowflake,
         schema: ModifyCurrentGuildMemberSchema,
@@ -441,7 +441,7 @@ impl types::GuildMember {
     /// This is an alias of [Guild::modify_current_member_profile]
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/guild#modify-guild-member-profile>
+    /// See <https://docs.discord.food/resources/guild#modify-guild-member-profile>
     pub async fn modify_current_profile(
         guild_id: Snowflake,
         schema: ModifyGuildMemberProfileSchema,
@@ -458,7 +458,7 @@ impl types::GuildMember {
     /// This is an alias of [Guild::add_member_role]
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/guild#add-guild-member-role>
+    /// See <https://docs.discord.food/resources/guild#add-guild-member-role>
     pub async fn add_role(
         user: &mut ChorusUser,
         audit_log_reason: Option<String>,
@@ -477,7 +477,7 @@ impl types::GuildMember {
     /// This is an alias of [Guild::remove_member_role]
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/guild#remove-guild-member-role>
+    /// See <https://docs.discord.food/resources/guild#remove-guild-member-role>
     pub async fn remove_role(
         user: &mut ChorusUser,
         audit_log_reason: Option<String>,

--- a/src/api/guilds/messages.rs
+++ b/src/api/guilds/messages.rs
@@ -16,7 +16,7 @@ impl Guild {
     /// In this case, the method will return a [`ChorusError::InvalidResponse`](crate::errors::ChorusError::InvalidResponse) error.
     ///
     /// # Reference:
-    /// See <https://discord-userdoccers.vercel.app/resources/message#search-messages>
+    /// See <https://docs.discord.food/resources/message#search-messages>
     pub async fn search_messages(
         guild_id: Snowflake,
         query: MessageSearchQuery,

--- a/src/api/guilds/roles.rs
+++ b/src/api/guilds/roles.rs
@@ -21,7 +21,7 @@ impl types::RoleObject {
     /// Retrieves a list of roles for a given guild.
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/guild#get-guild-roles>
+    /// See <https://docs.discord.food/resources/guild#get-guild-roles>
     pub async fn get_all(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -73,7 +73,7 @@ impl types::RoleObject {
     /// Retrieves a mapping of role IDs to their respective member counts.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-role-member-counts>
+    /// See <https://docs.discord.food/resources/guild#get-guild-role-member-counts>
     pub async fn get_all_member_counts(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -100,7 +100,7 @@ impl types::RoleObject {
     /// (This endpoint does not return results for the @everyone role)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-guild-role-members>
+    /// See <https://docs.discord.food/resources/guild#get-guild-role-members>
     pub async fn get_members(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -133,7 +133,7 @@ impl types::RoleObject {
     /// [Guild::add_member_role](crate::types::Guild::add_member_role)
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/guild#add-guild-member-role>
+    /// See <https://docs.discord.food/resources/guild#add-guild-member-role>
     pub async fn add_member(
         user: &mut ChorusUser,
         audit_log_reason: Option<String>,
@@ -154,7 +154,7 @@ impl types::RoleObject {
     /// [Guild::remove_member_role](crate::types::Guild::remove_member_role)
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/guild#remove-guild-member-role>
+    /// See <https://docs.discord.food/resources/guild#remove-guild-member-role>
     pub async fn remove_member(
         user: &mut ChorusUser,
         audit_log_reason: Option<String>,
@@ -179,7 +179,7 @@ impl types::RoleObject {
     /// Returns a mapping of member IDs to guild member objects.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#add-guild-role-members>
+    /// See <https://docs.discord.food/resources/guild#add-guild-role-members>
     pub async fn add_members(
         user: &mut ChorusUser,
         audit_log_reason: Option<String>,
@@ -211,7 +211,7 @@ impl types::RoleObject {
     /// Requires the [`MANAGE_ROLES`](crate::types::PermissionFlags::MANAGE_ROLES) permission.
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/guild#create-guild-role>
+    /// See <https://docs.discord.food/resources/guild#create-guild-role>
     pub async fn create(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -239,7 +239,7 @@ impl types::RoleObject {
     /// Requires the [`MANAGE_ROLES`](crate::types::PermissionFlags::MANAGE_ROLES) permission.
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/guild#modify-guild-role-positions>
+    /// See <https://docs.discord.food/resources/guild#modify-guild-role-positions>
     pub async fn position_update(
         user: &mut ChorusUser,
         guild_id: Snowflake,
@@ -267,7 +267,7 @@ impl types::RoleObject {
     /// Requires the [`MANAGE_ROLES`](crate::types::PermissionFlags::MANAGE_ROLES) permission.
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/guild#modify-guild-role>
+    /// See <https://docs.discord.food/resources/guild#modify-guild-role>
     pub async fn modify(
         user: &mut ChorusUser,
         guild_id: Snowflake,

--- a/src/api/invites/mod.rs
+++ b/src/api/invites/mod.rs
@@ -18,7 +18,7 @@ impl ChorusUser {
     /// Note that the session ID is required for guest invites.
     ///
     /// # Reference:
-    /// See <https://discord-userdoccers.vercel.app/resources/invite#accept-invite>
+    /// See <https://docs.discord.food/resources/invite#accept-invite>
     pub async fn accept_invite(
         &mut self,
         invite_code: &str,
@@ -44,7 +44,7 @@ impl ChorusUser {
     /// Note: Spacebar does not yet implement this endpoint.
     ///
     /// # Reference:
-    /// See <https://discord-userdoccers.vercel.app/resources/invite#create-user-invite>
+    /// See <https://docs.discord.food/resources/invite#create-user-invite>
     pub async fn create_user_invite(&mut self, code: Option<&str>) -> ChorusResult<Invite> {
         ChorusRequest {
             request: Client::new()
@@ -66,7 +66,7 @@ impl ChorusUser {
     /// For guild channels, the endpoint requires the [`CREATE_INSTANT_INVITE`](crate::types::PermissionFlags::CREATE_INSTANT_INVITE) permission.
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/invite#create-channel-invite>
+    /// See <https://docs.discord.food/resources/invite#create-channel-invite>
     pub async fn create_channel_invite(
         &mut self,
         create_channel_invite_schema: CreateChannelInviteSchema,

--- a/src/api/users/channels.rs
+++ b/src/api/users/channels.rs
@@ -16,7 +16,7 @@ impl ChorusUser {
     /// Fetches a list of private channels the user is in.
     ///
     /// # Reference:
-    /// See <https://docs.discord.sex/resources/channel#get-private-channels>
+    /// See <https://docs.discord.food/resources/channel#get-private-channels>
     pub async fn get_private_channels(&mut self) -> ChorusResult<Vec<Channel>> {
         let url = format!(
             "{}/users/@me/channels",
@@ -37,7 +37,7 @@ impl ChorusUser {
     /// none or multiple recipients create a group DM channel.
     ///
     /// # Reference:
-    /// See <https://discord-userdoccers.vercel.app/resources/channel#create-private-channel>
+    /// See <https://docs.discord.food/resources/channel#create-private-channel>
     pub async fn create_private_channel(
         &mut self,
         create_private_channel_schema: PrivateChannelCreateSchema,

--- a/src/api/users/connections.rs
+++ b/src/api/users/connections.rs
@@ -53,7 +53,7 @@ impl ChorusUser {
         }
         .with_headers_for(self);
         // Note: ommiting authorization causes a 401 Unauthorized,
-        // even though discord.sex mentions it as unauthenticated
+        // even though discord.food mentions it as unauthenticated
 
         chorus_request
             .send_and_deserialize_response::<AuthorizeConnectionReturn>(self)

--- a/src/api/users/connections.rs
+++ b/src/api/users/connections.rs
@@ -27,7 +27,7 @@ impl ChorusUser {
     /// [Self::create_connection_callback].
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#authorize-user-connection>
+    /// See <https://docs.discord.food/resources/user#authorize-user-connection>
     ///
     /// Note: it doesn't seem to be actually unauthenticated
     pub async fn authorize_connection(
@@ -68,7 +68,7 @@ impl ChorusUser {
     /// [Self::authorize_connection] to this one.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#create-user-connection-callback>
+    /// See <https://docs.discord.food/resources/user#create-user-connection-callback>
     // TODO: When is this called? When should it be used over authorize_connection?
     pub async fn create_connection_callback(
         &mut self,
@@ -103,7 +103,7 @@ impl ChorusUser {
     /// [Self::create_connection_callback]
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#create-contact-sync-connection>
+    /// See <https://docs.discord.food/resources/user#create-contact-sync-connection>
     pub async fn create_contact_sync_connection(
         &mut self,
         connection_account_id: &String,
@@ -175,7 +175,7 @@ impl ChorusUser {
     /// ```
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#create-domain-connection>
+    /// See <https://docs.discord.food/resources/user#create-domain-connection>
     pub async fn create_domain_connection(
         &mut self,
         domain: &String,
@@ -231,7 +231,7 @@ impl ChorusUser {
     /// Fetches the current user's [Connection]s
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#get-user-connections>
+    /// See <https://docs.discord.food/resources/user#get-user-connections>
     pub async fn get_connections(&mut self) -> ChorusResult<Vec<Connection>> {
         let request = Client::new().get(format!(
             "{}/users/@me/connections",
@@ -250,7 +250,7 @@ impl ChorusUser {
     /// Refreshes a local user's [Connection].
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#refresh-user-connection>
+    /// See <https://docs.discord.food/resources/user#refresh-user-connection>
     pub async fn refresh_connection(
         &mut self,
         connection_type: ConnectionType,
@@ -282,7 +282,7 @@ impl ChorusUser {
     /// Not all connection types support all parameters.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#modify-user-connection>
+    /// See <https://docs.discord.food/resources/user#modify-user-connection>
     pub async fn modify_connection(
         &mut self,
         connection_type: ConnectionType,
@@ -314,7 +314,7 @@ impl ChorusUser {
     /// Deletes a local user's [Connection].
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#delete-user-connection>
+    /// See <https://docs.discord.food/resources/user#delete-user-connection>
     pub async fn delete_connection(
         &mut self,
         connection_type: ConnectionType,
@@ -345,7 +345,7 @@ impl ChorusUser {
     /// Only available for [ConnectionType::Twitch], [ConnectionType::YouTube] and [ConnectionType::Spotify] connections.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#get-user-connection-access-token>
+    /// See <https://docs.discord.food/resources/user#get-user-connection-access-token>
     pub async fn get_connection_access_token(
         &mut self,
         connection_type: ConnectionType,
@@ -380,7 +380,7 @@ impl ChorusUser {
     /// Only available for [ConnectionType::Reddit] connections.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#get-user-connection-subreddits>
+    /// See <https://docs.discord.food/resources/user#get-user-connection-subreddits>
     pub async fn get_connection_subreddits(
         &mut self,
         connection_account_id: &String,

--- a/src/api/users/guilds.rs
+++ b/src/api/users/guilds.rs
@@ -16,7 +16,7 @@ impl ChorusUser {
     /// Fires a [crate::types::GuildDelete] and [crate::types::GuildMemberRemove] event
     ///
     /// # Reference:
-    /// See <https://discord-userdoccers.vercel.app/resources/guild#leave-guild>
+    /// See <https://docs.discord.food/resources/guild#leave-guild>
     // TODO: Docs: What is "lurking" here?
     // It is documented as "Whether the user is lurking in the guild",
     // but that says nothing about what this field actually does / means
@@ -46,7 +46,7 @@ impl ChorusUser {
     /// All parameters are optional
     ///
     /// # Reference:
-    /// See <https://docs.discord.sex/resources/guild#get-user-guilds>
+    /// See <https://docs.discord.food/resources/guild#get-user-guilds>
     pub async fn get_guilds(
         &mut self,
         query: Option<GetUserGuildsSchema>,
@@ -79,7 +79,7 @@ impl ChorusUser {
     /// pending join requests for.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/guild#get-join-request-guilds>
+    /// See <https://docs.discord.food/resources/guild#get-join-request-guilds>
     pub async fn get_join_request_guilds(&mut self) -> ChorusResult<Vec<Guild>> {
         let url = format!(
             "{}/users/@me/join-request-guilds",

--- a/src/api/users/mfa.rs
+++ b/src/api/users/mfa.rs
@@ -26,7 +26,7 @@ impl ChorusUser {
     /// Updates the authorization token for the current session.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#enable-totp-mfa>
+    /// See <https://docs.discord.food/resources/user#enable-totp-mfa>
     pub async fn enable_totp_mfa(
         &mut self,
         schema: EnableTotpMfaSchema,
@@ -63,7 +63,7 @@ impl ChorusUser {
     /// Fires a [`UserUpdate`](crate::types::UserUpdate) gateway event.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#disable-totp-mfa>
+    /// See <https://docs.discord.food/resources/user#disable-totp-mfa>
     pub async fn disable_totp_mfa(&mut self) -> ChorusResult<Token> {
         let request = Client::new().post(format!(
             "{}/users/@me/mfa/totp/disable",
@@ -94,7 +94,7 @@ impl ChorusUser {
     /// Fires a [`UserUpdate`](crate::types::UserUpdate) gateway event.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#enable-sms-mfa>
+    /// See <https://docs.discord.food/resources/user#enable-sms-mfa>
     pub async fn enable_sms_mfa(&mut self, schema: SmsMfaRouteSchema) -> ChorusResult<()> {
         let request = Client::new()
             .post(format!(
@@ -121,7 +121,7 @@ impl ChorusUser {
     /// Fires a [`UserUpdate`](crate::types::UserUpdate) gateway event.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#disable-sms-mfa>
+    /// See <https://docs.discord.food/resources/user#disable-sms-mfa>
     pub async fn disable_sms_mfa(&mut self, schema: SmsMfaRouteSchema) -> ChorusResult<()> {
         let request = Client::new()
             .post(format!(
@@ -144,7 +144,7 @@ impl ChorusUser {
     /// [MfaAuthenticator]s for the current user.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#get-webauthn-authenticators>
+    /// See <https://docs.discord.food/resources/user#get-webauthn-authenticators>
     pub async fn get_webauthn_authenticators(&mut self) -> ChorusResult<Vec<MfaAuthenticator>> {
         let request = Client::new().get(format!(
             "{}/users/@me/mfa/webauthn/credentials",
@@ -173,7 +173,7 @@ impl ChorusUser {
     /// Requires MFA.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#create-webauthn-authenticator>
+    /// See <https://docs.discord.food/resources/user#create-webauthn-authenticator>
     ///
     /// Note: for an easier to use API, we've split this one route into two methods
     pub async fn begin_webauthn_authenticator_creation(
@@ -210,7 +210,7 @@ impl ChorusUser {
     /// [UserUpdate](crate::types::UserUpdate) events.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#create-webauthn-authenticator>
+    /// See <https://docs.discord.food/resources/user#create-webauthn-authenticator>
     ///
     /// Note: for an easier to use API, we've split this one route into two methods
     pub async fn finish_webauthn_authenticator_creation(
@@ -245,7 +245,7 @@ impl ChorusUser {
     /// Fires an [AuthenticatorUpdate](crate::types::AuthenticatorUpdate) event.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#modify-webauthn-authenticator>
+    /// See <https://docs.discord.food/resources/user#modify-webauthn-authenticator>
     pub async fn modify_webauthn_authenticator(
         &mut self,
         authenticator_id: Snowflake,
@@ -283,7 +283,7 @@ impl ChorusUser {
     /// MFA cannot be disabled for administrators of guilds with published creator monetization listings.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#delete-webauthn-authenticator>
+    /// See <https://docs.discord.food/resources/user#delete-webauthn-authenticator>
     pub async fn delete_webauthn_authenticator(
         &mut self,
         authenticator_id: Snowflake,
@@ -313,7 +313,7 @@ impl ChorusUser {
     /// The two returned nonces can only be used once and expire after 30 minutes.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#send-backup-codes-challenge>
+    /// See <https://docs.discord.food/resources/user#send-backup-codes-challenge>
     pub async fn send_backup_codes_challenge(
         &mut self,
         schema: SendBackupCodesChallengeSchema,
@@ -349,7 +349,7 @@ impl ChorusUser {
     /// Each nonce can only be used once and expires after 30 minutes.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#get-backup-codes>
+    /// See <https://docs.discord.food/resources/user#get-backup-codes>
     pub async fn get_backup_codes(
         &mut self,
         schema: GetBackupCodesSchema,

--- a/src/api/users/relationships.rs
+++ b/src/api/users/relationships.rs
@@ -152,7 +152,7 @@ impl ChorusUser {
     /// Removes multiple relationships.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/relationships#bulk-remove-relationships>
+    /// See <https://docs.discord.food/resources/relationships#bulk-remove-relationships>
     pub async fn bulk_remove_relationships(
         &mut self,
         query: Option<BulkRemoveRelationshipsQuery>,
@@ -181,7 +181,7 @@ impl ChorusUser {
     /// As of 2025/03/16, Spacebar does not yet implement this endpoint.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/relationships#ignore-user>
+    /// See <https://docs.discord.food/resources/relationships#ignore-user>
     pub async fn ignore_user(&mut self, user_id: Snowflake) -> ChorusResult<()> {
         let url = format!(
             "{}/users/@me/relationships/{}/ignore",
@@ -204,7 +204,7 @@ impl ChorusUser {
     /// As of 2025/03/16, Spacebar does not yet implement this endpoint.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/relationships#unignore-user>
+    /// See <https://docs.discord.food/resources/relationships#unignore-user>
     pub async fn unignore_user(&mut self, user_id: Snowflake) -> ChorusResult<()> {
         let url = format!(
             "{}/users/@me/relationships/{}/ignore",

--- a/src/api/users/users.rs
+++ b/src/api/users/users.rs
@@ -32,7 +32,7 @@ impl ChorusUser {
     /// This function is a wrapper around [`User::get_current`].
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#get-current-user>
+    /// See <https://docs.discord.food/resources/user#get-current-user>
     pub async fn get_current_user(&mut self) -> ChorusResult<User> {
         User::get_current(self).await
     }
@@ -43,7 +43,7 @@ impl ChorusUser {
     /// This function is a wrapper around [`User::get`].
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#get-user>
+    /// See <https://docs.discord.food/resources/user#get-user>
     pub async fn get_user(&mut self, id: Snowflake) -> ChorusResult<PublicUser> {
         User::get(self, id).await
     }
@@ -68,7 +68,7 @@ impl ChorusUser {
     /// This function is a wrapper around [`User::get_by_username`].
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#get-user-by-username>
+    /// See <https://docs.discord.food/resources/user#get-user-by-username>
     pub async fn get_user_by_username(
         &mut self,
         username: &String,
@@ -91,9 +91,9 @@ impl ChorusUser {
     /// This route requires MFA.
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/user#modify-current-user>
+    /// See <https://docs.discord.food/resources/user#modify-current-user>
     pub async fn modify(&mut self, modify_schema: UserModifySchema) -> ChorusResult<User> {
-        // See <https://docs.discord.sex/resources/user#json-params>, note 1
+        // See <https://docs.discord.food/resources/user#json-params>, note 1
         let requires_current_password = modify_schema.username.is_some()
             || modify_schema.discriminator.is_some()
             || modify_schema.email.is_some()
@@ -133,7 +133,7 @@ impl ChorusUser {
     /// This route requires MFA.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#disable-user>
+    /// See <https://docs.discord.food/resources/user#disable-user>
     pub async fn disable(&mut self, schema: DeleteDisableUserSchema) -> ChorusResult<()> {
         let request = Client::new()
             .post(format!(
@@ -160,7 +160,7 @@ impl ChorusUser {
     /// This route requires MFA.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#delete-user>
+    /// See <https://docs.discord.food/resources/user#delete-user>
     pub async fn delete(&mut self, schema: DeleteDisableUserSchema) -> ChorusResult<()> {
         let request = Client::new()
             .post(format!(
@@ -193,7 +193,7 @@ impl ChorusUser {
     /// This function is a wrapper around [`User::get_profile`].
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#get-user-profile>
+    /// See <https://docs.discord.food/resources/user#get-user-profile>
     pub async fn get_user_profile(
         &mut self,
         id: Snowflake,
@@ -210,7 +210,7 @@ impl ChorusUser {
     /// This function is a wrapper around [`User::modify_profile`].
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#modify-user-profile>
+    /// See <https://docs.discord.food/resources/user#modify-user-profile>
     pub async fn modify_profile(
         &mut self,
         schema: UserModifyProfileSchema,
@@ -225,7 +225,7 @@ impl ChorusUser {
     /// Should be followed up with [Self::verify_email_change]
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#modify-user-email>
+    /// See <https://docs.discord.food/resources/user#modify-user-email>
     pub async fn initiate_email_change(&mut self) -> ChorusResult<()> {
         let request = Client::new().put(format!(
             "{}/users/@me/email",
@@ -251,7 +251,7 @@ impl ChorusUser {
     // FIXME: Does this mean PUT users/@me/email is different?
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#modify-user-email>
+    /// See <https://docs.discord.food/resources/user#modify-user-email>
     pub async fn verify_email_change(
         &mut self,
         schema: VerifyUserEmailChangeSchema,
@@ -285,7 +285,7 @@ impl ChorusUser {
     /// As of 2024/08/08, Spacebar does not yet implement this endpoint.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#get-pomelo-suggestions>
+    /// See <https://docs.discord.food/resources/user#get-pomelo-suggestions>
     pub async fn get_pomelo_suggestions(&mut self) -> ChorusResult<String> {
         let request = Client::new().get(format!(
             "{}/users/@me/pomelo-suggestions",
@@ -311,7 +311,7 @@ impl ChorusUser {
     /// As of 2024/08/08, Spacebar does not yet implement this endpoint.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#get-pomelo-eligibility>
+    /// See <https://docs.discord.food/resources/user#get-pomelo-eligibility>
     pub async fn get_pomelo_eligibility(&mut self, username: &String) -> ChorusResult<bool> {
         let request = Client::new()
             .post(format!(
@@ -351,7 +351,7 @@ impl ChorusUser {
     /// As of 2024/08/08, Spacebar does not yet implement this endpoint.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#create-pomelo-migration>
+    /// See <https://docs.discord.food/resources/user#create-pomelo-migration>
     pub async fn create_pomelo_migration(&mut self, username: &String) -> ChorusResult<()> {
         let request = Client::new()
             .post(format!(
@@ -388,7 +388,7 @@ impl ChorusUser {
     /// As of 2024/08/09, Spacebar does not yet implement this endpoint.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#get-recent-mentions>
+    /// See <https://docs.discord.food/resources/user#get-recent-mentions>
     pub async fn get_recent_mentions(
         &mut self,
         query_parameters: GetRecentMentionsSchema,
@@ -419,7 +419,7 @@ impl ChorusUser {
     /// As of 2024/08/09, Spacebar does not yet implement this endpoint.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#delete-recent-mention>
+    /// See <https://docs.discord.food/resources/user#delete-recent-mention>
     pub async fn delete_recent_mention(&mut self, message_id: Snowflake) -> ChorusResult<()> {
         let request = Client::new().delete(format!(
             "{}/users/@me/mentions/{}",
@@ -444,7 +444,7 @@ impl ChorusUser {
     /// As of 2024/08/09, Spacebar does not yet implement this endpoint. (Or data harvesting)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#get-user-harvest>
+    /// See <https://docs.discord.food/resources/user#get-user-harvest>
     pub async fn get_harvest(&mut self) -> ChorusResult<Option<Harvest>> {
         let request = Client::new().get(format!(
             "{}/users/@me/harvest",
@@ -509,7 +509,7 @@ impl ChorusUser {
     /// As of 2024/08/09, Spacebar does not yet implement this endpoint. (Or data harvesting)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#create-user-harvest>
+    /// See <https://docs.discord.food/resources/user#create-user-harvest>
     pub async fn create_harvest(
         &mut self,
         backends: Vec<HarvestBackendType>,
@@ -544,7 +544,7 @@ impl ChorusUser {
     /// As of 2024/08/21, Spacebar does not yet implement this endpoint.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#get-user-notes>
+    /// See <https://docs.discord.food/resources/user#get-user-notes>
     pub async fn get_user_notes(&mut self) -> ChorusResult<HashMap<Snowflake, String>> {
         let request = Client::new().get(format!(
             "{}/users/@me/notes",
@@ -569,7 +569,7 @@ impl ChorusUser {
     /// This function is a wrapper around [`User::get_note`].
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#get-user-note>
+    /// See <https://docs.discord.food/resources/user#get-user-note>
     pub async fn get_user_note(&mut self, target_user_id: Snowflake) -> ChorusResult<UserNote> {
         User::get_note(self, target_user_id).await
     }
@@ -582,7 +582,7 @@ impl ChorusUser {
     /// This function is a wrapper around [`User::set_note`].
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#modify-user-note>
+    /// See <https://docs.discord.food/resources/user#modify-user-note>
     pub async fn set_user_note(
         &mut self,
         target_user_id: Snowflake,
@@ -596,7 +596,7 @@ impl ChorusUser {
     /// (Affinity scores are a measure of how likely a user is to be friends with another user.)
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#get-user-affinities>
+    /// See <https://docs.discord.food/resources/user#get-user-affinities>
     pub async fn get_user_affinities(&mut self) -> ChorusResult<UserAffinities> {
         let request = Client::new().get(format!(
             "{}/users/@me/affinities/users",
@@ -615,7 +615,7 @@ impl ChorusUser {
     /// Fetches the current user's affinity scores for their joined guilds.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#get-guild-affinities>
+    /// See <https://docs.discord.food/resources/user#get-guild-affinities>
     pub async fn get_guild_affinities(&mut self) -> ChorusResult<GuildAffinities> {
         let request = Client::new().get(format!(
             "{}/users/@me/affinities/guilds",
@@ -640,7 +640,7 @@ impl ChorusUser {
     /// As of 2024/08/16, Spacebar does not yet implement this endpoint.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#get-user-premium-usage>
+    /// See <https://docs.discord.food/resources/user#get-user-premium-usage>
     pub async fn get_premium_usage(&mut self) -> ChorusResult<PremiumUsage> {
         let request = Client::new().get(format!(
             "{}/users/@me/premium-usage",
@@ -683,7 +683,7 @@ impl User {
     /// Gets the local / current user.
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#get-current-user>
+    /// See <https://docs.discord.food/resources/user#get-current-user>
     pub async fn get_current(user: &mut ChorusUser) -> ChorusResult<User> {
         let url_api = user.belongs_to.read().unwrap().urls.api.clone();
         let url = format!("{}/users/@me", url_api);
@@ -701,7 +701,7 @@ impl User {
     /// Gets a non-local user by their id
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/user#get-user>
+    /// See <https://docs.discord.food/resources/user#get-user>
     pub async fn get(user: &mut ChorusUser, id: Snowflake) -> ChorusResult<PublicUser> {
         let url_api = user.belongs_to.read().unwrap().urls.api.clone();
         let url = format!("{}/users/{}", url_api, id);
@@ -733,7 +733,7 @@ impl User {
     /// Due to this restriction, you are not able to resolve your own username."
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#get-user-by-username>
+    /// See <https://docs.discord.food/resources/user#get-user-by-username>
     pub async fn get_by_username(
         user: &mut ChorusUser,
         username: &String,
@@ -786,7 +786,7 @@ impl User {
     /// - The other user has an outgoing friend request to the current user
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#get-user-profile>
+    /// See <https://docs.discord.food/resources/user#get-user-profile>
     pub async fn get_profile(
         user: &mut ChorusUser,
         id: Snowflake,
@@ -812,7 +812,7 @@ impl User {
     /// Returns the updated [UserProfileMetadata].
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#modify-user-profile>
+    /// See <https://docs.discord.food/resources/user#modify-user-profile>
     pub async fn modify_profile(
         user: &mut ChorusUser,
         schema: UserModifyProfileSchema,
@@ -837,7 +837,7 @@ impl User {
     /// returns `Err(NotFound { error: "{\"message\": \"Unknown User\", \"code\": 10013}" })`
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#get-user-note>
+    /// See <https://docs.discord.food/resources/user#get-user-note>
     pub async fn get_note(
         user: &mut ChorusUser,
         target_user_id: Snowflake,
@@ -862,7 +862,7 @@ impl User {
     /// Fires a `UserNoteUpdate` gateway event. (Note: yet to be implemented in chorus, see [#546](https://github.com/polyphony-chat/chorus/issues/546))
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/resources/user#modify-user-note>
+    /// See <https://docs.discord.food/resources/user#modify-user-note>
     pub async fn set_note(
         user: &mut ChorusUser,
         target_user_id: Snowflake,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -80,7 +80,7 @@ impl From<reqwest::Error> for ChorusError {
 pub struct ApiError {
     /// More specific error data with a unique code and message
     ///
-    /// See <https://docs.discord.sex/topics/opcodes-and-status-codes#json>
+    /// See <https://docs.discord.food/topics/opcodes-and-status-codes#json>
     pub json_error: JsonError,
 
     /// The https response status
@@ -109,7 +109,7 @@ impl fmt::Display for ApiError {
 /// Data about the specific error encountered, returned as JSON by the API.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/topics/opcodes-and-status-codes#json>
+/// See <https://docs.discord.food/topics/opcodes-and-status-codes#json>
 pub struct JsonError {
     /// A unique code for this type of error.
     ///
@@ -120,7 +120,7 @@ pub struct JsonError {
     #[serde(default)]
     pub message: Option<String>,
 
-    /// See <https://docs.discord.sex/reference#error-messages>
+    /// See <https://docs.discord.food/reference#error-messages>
     ///
     /// A nested JSON object detailing where the error is, ending in an [JsonErrorKey] object.
     #[serde(default)]
@@ -143,7 +143,7 @@ impl fmt::Display for JsonError {
 /// See [JsonError].errors
 ///
 /// # Reference
-/// See <https://docs.discord.sex/topics/opcodes-and-status-codes#json>
+/// See <https://docs.discord.food/topics/opcodes-and-status-codes#json>
 pub struct JsonErrorKey {
     #[serde(rename = "_errors")]
     pub errors: Vec<JsonErrorKeyError>,
@@ -155,7 +155,7 @@ pub struct JsonErrorKey {
 /// See [JsonErrorKey]
 ///
 /// # Reference
-/// See <https://docs.discord.sex/topics/opcodes-and-status-codes#json>
+/// See <https://docs.discord.food/topics/opcodes-and-status-codes#json>
 pub struct JsonErrorKeyError {
     /// An UPPER_SNAKE_CASE code for the error
     pub code: String,
@@ -171,7 +171,7 @@ custom_error! {
 }
 
 custom_error! {
-    /// For errors we receive from the gateway, see <https://discord-userdoccers.vercel.app/topics/opcodes-and-status-codes#gateway-close-event-codes>;
+    /// For errors we receive from the gateway, see <https://docs.discord.food/topics/opcodes-and-status-codes#gateway-close-event-codes>;
     ///
     /// Supposed to be sent as numbers, though they are sent as string most of the time?
     ///

--- a/src/gateway/options.rs
+++ b/src/gateway/options.rs
@@ -17,7 +17,7 @@ use crate::instance::InstanceSoftware;
 /// Similarly, discord also supports etf encoding, while chorus does not (yet).
 /// We are looking into supporting it as an option, since it is faster and more lightweight.
 ///
-/// See <https://docs.discord.sex/topics/gateway#connections>
+/// See <https://docs.discord.food/topics/gateway#connections>
 pub struct GatewayOptions {
     pub encoding: GatewayEncoding,
     pub transport_compression: GatewayTransportCompression,
@@ -84,7 +84,7 @@ impl GatewayOptions {
 #[derive(Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Debug, Default)]
 /// Possible transport compression options for the gateway.
 ///
-/// See <https://docs.discord.sex/topics/gateway#transport-compression>
+/// See <https://docs.discord.food/topics/gateway#transport-compression>
 pub enum GatewayTransportCompression {
     /// Do not transport compress packets
     None,
@@ -108,7 +108,7 @@ impl GatewayTransportCompression {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Debug, Default)]
-/// See <https://docs.discord.sex/topics/gateway#encoding-and-compression>
+/// See <https://docs.discord.food/topics/gateway#encoding-and-compression>
 pub enum GatewayEncoding {
     /// Javascript object notation, a standard for websocket connections,
     /// but contains a lot of overhead

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -429,7 +429,7 @@ impl ChorusUser {
     /// This route is usually used in response to [ChorusError::MfaRequired](crate::ChorusError::MfaRequired).
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/authentication#verify-mfa>
+    /// See <https://docs.discord.food/authentication#verify-mfa>
     pub async fn complete_mfa_challenge(
         &mut self,
         mfa_verify_schema: MfaVerifySchema,

--- a/src/types/config/types/guild_configuration.rs
+++ b/src/types/config/types/guild_configuration.rs
@@ -16,7 +16,7 @@ use crate::types::{Error, GuildError};
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#guild-features>
+/// See <https://docs.discord.food/resources/guild#guild-features>
 pub enum GuildFeatures {
     ActivitiesAlpha,
     ActivitiesEmployee,

--- a/src/types/entities/audit_log.rs
+++ b/src/types/entities/audit_log.rs
@@ -113,7 +113,7 @@ pub struct AuditLogChange {
 #[cfg_attr(feature = "sqlx", repr(i16))]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 /// # Reference:
-/// See <https://docs.discord.sex/resources/audit-log#audit-log-events>
+/// See <https://docs.discord.food/resources/audit-log#audit-log-events>
 pub enum AuditLogActionType {
     #[default]
     /// Guild settings were updated

--- a/src/types/entities/channel.rs
+++ b/src/types/entities/channel.rs
@@ -40,7 +40,7 @@ use super::{option_arc_rwlock_ptr_eq, option_vec_arc_rwlock_ptr_eq, Emoji};
 /// Represents a guild or private channel
 ///
 /// # Reference
-/// See <https://discord-userdoccers.vercel.app/resources/channel#channels-resource>
+/// See <https://docs.discord.food/resources/channel#channels-resource>
 pub struct Channel {
     pub application_id: Option<Snowflake>,
     #[cfg(not(feature = "sqlx"))]
@@ -178,7 +178,7 @@ fn compare_permission_overwrites(
 /// A tag that can be applied to a thread in a [ChannelType::GuildForum] or [ChannelType::GuildMedia] channel.
 ///
 /// # Reference
-/// See <https://discord-userdoccers.vercel.app/resources/channel#forum-tag-object>
+/// See <https://docs.discord.food/resources/channel#forum-tag-object>
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow, sqlx::Type))]
 #[cfg_attr(feature = "sqlx", sqlx(type_name = "interface_type"))]
 pub struct Tag {
@@ -212,7 +212,7 @@ pub struct PermissionOverwrite {
 #[cfg_attr(feature = "sqlx", repr(i16))]
 /// # Reference
 ///
-/// See <https://docs.discord.sex/resources/channel#permission-overwrite-type>
+/// See <https://docs.discord.food/resources/channel#permission-overwrite-type>
 pub enum PermissionOverwriteType {
     Role = 0,
     Member = 1,
@@ -291,7 +291,7 @@ impl<'de> Deserialize<'de> for PermissionOverwriteType {
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Copy)]
 /// # Reference
-/// See <https://discord-userdoccers.vercel.app/resources/channel#thread-metadata-object>
+/// See <https://docs.discord.food/resources/channel#thread-metadata-object>
 pub struct ThreadMetadata {
     pub archived: bool,
     pub auto_archive_duration: i32,
@@ -303,7 +303,7 @@ pub struct ThreadMetadata {
 
 #[derive(Default, Debug, Deserialize, Serialize, Clone)]
 /// # Reference
-/// See <https://discord-userdoccers.vercel.app/resources/channel#thread-member-object>
+/// See <https://docs.discord.food/resources/channel#thread-member-object>
 pub struct ThreadMember {
     pub id: Option<Snowflake>,
     pub user_id: Option<Snowflake>,
@@ -327,7 +327,7 @@ impl PartialEq for ThreadMember {
 /// Specifies the emoji to use as the default way to react to a [ChannelType::GuildForum] or [ChannelType::GuildMedia] channel post.
 ///
 /// # Reference
-/// See <https://discord-userdoccers.vercel.app/resources/channel#default-reaction-object>
+/// See <https://docs.discord.food/resources/channel#default-reaction-object>
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow, sqlx::Type))]
 #[cfg_attr(feature = "sqlx", sqlx(type_name = "interface_type"))]
 pub struct DefaultReaction {
@@ -364,7 +364,7 @@ impl From<Emoji> for DefaultReaction {
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[repr(i32)]
 /// # Reference
-/// See <https://discord-userdoccers.vercel.app/resources/channel#channel-type>
+/// See <https://docs.discord.food/resources/channel#channel-type>
 pub enum ChannelType {
     #[default]
     /// A text channel within a guild
@@ -417,7 +417,7 @@ pub enum ChannelType {
 }
 
 /// # Reference
-/// See <https://docs.discord.sex/resources/message#followed-channel-object>
+/// See <https://docs.discord.food/resources/message#followed-channel-object>
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Copy, Hash, PartialOrd, Ord)]
 pub struct FollowedChannel {
     pub channel_id: Snowflake,

--- a/src/types/entities/connection.rs
+++ b/src/types/entities/connection.rs
@@ -10,7 +10,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 /// A 3rd party service connection to a user's account.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/user#connection-object>
+/// See <https://docs.discord.food/resources/user#connection-object>
 // TODO: Should (could) this type be Updateable and Composite?
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
@@ -71,7 +71,7 @@ impl Connection {
 /// A partial / public [Connection] type.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/user#partial-connection-structure>
+/// See <https://docs.discord.food/resources/user#partial-connection-structure>
 // FIXME: Should (could) this type also be Updateable and Composite?
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct PublicConnection {
@@ -107,7 +107,7 @@ impl From<Connection> for PublicConnection {
 /// Note: this is subject to change, and the enum is likely non-exhaustive
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/user#connection-type>
+/// See <https://docs.discord.food/resources/user#connection-type>
 pub enum ConnectionType {
     #[serde(rename = "amazon-music")]
     AmazonMusic,
@@ -257,7 +257,7 @@ impl ConnectionType {
 #[repr(u8)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// # Reference
-/// See <https://docs.discord.sex/resources/user#visibility-type>
+/// See <https://docs.discord.food/resources/user#visibility-type>
 pub enum ConnectionVisibilityType {
     /// Invisible to everyone except the user themselves
     None = 0,
@@ -271,7 +271,7 @@ pub enum ConnectionVisibilityType {
 /// A type of two-way connection link
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/user#two-way-link-type>
+/// See <https://docs.discord.food/resources/user#two-way-link-type>
 pub enum TwoWayLinkType {
     /// The connection is linked via web
     Web,
@@ -291,7 +291,7 @@ impl Display for TwoWayLinkType {
 /// Defines a subreddit as fetched through a Reddit connection ([[ConnectionType::Reddit]]).
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/user#subreddit-structure>
+/// See <https://docs.discord.food/resources/user#subreddit-structure>
 pub struct ConnectionSubreddit {
     /// The subreddit's internal id, e.g. "t5_388p4"
     pub id: String,

--- a/src/types/entities/emoji.rs
+++ b/src/types/entities/emoji.rs
@@ -28,7 +28,7 @@ use super::option_arc_rwlock_ptr_eq;
 #[cfg_attr(feature = "client", derive(Updateable, Composite))]
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 /// # Reference
-/// See <https://discord-userdoccers.vercel.app/resources/emoji#emoji-object>
+/// See <https://docs.discord.food/resources/emoji#emoji-object>
 pub struct Emoji {
     pub id: Snowflake,
     pub name: Option<String>,

--- a/src/types/entities/guild.rs
+++ b/src/types/entities/guild.rs
@@ -260,7 +260,7 @@ pub struct GuildCreateResponse {
 /// An embeddable widget for a guild.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#guild-widget-object>
+/// See <https://docs.discord.food/resources/guild#guild-widget-object>
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq, Hash)]
 pub struct GuildWidget {
     /// The ID of the guild the widget is for
@@ -285,7 +285,7 @@ pub struct GuildWidget {
 /// A channel, as provided in [GuildWidget]
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#guild-widget-channel-structure>
+/// See <https://docs.discord.food/resources/guild#guild-widget-channel-structure>
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq, Hash)]
 pub struct GuildWidgetChannel {
     /// The ID of the channel
@@ -306,7 +306,7 @@ pub struct GuildWidgetChannel {
 /// and `avatar` is always `null` (replaced with an encrypted `avatar_url` field).
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#guild-widget-member-structure>
+/// See <https://docs.discord.food/resources/guild#guild-widget-member-structure>
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq, Hash)]
 pub struct GuildWidgetMember {
     /// The incrementing ID of the member
@@ -345,7 +345,7 @@ pub struct GuildWidgetMember {
 /// An activity, as provided in [GuildWidgetMember]
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#guild-widget-member-activity-structure>
+/// See <https://docs.discord.food/resources/guild#guild-widget-member-activity-structure>
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq, Hash)]
 pub struct GuildWidgetMemberActivity {
     /// The name of the activity
@@ -471,7 +471,7 @@ pub struct VoiceRegion {
 #[cfg_attr(not(feature = "sqlx"), repr(u8))]
 #[cfg_attr(feature = "sqlx", repr(i16))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-/// See <https://discord-userdoccers.vercel.app/resources/guild#message-notification-level>
+/// See <https://docs.discord.food/resources/guild#message-notification-level>
 pub enum MessageNotificationLevel {
     #[default]
     AllMessages = 0,
@@ -495,7 +495,7 @@ pub enum MessageNotificationLevel {
 #[cfg_attr(not(feature = "sqlx"), repr(u8))]
 #[cfg_attr(feature = "sqlx", repr(i16))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-/// See <https://discord-userdoccers.vercel.app/resources/guild#explicit-content-filter-level>
+/// See <https://docs.discord.food/resources/guild#explicit-content-filter-level>
 pub enum ExplicitContentFilterLevel {
     #[default]
     Disabled = 0,
@@ -521,7 +521,7 @@ pub enum ExplicitContentFilterLevel {
 #[cfg_attr(feature = "sqlx", repr(i16))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#verification-level>
+/// See <https://docs.discord.food/resources/guild#verification-level>
 pub enum VerificationLevel {
     #[default]
     /// Unrestricted
@@ -557,7 +557,7 @@ pub enum VerificationLevel {
 #[cfg_attr(not(feature = "sqlx"), repr(u8))]
 #[cfg_attr(feature = "sqlx", repr(i16))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-/// See <https://docs.discord.sex/resources/guild#mfa-level>
+/// See <https://docs.discord.food/resources/guild#mfa-level>
 pub enum MFALevel {
     #[default]
     None = 0,
@@ -581,7 +581,7 @@ pub enum MFALevel {
 #[cfg_attr(not(feature = "sqlx"), repr(u8))]
 #[cfg_attr(feature = "sqlx", repr(i16))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-/// See <https://docs.discord.sex/resources/guild#nsfw-level>
+/// See <https://docs.discord.food/resources/guild#nsfw-level>
 pub enum NSFWLevel {
     #[default]
     Default = 0,
@@ -610,7 +610,7 @@ pub enum NSFWLevel {
 // Note: Maybe rename this to GuildPremiumTier?
 /// **Guild** premium (Boosting) tier
 ///
-/// See <https://docs.discord.sex/resources/guild#premium-tier>
+/// See <https://docs.discord.food/resources/guild#premium-tier>
 pub enum PremiumTier {
     #[default]
     /// No server boost perks
@@ -627,7 +627,7 @@ bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, chorus_macros::SerdeBitFlags)]
     #[cfg_attr(feature = "sqlx", derive(chorus_macros::SqlxBitFlags))]
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/guild#system-channel-flags>
+    /// See <https://docs.discord.food/resources/guild#system-channel-flags>
     pub struct SystemChannelFlags: u64 {
         /// Indicates if an app uses the Auto Moderation API
         const SUPPRESS_JOIN_NOTIFICATIONS = 1 << 0;
@@ -641,7 +641,7 @@ bitflags! {
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#member-verification-object>
+/// See <https://docs.discord.food/resources/guild#member-verification-object>
 pub struct GuildMemberVerification {
     /// When the verification object was last modified
     #[serde(default)]
@@ -667,7 +667,7 @@ pub struct GuildMemberVerification {
 /// A question in [GuildMemberVerification].
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#member-verification-form-field-structure>
+/// See <https://docs.discord.food/resources/guild#member-verification-form-field-structure>
 pub struct GuildMemberVerificationFormField {
     /// The type of question
     pub field_type: GuildMemberVerificationFormFieldType,
@@ -716,7 +716,7 @@ pub struct GuildMemberVerificationFormField {
 /// For [GuildMemberVerificationFormFieldType::MultipleChoice], this should be [GuildMemberVerificationResponse::Index] (with the index of the selected choice)
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#member-verification-form-field-type>
+/// See <https://docs.discord.food/resources/guild#member-verification-form-field-type>
 pub enum GuildMemberVerificationResponse {
     String(String),
     Index(usize),
@@ -730,7 +730,7 @@ pub enum GuildMemberVerificationResponse {
 /// Types of form questions in [GuildMemberVerificationFormField].
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#member-verification-form-field-type>
+/// See <https://docs.discord.food/resources/guild#member-verification-form-field-type>
 pub enum GuildMemberVerificationFormFieldType {
     /// User must agree to the guild rules
     #[default]
@@ -755,7 +755,7 @@ pub enum GuildMemberVerificationFormFieldType {
 /// A guild, as provided in [GuildMemberVerification].
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#member-verification-guild-structure>
+/// See <https://docs.discord.food/resources/guild#member-verification-guild-structure>
 pub struct GuildMemberVerificationGuild {
     /// The ID of the guild
     pub id: Snowflake,
@@ -795,7 +795,7 @@ pub struct GuildMemberVerificationGuild {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-/// [GuildJoinRequest]s are an extension of [member verification](https://docs.discord.sex/resources/guild#member-verification-object).
+/// [GuildJoinRequest]s are an extension of [member verification](https://docs.discord.food/resources/guild#member-verification-object).
 ///
 /// A join request is created when a user attempts to join a guild with member verification enabled. They must complete the verification process to join the guild.
 ///
@@ -805,7 +805,7 @@ pub struct GuildMemberVerificationGuild {
 /// [MemberVerificationManualApproval](crate::types::types::guild_configuration::GuildFeatures::MemberVerificationManualApproval) feature.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#guild-join-request-object>
+/// See <https://docs.discord.food/resources/guild#guild-join-request-object>
 pub struct GuildJoinRequest {
     /// The ID of the join request
     pub id: Snowflake,
@@ -870,7 +870,7 @@ pub struct GuildJoinRequest {
 /// Status of a [GuildJoinRequest].
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#guild-join-request-status>
+/// See <https://docs.discord.food/resources/guild#guild-join-request-status>
 pub enum GuildJoinRequestStatus {
     /// The request is started but is not yet submitted
     Started,
@@ -901,7 +901,7 @@ pub enum GuildJoinRequestStatus {
 /// The mode field modifies what is considered when enforcing these constraints.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#onboarding-object>
+/// See <https://docs.discord.food/resources/guild#onboarding-object>
 pub struct GuildOnboarding {
     /// Id of the relevant guild
     pub guild_id: Snowflake,
@@ -942,7 +942,7 @@ pub struct GuildOnboarding {
 /// Defines the criteria used to satisfy [GuildOnboarding] constraints.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#onboarding-mode>
+/// See <https://docs.discord.food/resources/guild#onboarding-mode>
 pub enum GuildOnboardingMode {
     /// Count only default channels towards constraints
     #[default]
@@ -959,7 +959,7 @@ pub enum GuildOnboardingMode {
 /// have in the guild
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#onboarding-prompt-structure>
+/// See <https://docs.discord.food/resources/guild#onboarding-prompt-structure>
 pub struct GuildOnboardingPrompt {
     /// Id of the prompt
     pub id: Snowflake,
@@ -1004,7 +1004,7 @@ pub struct GuildOnboardingPrompt {
 /// Type of [GuildOnboardingPrompt]
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#onboarding-prompt-type>
+/// See <https://docs.discord.food/resources/guild#onboarding-prompt-type>
 pub enum GuildOnboardingPromptType {
     /// Prompt offers multiple options to select from
     #[default]
@@ -1018,7 +1018,7 @@ pub enum GuildOnboardingPromptType {
 /// Part of [GuildOnboardingPrompt]; an individual option in the prompt
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#onboarding-prompt-option-structure>
+/// See <https://docs.discord.food/resources/guild#onboarding-prompt-option-structure>
 pub struct GuildOnboardingPromptOption {
     /// The option's unique id
     pub id: Snowflake,

--- a/src/types/entities/guild_member.rs
+++ b/src/types/entities/guild_member.rs
@@ -17,7 +17,7 @@ use super::option_arc_rwlock_ptr_eq;
 /// Represents a participating user in a guild.
 ///
 /// # Reference
-/// See <https://discord-userdoccers.vercel.app/resources/guild#guild-member-object>
+/// See <https://docs.discord.food/resources/guild#guild-member-object>
 pub struct GuildMember {
     #[cfg_attr(feature = "sqlx", sqlx(skip))]
     pub user: Option<Shared<PublicUser>>,
@@ -65,7 +65,7 @@ impl PartialEq for GuildMember {
 /// [ChorusUser]: [crate::instance::ChorusUser]
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#supplemental-guild-member-object>
+/// See <https://docs.discord.food/resources/guild#supplemental-guild-member-object>
 pub struct SupplementalGuildMember {
     /// The ID of the user this member represents
     ///
@@ -96,7 +96,7 @@ pub struct SupplementalGuildMember {
 /// Used in [SupplementalGuildMember]
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#join-source-type>
+/// See <https://docs.discord.food/resources/guild#join-source-type>
 pub enum JoinSourceType {
     /// The user joined through an unknown source
     Unspecified = 0,

--- a/src/types/entities/harvest.rs
+++ b/src/types/entities/harvest.rs
@@ -18,7 +18,7 @@ use crate::gateway::Updateable;
 ///
 /// # Reference
 ///
-/// See <https://docs.discord.sex/resources/user#harvest-object>
+/// See <https://docs.discord.food/resources/user#harvest-object>
 pub struct Harvest {
     pub harvest_id: Snowflake,
     /// The id of the user being harvested
@@ -59,7 +59,7 @@ impl Updateable for Harvest {
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// Current status of a [Harvest]
 ///
-/// See <https://docs.discord.sex/resources/user#harvest-status> and <https://docs.discord.sex/resources/user#harvest-object>
+/// See <https://docs.discord.food/resources/user#harvest-status> and <https://docs.discord.food/resources/user#harvest-object>
 pub enum HarvestStatus {
     /// The harvest is queued and has not been started
     Queued = 0,
@@ -77,7 +77,7 @@ pub enum HarvestStatus {
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 /// A type of backend / service a harvest can be requested for.
 ///
-/// See <https://docs.discord.sex/resources/user#harvest-backend-type> and <https://support.discord.com/hc/en-us/articles/360004957991-Your-Discord-Data-Package>
+/// See <https://docs.discord.food/resources/user#harvest-backend-type> and <https://support.discord.com/hc/en-us/articles/360004957991-Your-Discord-Data-Package>
 pub enum HarvestBackendType {
     /// All account information;
     Accounts,

--- a/src/types/entities/integration.rs
+++ b/src/types/entities/integration.rs
@@ -52,7 +52,7 @@ pub struct IntegrationAccount {
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[cfg_attr(feature = "sqlx", sqlx(rename_all = "snake_case"))]
-/// See <https://docs.discord.sex/resources/integration#integration-type>
+/// See <https://docs.discord.food/resources/integration#integration-type>
 pub enum IntegrationType {
     #[default]
     Twitch,
@@ -79,7 +79,7 @@ pub enum IntegrationType {
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// Defines the behaviour that is executed when a user's subscription to the integration expires.
 ///
-/// See <https://docs.discord.sex/resources/integration#integration-expire-behavior>
+/// See <https://docs.discord.food/resources/integration#integration-expire-behavior>
 pub enum IntegrationExpireBehaviour {
     #[default]
     /// Remove the subscriber role from the user

--- a/src/types/entities/invite.rs
+++ b/src/types/entities/invite.rs
@@ -16,7 +16,7 @@ use super::guild::GuildScheduledEvent;
 use super::{Application, Channel, GuildMember, NSFWLevel, User};
 
 /// Represents a code that when used, adds a user to a guild or group DM channel, or creates a relationship between two users.
-/// See <https://discord-userdoccers.vercel.app/resources/invite#invite-object>
+/// See <https://docs.discord.food/resources/invite#invite-object>
 #[derive(Default, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 pub struct Invite {
@@ -55,7 +55,7 @@ pub struct Invite {
 }
 
 /// The guild an invite is for.
-/// See <https://discord-userdoccers.vercel.app/resources/invite#invite-guild-object>
+/// See <https://docs.discord.food/resources/invite#invite-guild-object>
 #[derive(Debug, Serialize, Deserialize)]
 pub struct InviteGuild {
     pub id: Snowflake,
@@ -98,7 +98,7 @@ impl From<Guild> for InviteGuild {
     }
 }
 
-/// See <https://discord-userdoccers.vercel.app/resources/invite#invite-stage-instance-object>
+/// See <https://docs.discord.food/resources/invite#invite-stage-instance-object>
 #[derive(Debug, Serialize, Deserialize)]
 pub struct InviteStageInstance {
     pub members: Vec<Shared<GuildMember>>,

--- a/src/types/entities/message.rs
+++ b/src/types/entities/message.rs
@@ -24,7 +24,7 @@ use super::option_arc_rwlock_ptr_eq;
 /// Represents a message sent in a channel.
 ///
 /// # Reference
-/// See <https://discord-userdoccers.vercel.app/resources/message#message-object>
+/// See <https://docs.discord.food/resources/message#message-object>
 pub struct Message {
     pub id: Snowflake,
     pub channel_id: Snowflake,
@@ -129,7 +129,7 @@ impl PartialEq for Message {
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Eq, Ord, PartialOrd, Copy)]
 /// # Reference
-/// See <https://discord-userdoccers.vercel.app/resources/message#message-reference-object>
+/// See <https://docs.discord.food/resources/message#message-reference-object>
 pub struct MessageReference {
     #[serde(rename = "type")]
     #[serde(default)]
@@ -301,7 +301,7 @@ pub struct EmbedField {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 /// # Reference
-/// See <https://docs.discord.sex/resources/message#reaction-object>
+/// See <https://docs.discord.food/resources/message#reaction-object>
 pub struct Reaction {
     pub count: UInt32,
     pub burst_count: UInt32,
@@ -336,7 +336,7 @@ pub enum Component {
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 /// # Reference
-/// See <https://discord-userdoccers.vercel.app/resources/message#message-activity-object>
+/// See <https://docs.discord.food/resources/message#message-activity-object>
 pub struct MessageActivity {
     #[serde(rename = "type")]
     pub activity_type: i64,
@@ -351,7 +351,7 @@ pub struct MessageActivity {
 #[cfg_attr(feature = "sqlx", repr(i16))]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 /// # Reference
-/// See <https://docs.discord.sex/resources/message#message-type>
+/// See <https://docs.discord.food/resources/message#message-type>
 pub enum MessageType {
     /// A default message
     #[default]
@@ -449,7 +449,7 @@ bitflags! {
     #[derive(Debug, Clone, Copy,  PartialEq, Eq, Hash, PartialOrd, chorus_macros::SerdeBitFlags)]
     #[cfg_attr(feature = "sqlx", derive(chorus_macros::SqlxBitFlags))]
     /// # Reference
-    /// See <https://docs.discord.sex/resources/message#message-type>
+    /// See <https://docs.discord.food/resources/message#message-type>
     pub struct MessageFlags: u64 {
         /// This message has been published to subscribed channels (via Channel Following)
         const CROSSPOSTED = 1 << 0;

--- a/src/types/entities/relationship.rs
+++ b/src/types/entities/relationship.rs
@@ -14,7 +14,7 @@ use super::{option_arc_rwlock_ptr_eq, PublicUser};
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 /// # Reference
-/// See <https://docs.discord.sex/resources/relationships#relationship-structure>
+/// See <https://docs.discord.food/resources/relationships#relationship-structure>
 pub struct Relationship {
     /// The ID of the target user
     #[cfg_attr(feature = "sqlx", sqlx(rename = "to_id"))]
@@ -86,7 +86,7 @@ impl PartialEq for Relationship {
 )]
 #[repr(u8)]
 /// # Reference
-/// See <https://docs.discord.sex/resources/relationships#relationship-type>
+/// See <https://docs.discord.food/resources/relationships#relationship-type>
 pub enum RelationshipType {
     /// Deprecated
     Suggestion = 6,

--- a/src/types/entities/sticker.rs
+++ b/src/types/entities/sticker.rs
@@ -14,7 +14,7 @@ use super::option_arc_rwlock_ptr_eq;
 /// Represents a sticker that can be sent in messages.
 ///
 /// # Reference
-/// See <https://discord-userdoccers.vercel.app/resources/sticker#sticker-object>
+/// See <https://docs.discord.food/resources/sticker#sticker-object>
 pub struct Sticker {
     #[serde(default)]
     pub id: Snowflake,
@@ -67,7 +67,7 @@ impl Sticker {
 /// Represents the smallest amount of data required to render a sticker.
 ///
 /// # Reference
-/// See <https://discord-userdoccers.vercel.app/resources/sticker#sticker-item-object>
+/// See <https://docs.discord.food/resources/sticker#sticker-item-object>
 pub struct StickerItem {
     pub id: Snowflake,
     pub name: String,
@@ -82,7 +82,7 @@ pub struct StickerItem {
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[serde(rename = "SCREAMING_SNAKE_CASE")]
 /// # Reference
-/// See <https://docs.discord.sex/resources/sticker#sticker-types>
+/// See <https://docs.discord.food/resources/sticker#sticker-types>
 pub enum StickerType {
     /// An official sticker in a current or legacy purchasable pack
     Standard = 1,
@@ -98,7 +98,7 @@ pub enum StickerType {
 #[cfg_attr(feature = "sqlx", repr(i16))]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 /// # Reference
-/// See <https://docs.discord.sex/resources/sticker#sticker-format-types>
+/// See <https://docs.discord.food/resources/sticker#sticker-format-types>
 pub enum StickerFormatType {
     #[default]
     /// A PNG image

--- a/src/types/entities/user.rs
+++ b/src/types/entities/user.rs
@@ -42,7 +42,7 @@ impl User {
 #[cfg_attr(feature = "client", derive(Updateable, Composite))]
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 /// # Reference
-/// See <https://docs.discord.sex/resources/user#user-structure>
+/// See <https://docs.discord.food/resources/user#user-structure>
 pub struct User {
     pub id: Snowflake,
     pub username: String,
@@ -148,7 +148,7 @@ impl sqlx::Type<sqlx::Postgres> for ThemeColors {
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 /// # Reference
-/// See <https://docs.discord.sex/resources/user#partial-user-structure>
+/// See <https://docs.discord.food/resources/user#partial-user-structure>
 pub struct PublicUser {
     pub id: Snowflake,
     pub username: Option<String>,
@@ -194,7 +194,7 @@ bitflags::bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, chorus_macros::SerdeBitFlags)]
     #[cfg_attr(feature = "sqlx", derive(chorus_macros::SqlxBitFlags))]
      /// # Reference
-     /// See <https://docs.discord.sex/resources/user#user-flags>
+     /// See <https://docs.discord.food/resources/user#user-flags>
     pub struct UserFlags: u64 {
         const DISCORD_EMPLOYEE = 1 << 0;
         const PARTNERED_SERVER_OWNER = 1 << 1;
@@ -237,7 +237,7 @@ bitflags::bitflags! {
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// **User** premium (Nitro) type
 ///
-/// See <https://docs.discord.sex/resources/user#premium-type>
+/// See <https://docs.discord.food/resources/user#premium-type>
 pub enum PremiumType {
     #[default]
     /// No Nitro
@@ -296,7 +296,7 @@ impl<'r> sqlx::Decode<'r, sqlx::Postgres> for PremiumType {
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 /// # Reference
-/// See <https://docs.discord.sex/resources/user#profile-metadata-object>
+/// See <https://docs.discord.food/resources/user#profile-metadata-object>
 pub struct UserProfileMetadata {
     /// The guild ID this profile applies to, if it is a guild profile.
     pub guild_id: Option<Snowflake>,
@@ -321,7 +321,7 @@ pub struct UserProfileMetadata {
 /// A user's publically facing profile
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/user#profile-metadata-object>
+/// See <https://docs.discord.food/resources/user#profile-metadata-object>
 pub struct UserProfile {
     // TODO: add profile application object
     pub user: PublicUser,
@@ -366,7 +366,7 @@ pub struct UserProfile {
 /// Info about a badge on a user's profile ([UserProfile])
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/user#profile-badge-structure>
+/// See <https://docs.discord.food/resources/user#profile-badge-structure>
 ///
 /// For a list of know badges, see <https://gist.github.com/XYZenix/c45156b7c883b5301c9028e39d71b479>
 pub struct ProfileBadge {
@@ -806,7 +806,7 @@ impl ProfileBadge {
 /// Structure which shows a mutual guild with a user
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/user#mutual-guild-structure>
+/// See <https://docs.discord.food/resources/user#mutual-guild-structure>
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct MutualGuild {
     pub id: Snowflake,
@@ -821,7 +821,7 @@ pub struct MutualGuild {
 // Specualation: this is probably how Discord stores notes internally
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/user#get-user-note>
+/// See <https://docs.discord.food/resources/user#get-user-note>
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 pub struct UserNote {
@@ -839,7 +839,7 @@ pub struct UserNote {
 /// Structure which defines an affinity the local user has with another user.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/user#user-affinity-structure>
+/// See <https://docs.discord.food/resources/user#user-affinity-structure>
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, PartialOrd)]
 pub struct UserAffinity {
     /// The other user's id
@@ -851,7 +851,7 @@ pub struct UserAffinity {
 /// Structure which defines an affinity the local user has with a guild.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/user#guild-affinity-structure>
+/// See <https://docs.discord.food/resources/user#guild-affinity-structure>
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, PartialOrd)]
 pub struct GuildAffinity {
     /// The guild's id
@@ -863,7 +863,7 @@ pub struct GuildAffinity {
 /// Structure which defines the local user's premium perk usage.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/user#get-user-premium-usage>
+/// See <https://docs.discord.food/resources/user#get-user-premium-usage>
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PremiumUsage {
     /// Number of Nitro stickers the user has sent
@@ -885,7 +885,7 @@ pub struct PremiumUsage {
 /// Currently only contains the number of uses of a premium perk.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/user#premium-usage-structure>
+/// See <https://docs.discord.food/resources/user#premium-usage-structure>
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PremiumUsageData {
     /// Total number of uses for this perk

--- a/src/types/events/call.rs
+++ b/src/types/events/call.rs
@@ -12,7 +12,7 @@ use chorus_macros::WebSocketEvent;
 /// Is sent to a client by the server to signify a new call being created;
 ///
 /// # Reference
-/// See <https://docs.discord.sex/topics/gateway-events#call-create>
+/// See <https://docs.discord.food/topics/gateway-events#call-create>
 pub struct CallCreate {
     /// Id of the private channel this call is in
     pub channel_id: Snowflake,
@@ -35,7 +35,7 @@ pub struct CallCreate {
 /// Updates the client when metadata about a call changes.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/topics/gateway-events#call-update>
+/// See <https://docs.discord.food/topics/gateway-events#call-update>
 pub struct CallUpdate {
     /// Id of the private channel this call is in
     pub channel_id: Snowflake,
@@ -65,7 +65,7 @@ pub struct CallUpdate {
 /// Sent when a call is deleted, or becomes unavailable due to an outage.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/topics/gateway-events#call-delete>
+/// See <https://docs.discord.food/topics/gateway-events#call-delete>
 pub struct CallDelete {
     pub channel_id: Snowflake,
 	 /// Whether the call is unavailable due to an outage
@@ -91,7 +91,7 @@ pub struct CallDelete {
 /// Fires a [CallCreate] event if a call is found.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/topics/gateway-events#request-call-connect>;
+/// See <https://docs.discord.food/topics/gateway-events#request-call-connect>;
 pub struct CallSync {
     pub channel_id: Snowflake,
 }

--- a/src/types/events/hello.rs
+++ b/src/types/events/hello.rs
@@ -37,7 +37,7 @@ impl std::default::Default for GatewayHello {
 impl std::default::Default for HelloData {
     fn default() -> Self {
         Self {
-            // Discord docs mention 45000 seconds - discord.sex mentions 41250. Defaulting to 45s
+            // Discord docs mention 45000 seconds - discord.food mentions 41250. Defaulting to 45s
             heartbeat_interval: 45000,
         }
     }

--- a/src/types/events/identify.rs
+++ b/src/types/events/identify.rs
@@ -78,7 +78,7 @@ bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, chorus_macros::SerdeBitFlags)]
     #[cfg_attr(feature = "sqlx", derive(chorus_macros::SqlxBitFlags))]
     /// # Reference
-    /// See <https://docs.discord.sex/topics/gateway#gateway-capabilities>
+    /// See <https://docs.discord.food/topics/gateway#gateway-capabilities>
     pub struct GatewayCapabilities: u64 {
         /// Removes the notes field from the Ready event,
         const LAZY_USER_NOTES = 1 << 0;
@@ -132,7 +132,7 @@ bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, chorus_macros::SerdeBitFlags)]
     #[cfg_attr(feature = "sqlx", derive(chorus_macros::SqlxBitFlags))]
     /// # Reference
-    /// See <https://docs.discord.sex/topics/gateway#gateway-intents>
+    /// See <https://docs.discord.food/topics/gateway#gateway-intents>
     pub struct GatewayIntents: u64 {
         ///   - GUILD_CREATE
         ///   - GUILD_UPDATE
@@ -210,7 +210,7 @@ bitflags! {
         const DIRECT_MESSAGE_TYPING = 1 << 14;
         /// Unique privileged intent that isn't directly associated with any Gateway events. Instead, access to MESSAGE_CONTENT permits users to receive message content data across the APIs.
         /// # Reference
-        /// See <https://docs.discord.sex/topics/gateway#message-content-intent>
+        /// See <https://docs.discord.food/topics/gateway#message-content-intent>
         const MESSAGE_CONTENT = 1 << 15;
         ///   - GUILD_SCHEDULED_EVENT_CREATE
         ///   - GUILD_SCHEDULED_EVENT_UPDATE

--- a/src/types/events/invalid_session.rs
+++ b/src/types/events/invalid_session.rs
@@ -25,7 +25,7 @@ use super::WebSocketEvent;
 /// Either reauthenticate and reidentify or resume if possible.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/topics/gateway-events#invalid-session>
+/// See <https://docs.discord.food/topics/gateway-events#invalid-session>
 pub struct GatewayInvalidSession {
     #[serde(rename = "d")]
     pub resumable: bool,

--- a/src/types/events/message.rs
+++ b/src/types/events/message.rs
@@ -153,7 +153,7 @@ pub struct MessageReactionRemoveEmoji {
 /// Sent when a message that mentioned the current user in the last week is acknowledged and deleted.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/topics/gateway-events#recent-mention-delete>
+/// See <https://docs.discord.food/topics/gateway-events#recent-mention-delete>
 pub struct RecentMentionDelete {
     pub message_id: Snowflake,
 }
@@ -185,7 +185,7 @@ pub struct MessageACK {
 /// Fires a [LastMessages] events with up to 100 messages that match the request.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/topics/gateway-events#request-last-messages>
+/// See <https://docs.discord.food/topics/gateway-events#request-last-messages>
 pub struct RequestLastMessages {
     /// The ID of the guild the channels are in
     pub guild_id: Snowflake,
@@ -197,7 +197,7 @@ pub struct RequestLastMessages {
 /// Sent as a response to [RequestLastMessages].
 ///
 /// # Reference
-/// See <https://docs.discord.sex/topics/gateway-events#last-messages>
+/// See <https://docs.discord.food/topics/gateway-events#last-messages>
 pub struct LastMessages {
     /// The ID of the guild the channels are in
     pub guild_id: Snowflake,

--- a/src/types/events/mfa.rs
+++ b/src/types/events/mfa.rs
@@ -7,7 +7,7 @@ use chorus_macros::WebSocketEvent;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq, WebSocketEvent)]
-/// See <https://docs.discord.sex/topics/gateway-events#authenticator-create>;
+/// See <https://docs.discord.food/topics/gateway-events#authenticator-create>;
 ///
 /// Sent when an [MfaAuthenticator] is created.
 pub struct AuthenticatorCreate {
@@ -16,7 +16,7 @@ pub struct AuthenticatorCreate {
 }
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq, WebSocketEvent)]
-/// See <https://docs.discord.sex/topics/gateway-events#authenticator-update>;
+/// See <https://docs.discord.food/topics/gateway-events#authenticator-update>;
 ///
 /// Sent when an [MfaAuthenticator] is modified.
 pub struct AuthenticatorUpdate {
@@ -25,7 +25,7 @@ pub struct AuthenticatorUpdate {
 }
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, WebSocketEvent)]
-/// See <https://docs.discord.sex/topics/gateway-events#authenticator-delete>;
+/// See <https://docs.discord.food/topics/gateway-events#authenticator-delete>;
 ///
 /// Sent when an [MfaAuthenticator] is deleted.
 pub struct AuthenticatorDelete {

--- a/src/types/events/presence.rs
+++ b/src/types/events/presence.rs
@@ -26,7 +26,7 @@ pub struct UpdatePresence {
 /// the PresenceUpdate used in the IDENTIFY gateway event, see
 ///
 /// See <https://discord.com/developers/docs/topics/gateway-events#presence-update-presence-update-event-fields>
-/// (Same structure as <https://docs.discord.sex/resources/presence#presence-object>)
+/// (Same structure as <https://docs.discord.food/resources/presence#presence-object>)
 pub struct PresenceUpdate {
     pub user: PublicUser,
     #[serde(default)]

--- a/src/types/events/ready.rs
+++ b/src/types/events/ready.rs
@@ -18,7 +18,7 @@ use crate::{UInt32, UInt64, UInt8};
 #[derive(Debug, Deserialize, Serialize, Default, Clone, WebSocketEvent)]
 /// Received after identifying, provides initial user information and client state.
 ///
-/// See <https://docs.discord.sex/topics/gateway-events#ready> and <https://discord.com/developers/docs/topics/gateway-events#ready>
+/// See <https://docs.discord.food/topics/gateway-events#ready> and <https://discord.com/developers/docs/topics/gateway-events#ready>
 pub struct GatewayReady {
     #[serde(default)]
     /// An array of stringified JSON values representing the connection trace, used for debugging
@@ -111,7 +111,7 @@ pub struct GatewayReady {
 #[derive(Debug, Deserialize, Serialize, Default, Clone, WebSocketEvent)]
 /// Received after identifying, provides initial information about the bot session.
 ///
-/// See <https://docs.discord.sex/topics/gateway-events#ready> and <https://discord.com/developers/docs/topics/gateway-events#ready>
+/// See <https://docs.discord.food/topics/gateway-events#ready> and <https://discord.com/developers/docs/topics/gateway-events#ready>
 pub struct GatewayReadyBot {
     #[serde(default)]
     /// An array of stringified JSON values representing the connection trace, used for debugging
@@ -182,7 +182,7 @@ impl GatewayReady {
 /// Sent after the READY event when a client is a user,
 /// seems to somehow add onto the ready event;
 ///
-/// See <https://docs.discord.sex/topics/gateway-events#ready-supplemental>
+/// See <https://docs.discord.food/topics/gateway-events#ready-supplemental>
 pub struct GatewayReadySupplemental {
     /// The presences of the user's relationships and guild presences sent at startup
     pub merged_presences: MergedPresences,
@@ -194,7 +194,7 @@ pub struct GatewayReadySupplemental {
 }
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
-/// See <https://docs.discord.sex/topics/gateway-events#merged-presences-structure>
+/// See <https://docs.discord.food/topics/gateway-events#merged-presences-structure>
 pub struct MergedPresences {
     /// "Presences of the user's guilds in the same order as the guilds array in ready"
     /// (discord.sex)
@@ -228,7 +228,7 @@ pub struct MergedPresenceGuild {
 }
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
-/// See <https://docs.discord.sex/topics/gateway-events#supplemental-guild-structure>
+/// See <https://docs.discord.food/topics/gateway-events#supplemental-guild-structure>
 pub struct SupplementalGuild {
     pub id: Snowflake,
     pub voice_states: Option<Vec<VoiceState>>,

--- a/src/types/events/ready.rs
+++ b/src/types/events/ready.rs
@@ -189,7 +189,7 @@ pub struct GatewayReadySupplemental {
     pub merged_members: Vec<Vec<GuildMember>>,
     pub lazy_private_channels: Vec<Channel>,
     pub guilds: Vec<SupplementalGuild>,
-    // "Upcoming changes that the client should disclose to the user" (discord.sex)
+    // "Upcoming changes that the client should disclose to the user" (discord.food)
     pub disclose: Vec<String>,
 }
 
@@ -197,9 +197,9 @@ pub struct GatewayReadySupplemental {
 /// See <https://docs.discord.food/topics/gateway-events#merged-presences-structure>
 pub struct MergedPresences {
     /// "Presences of the user's guilds in the same order as the guilds array in ready"
-    /// (discord.sex)
+    /// (discord.food)
     pub guilds: Vec<Vec<MergedPresenceGuild>>,
-    /// "Presences of the user's friends and implicit relationships" (discord.sex)
+    /// "Presences of the user's friends and implicit relationships" (discord.food)
     pub friends: Vec<MergedPresenceFriend>,
 }
 

--- a/src/types/events/reconnect.rs
+++ b/src/types/events/reconnect.rs
@@ -23,5 +23,5 @@ use super::WebSocketEvent;
 /// "The reconnect event is dispatched when a client should reconnect to the Gateway (and resume their existing session, if they have one). This event usually occurs during deploys to migrate sessions gracefully off old hosts"
 ///
 /// # Reference
-/// See <https://docs.discord.sex/topics/gateway-events#reconnect>
+/// See <https://docs.discord.food/topics/gateway-events#reconnect>
 pub struct GatewayReconnect {}

--- a/src/types/events/request_members.rs
+++ b/src/types/events/request_members.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 /// If `query` is set, `limit` is required (if requesting all members, set `limit` to 0)
 ///
 /// # Reference
-/// See <https://docs.discord.sex/topics/gateway-events#request-guild-members>
+/// See <https://docs.discord.food/topics/gateway-events#request-guild-members>
 pub struct GatewayRequestGuildMembers {
     /// Id(s) of the guild(s) to get members for
     pub guild_id: OneOrMoreSnowflakes,

--- a/src/types/events/resume.rs
+++ b/src/types/events/resume.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 /// Used to replay missed events when a disconnected client resumes.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/topics/gateway-events#resume>
+/// See <https://docs.discord.food/topics/gateway-events#resume>
 #[derive(Debug, Clone, Deserialize, Serialize, Default, WebSocketEvent)]
 pub struct GatewayResume {
     pub token: String,
@@ -23,7 +23,7 @@ pub struct GatewayResume {
 /// Signifies the end of event replaying.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/topics/gateway-events#resumed>
+/// See <https://docs.discord.food/topics/gateway-events#resumed>
 #[derive(Debug, Clone, Deserialize, Serialize, Default, WebSocketEvent)]
 pub struct GatewayResumed {
     #[serde(rename = "_trace")]

--- a/src/types/events/user.rs
+++ b/src/types/events/user.rs
@@ -27,7 +27,7 @@ pub struct UserConnectionsUpdate {
 }
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq, WebSocketEvent)]
-/// See <https://docs.discord.sex/topics/gateway-events#user-note-update-structure>;
+/// See <https://docs.discord.food/topics/gateway-events#user-note-update-structure>;
 ///
 /// Sent when a note the current user has on another user is modified;
 ///

--- a/src/types/events/voice_gateway/client_disconnect.rs
+++ b/src/types/events/voice_gateway/client_disconnect.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// When received, the SSRC of the user should be discarded.
 ///
-/// See <https://discord-userdoccers.vercel.app/topics/voice-connections#other-client-disconnection>
+/// See <https://docs.discord.food/topics/voice-connections#other-client-disconnection>
 pub struct VoiceClientDisconnection {
     pub user_id: Snowflake,
 }

--- a/src/types/events/voice_gateway/hello.rs
+++ b/src/types/events/voice_gateway/hello.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// Differs from the normal hello data in that discord sends heartbeat interval as a float.
 ///
-/// See <https://discord-userdoccers.vercel.app/topics/voice-connections#heartbeating>
+/// See <https://docs.discord.food/topics/voice-connections#heartbeating>
 pub struct VoiceHelloData {
     /// The voice gateway version.
     ///

--- a/src/types/events/voice_gateway/identify.rs
+++ b/src/types/events/voice_gateway/identify.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// Contains authentication info and context to authenticate to the voice gateway.
 ///
-/// See <https://discord-userdoccers.vercel.app/topics/voice-connections#identify-structure>
+/// See <https://docs.discord.food/topics/voice-connections#identify-structure>
 pub struct VoiceIdentify {
     /// The ID of the guild or the private channel being connected to
     pub server_id: Snowflake,

--- a/src/types/events/voice_gateway/media_sink_wants.rs
+++ b/src/types/events/voice_gateway/media_sink_wants.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// {"op":15,"d":{"any":100}}
 ///
-/// Opcode from <https://discord-userdoccers.vercel.app/topics/opcodes-and-status-codes#voice-opcodes>
+/// Opcode from <https://docs.discord.food/topics/opcodes-and-status-codes#voice-opcodes>
 pub struct VoiceMediaSinkWants {
     pub any: u16,
 }

--- a/src/types/events/voice_gateway/mod.rs
+++ b/src/types/events/voice_gateway/mod.rs
@@ -65,7 +65,7 @@ impl<'a> WebSocketEvent for VoiceGatewayReceivePayload<'a> {}
 /// to use either [[VoiceEncryptionMode::Xsalsa20Poly1305]] or
 /// [[VoiceEncryptionMode::Xsalsa20Poly1305Suffix]]
 ///
-/// See <https://discord-userdoccers.vercel.app/topics/voice-connections#encryption-mode> and <https://discord.com/developers/docs/topics/voice-connections#establishing-a-voice-udp-connection-encryption-modes>
+/// See <https://docs.discord.food/topics/voice-connections#encryption-mode> and <https://discord.com/developers/docs/topics/voice-connections#establishing-a-voice-udp-connection-encryption-modes>
 #[derive(Debug, Default, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum VoiceEncryptionMode {
@@ -157,9 +157,9 @@ pub const VOICE_SESSION_UPDATE: u8 = 14;
 ///
 /// {"op":15,"d":{"any":100}}
 ///
-/// Opcode from <https://discord-userdoccers.vercel.app/topics/opcodes-and-status-codes#voice-opcodes>
+/// Opcode from <https://docs.discord.food/topics/opcodes-and-status-codes#voice-opcodes>
 pub const VOICE_MEDIA_SINK_WANTS: u8 = 15;
-/// See <https://discord-userdoccers.vercel.app/topics/opcodes-and-status-codes#voice-opcodes>
+/// See <https://docs.discord.food/topics/opcodes-and-status-codes#voice-opcodes>
 /// Sent with empty data from the client, the server responds with the voice backend version;
 pub const VOICE_BACKEND_VERSION: u8 = 16;
 

--- a/src/types/events/voice_gateway/ready.rs
+++ b/src/types/events/voice_gateway/ready.rs
@@ -18,7 +18,7 @@ use super::VoiceEncryptionMode;
 ///
 /// Sent in response to an Identify event.
 ///
-/// See <https://discord-userdoccers.vercel.app/topics/voice-connections#ready-structure>
+/// See <https://docs.discord.food/topics/voice-connections#ready-structure>
 pub struct VoiceReady {
     /// See <https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpStreamStats/ssrc>
     pub ssrc: u32,

--- a/src/types/events/voice_gateway/select_protocol.rs
+++ b/src/types/events/voice_gateway/select_protocol.rs
@@ -10,7 +10,7 @@ use super::VoiceEncryptionMode;
 /// An event sent by the client to the voice gateway server,
 /// detailing what protocol, address and encryption to use;
 ///
-/// See <https://discord-userdoccers.vercel.app/topics/voice-connections#select-protocol-structure>
+/// See <https://docs.discord.food/topics/voice-connections#select-protocol-structure>
 pub struct SelectProtocol {
     /// The protocol to use. The only option chorus supports is [VoiceProtocol::Udp].
     pub protocol: VoiceProtocol,
@@ -27,7 +27,7 @@ pub struct SelectProtocol {
 
 /// The possible protocol for sending a receiving voice data.
 ///
-/// See <https://discord-userdoccers.vercel.app/topics/voice-connections#select-protocol-structure>
+/// See <https://docs.discord.food/topics/voice-connections#select-protocol-structure>
 #[derive(Debug, Default, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum VoiceProtocol {
@@ -41,7 +41,7 @@ pub enum VoiceProtocol {
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 /// The data field of the SelectProtocol Event
 ///
-/// See <https://discord-userdoccers.vercel.app/topics/voice-connections#protocol-data-structure>
+/// See <https://docs.discord.food/topics/voice-connections#protocol-data-structure>
 pub struct SelectProtocolData {
     /// Our external IP we got from IP discovery
     pub address: String,

--- a/src/types/events/voice_gateway/session_description.rs
+++ b/src/types/events/voice_gateway/session_description.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Deserialize, Serialize, Clone, Default, WebSocketEvent)]
 /// Event that describes our encryption mode and secret key for encryption
 ///
-/// See <https://discord-userdoccers.vercel.app/topics/voice-connections#session-description-structure>
+/// See <https://docs.discord.food/topics/voice-connections#session-description-structure>
 pub struct SessionDescription {
     pub audio_codec: AudioCodec,
     pub video_codec: VideoCodec,
@@ -27,7 +27,7 @@ pub struct SessionDescription {
 #[derive(Debug, Deserialize, Serialize, Clone, Default, WebSocketEvent)]
 /// Event that might be sent to update session parameters
 ///
-/// See <https://discord-userdoccers.vercel.app/topics/voice-connections#session-update-structure>
+/// See <https://docs.discord.food/topics/voice-connections#session-update-structure>
 pub struct SessionUpdate {
     #[serde(rename = "audio_codec")]
     pub new_audio_codec: Option<AudioCodec>,

--- a/src/types/events/voice_gateway/speaking.rs
+++ b/src/types/events/voice_gateway/speaking.rs
@@ -12,7 +12,7 @@ use chorus_macros::WebSocketEvent;
 ///
 /// Essentially, what allows us to send UDP data and lights up the green circle around your avatar.
 ///
-/// See <https://discord-userdoccers.vercel.app/topics/voice-connections#speaking-structure>
+/// See <https://docs.discord.food/topics/voice-connections#speaking-structure>
 #[derive(
     Debug,
     Deserialize,

--- a/src/types/events/voice_gateway/voice_backend_version.rs
+++ b/src/types/events/voice_gateway/voice_backend_version.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, WebSocketEvent)]
 /// Received from the voice gateway server to describe the backend version.
 ///
-/// See <https://discord-userdoccers.vercel.app/topics/voice-connections#voice-backend-version>
+/// See <https://docs.discord.food/topics/voice-connections#voice-backend-version>
 pub struct VoiceBackendVersion {
     /// The voice backend's version
     #[serde(rename = "voice")]

--- a/src/types/interfaces/activity.rs
+++ b/src/types/interfaces/activity.rs
@@ -14,7 +14,7 @@ use crate::types::{entities::Emoji, PartialEmoji, Snowflake};
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 /// # Reference
-/// See <https://docs.discord.sex/resources/presence#activity-object>
+/// See <https://docs.discord.food/resources/presence#activity-object>
 pub struct Activity {
     /// The ID of the activity
     ///
@@ -106,7 +106,7 @@ pub struct Activity {
     ///
     /// Treat data within this object carefully.
     ///
-    /// The official clients follow a convention: <https://docs.discord.sex/resources/presence#activity-metadata-structure>
+    /// The official clients follow a convention: <https://docs.discord.food/resources/presence#activity-metadata-structure>
     ///
     /// This field is send-only, but can be retrieved with its own route.
     #[serde(default)]
@@ -134,7 +134,7 @@ pub struct Activity {
 #[cfg_attr(feature = "sqlx", repr(i16))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 /// # Reference
-/// See <https://docs.discord.sex/resources/presence#activity-type>
+/// See <https://docs.discord.food/resources/presence#activity-type>
 pub enum ActivityType {
     #[default]
     /// "Playing {name}"
@@ -160,7 +160,7 @@ pub enum ActivityType {
 /// Platform an [Activity] is being played on
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/presence#activity-platform-type>
+/// See <https://docs.discord.food/resources/presence#activity-platform-type>
 pub enum ActivityPlatformType {
     #[default]
     Desktop,
@@ -179,7 +179,7 @@ pub enum ActivityPlatformType {
 /// Unix timestamps (sent in milliseconds) for start and/or end of the game
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/presence#activity-timestamps-structure>
+/// See <https://docs.discord.food/resources/presence#activity-timestamps-structure>
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
 pub struct ActivityTimestamps {
     /// Unix time (sent in milliseconds) of when the activity starts
@@ -195,7 +195,7 @@ pub struct ActivityTimestamps {
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 /// # Reference
-/// See <https://docs.discord.sex/resources/presence#activity-party-structure>
+/// See <https://docs.discord.food/resources/presence#activity-party-structure>
 pub struct ActivityParty {
     /// The ID of the party (max 128 characters)
     #[serde(default)]
@@ -208,7 +208,7 @@ pub struct ActivityParty {
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 /// # Reference
-/// See <https://docs.discord.sex/resources/presence#activity-assets-structure>
+/// See <https://docs.discord.food/resources/presence#activity-assets-structure>
 pub struct ActivityAssets {
     /// The large activity asset image (max 313 characters)
     #[serde(default)]
@@ -229,7 +229,7 @@ pub struct ActivityAssets {
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 /// # Reference
-/// See <https://docs.discord.sex/resources/presence#activity-secrets-structure>
+/// See <https://docs.discord.food/resources/presence#activity-secrets-structure>
 pub struct ActivitySecrets {
     /// The secret for joining a party (max 128 characters)
     #[serde(default)]
@@ -256,7 +256,7 @@ bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, chorus_macros::SerdeBitFlags)]
     #[cfg_attr(feature = "sqlx", derive(chorus_macros::SqlxBitFlags))]
     /// # Reference
-    /// See <https://docs.discord.sex/resources/presence#activity-flags>
+    /// See <https://docs.discord.food/resources/presence#activity-flags>
     pub struct ActivityFlags: u64 {
         /// The activity is an instanced game session; a match that will end
         const INSTANCE = 1 << 0;

--- a/src/types/interfaces/client_properties.rs
+++ b/src/types/interfaces/client_properties.rs
@@ -68,7 +68,7 @@ use crate::{instance::ChorusUser, ratelimiter::ChorusRequest};
 /// If you wish to create your own profile, please use `..ClientProperties::minimal()` instead of `..ClientProperties::default()` for unset fields.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/reference#client-properties>
+/// See <https://docs.discord.food/reference#client-properties>
 pub struct ClientProperties {
     /// **Not part of the sent data**
     ///
@@ -162,7 +162,7 @@ pub struct ClientProperties {
     /// The alternate event source this request originated from
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/reference#client-event-source>
+    /// See <https://docs.discord.food/reference#client-event-source>
     #[serde(default)]
     pub client_event_source: Option<String>,
 
@@ -238,7 +238,7 @@ pub struct ClientProperties {
     /// Common values are "google", "bing", "yahoo" and "duckduckgo"
     ///
     /// # Reference
-    /// See <https://docs.discord.sex/reference#search-engine>
+    /// See <https://docs.discord.food/reference#search-engine>
     #[serde(skip_serializing_if = "Option::is_none")]
     pub search_engine: Option<String>,
 
@@ -458,7 +458,7 @@ impl ChorusRequest {
 /// This is used for [ClientProperties]
 ///
 /// # Reference
-/// See <https://docs.discord.sex/reference#operating-system-type>
+/// See <https://docs.discord.food/reference#operating-system-type>
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(transparent)]
 pub struct ClientOs(String);
@@ -532,7 +532,7 @@ impl Default for ClientOs {
 /// This is used for [ClientProperties]
 ///
 /// # Reference
-/// See <https://docs.discord.sex/reference#client-properties-structure>
+/// See <https://docs.discord.food/reference#client-properties-structure>
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(transparent)]
 pub struct ClientOsVersion(String);
@@ -626,7 +626,7 @@ impl Default for ClientOsVersion {
 /// This is used for [ClientProperties]
 ///
 /// # Reference
-/// See <https://docs.discord.sex/reference#browser-type>
+/// See <https://docs.discord.food/reference#browser-type>
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(transparent)]
 pub struct ClientBrowser(String);
@@ -756,7 +756,7 @@ impl Default for ClientBrowser {
 /// This is used for [ClientProperties]
 ///
 /// # Reference
-/// See <https://docs.discord.sex/reference#browser-type>
+/// See <https://docs.discord.food/reference#browser-type>
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(transparent)]
 pub struct ClientUserAgent(pub(crate) String);
@@ -886,7 +886,7 @@ impl Default for ClientUserAgent {
 /// This is used for [ClientProperties]
 ///
 /// # Reference
-/// See <https://docs.discord.sex/reference#client-properties-structure>
+/// See <https://docs.discord.food/reference#client-properties-structure>
 #[derive(Debug, Deserialize, Serialize, Copy, Clone, PartialEq, Eq)]
 #[serde(transparent)]
 pub struct ClientBuildNumber(u64);
@@ -935,7 +935,7 @@ impl Default for ClientBuildNumber {
 /// This is used for [ClientProperties]
 ///
 /// # Reference
-/// See <https://docs.discord.sex/topics/client-distribution#desktop-release-channel> and <https://docs.discord.sex/topics/client-distribution#web-release-channel>
+/// See <https://docs.discord.food/topics/client-distribution#desktop-release-channel> and <https://docs.discord.food/topics/client-distribution#web-release-channel>
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(transparent)]
 pub struct ClientReleaseChannel(String);
@@ -996,7 +996,7 @@ impl Default for ClientReleaseChannel {
 /// This is used for [ClientProperties]
 ///
 /// # Reference
-/// See <https://docs.discord.sex/reference#client-properties-structure>
+/// See <https://docs.discord.food/reference#client-properties-structure>
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 #[serde(transparent)]
 pub struct ClientSystemLocale(String);

--- a/src/types/interfaces/guild_welcome_screen.rs
+++ b/src/types/interfaces/guild_welcome_screen.rs
@@ -8,7 +8,7 @@ use crate::types::utils::Snowflake;
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq, Hash)]
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#welcome-screen-structure>
+/// See <https://docs.discord.food/resources/guild#welcome-screen-structure>
 pub struct WelcomeScreenObject {
     /// Whether or not the guild has the welcome screen enabled
     pub enabled: bool,
@@ -33,7 +33,7 @@ impl From<WelcomeScreenObject> for PublicGuildWelcomeScreen {
 /// A [Guild](crate::types::Guild) [WelcomeScreenObject] as returned by the api.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#welcome-screen-structure>
+/// See <https://docs.discord.food/resources/guild#welcome-screen-structure>
 pub struct PublicGuildWelcomeScreen {
     /// The welcome message shown in the welcome screen (max 140 characters)
     pub description: Option<String>,
@@ -46,7 +46,7 @@ pub struct PublicGuildWelcomeScreen {
 /// A [Channel](crate::types::Channel) as shown in the guild's [Welcome Screen](WelcomeScreenObject)
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#welcome-screen-channel-structure>
+/// See <https://docs.discord.food/resources/guild#welcome-screen-channel-structure>
 pub struct WelcomeScreenChannel {
     /// The id of the channel
     pub channel_id: Snowflake,

--- a/src/types/schema/channel.rs
+++ b/src/types/schema/channel.rs
@@ -164,14 +164,14 @@ pub enum InviteTargetType {
     CreatorPage = 4,
 }
 
-/// See <https://discord-userdoccers.vercel.app/resources/channel#add-channel-recipient>
+/// See <https://docs.discord.food/resources/channel#add-channel-recipient>
 #[derive(Debug, Deserialize, Serialize, Clone, Default, PartialOrd, Ord, PartialEq, Eq)]
 pub struct AddChannelRecipientSchema {
     pub access_token: Option<String>,
     pub nick: Option<String>,
 }
 
-/// See <https://discord-userdoccers.vercel.app/resources/channel#add-channel-recipient>
+/// See <https://docs.discord.food/resources/channel#add-channel-recipient>
 #[derive(
     Debug, Deserialize, Serialize, Clone, Default, PartialOrd, Ord, PartialEq, Eq, Copy, Hash,
 )]
@@ -182,7 +182,7 @@ pub struct ModifyChannelPositionsSchema {
     pub parent_id: Option<Snowflake>,
 }
 
-/// See <https://docs.discord.sex/resources/channel#follow-channel>
+/// See <https://docs.discord.food/resources/channel#follow-channel>
 #[derive(
     Debug, Deserialize, Serialize, Clone, Default, PartialOrd, Ord, PartialEq, Eq, Copy, Hash,
 )]

--- a/src/types/schema/guild.rs
+++ b/src/types/schema/guild.rs
@@ -24,7 +24,7 @@ use crate::types::{
 /// Represents the schema which needs to be sent to create a Guild.
 ///
 /// # Reference
-/// See <https://docs.spacebar.chat/routes/#cmp--schemas-guildcreateschema> and <https://docs.discord.sex/resources/guild#create-guild>
+/// See <https://docs.spacebar.chat/routes/#cmp--schemas-guildcreateschema> and <https://docs.discord.food/resources/guild#create-guild>
 pub struct GuildCreateSchema {
     /// The name of the guild (2-100 characters, excluding trailing and leading whitespace)
     pub name: Option<String>,
@@ -34,7 +34,7 @@ pub struct GuildCreateSchema {
     /// Note: this field is deprecated
     pub region: Option<String>,
 
-    /// See <https://docs.discord.sex/reference#cdn-data>
+    /// See <https://docs.discord.food/reference#cdn-data>
     pub icon: Option<String>,
 
     /// Note: this field is not implemented yet on Spacebar, see <https://github.com/spacebarchat/server/issues/1251>
@@ -111,7 +111,7 @@ impl PartialEq for GuildCreateSchema {
 /// Represents the schema which needs to be sent to create a Guild Ban.
 ///
 /// # Reference
-/// See <https://discord-userdoccers.vercel.app/resources/guild#create-guild-ban>
+/// See <https://docs.discord.food/resources/guild#create-guild-ban>
 pub struct GuildBanCreateSchema {
     /// Number of seconds to delete messages for (0-604800, default 0)
     pub delete_message_seconds: Option<u32>,
@@ -122,7 +122,7 @@ pub struct GuildBanCreateSchema {
 /// Schema for the [crate::instance::ChorusUser::leave_guild] route
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#json-params>
+/// See <https://docs.discord.food/resources/guild#json-params>
 pub(crate) struct GuildLeaveSchema {
     /// "Whether the user is lurking in the guild"
     pub lurking: Option<bool>,
@@ -133,7 +133,7 @@ pub(crate) struct GuildLeaveSchema {
 /// Schema for the bulk guild ban endpoint.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#json-params>
+/// See <https://docs.discord.food/resources/guild#json-params>
 pub struct BulkGuildBanSchema {
     /// The user IDs to ban (max 200)
     pub user_ids: Vec<Snowflake>,
@@ -146,7 +146,7 @@ pub struct BulkGuildBanSchema {
 /// Return type for the bulk guild ban endpoint.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#response-body>
+/// See <https://docs.discord.food/resources/guild#response-body>
 pub struct BulkGuildBanReturn {
     /// The user IDs that were successfully banned
     pub banned_users: Vec<Snowflake>,
@@ -166,7 +166,7 @@ pub struct BulkGuildBanReturn {
 /// Schema for the Add Guild Role Members endpoint.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#add-guild-role-members>
+/// See <https://docs.discord.food/resources/guild#add-guild-role-members>
 pub struct AddRoleMembersSchema {
     /// The member IDs to assign the role to (max 30)
     pub member_ids: Vec<Snowflake>,
@@ -175,29 +175,29 @@ pub struct AddRoleMembersSchema {
 #[derive(Debug, Deserialize, Serialize, Default, Clone, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
 /// Represents the schema used to modify a guild.
-/// See: <https://docs.discord.sex/resources/guild#modify-guild>
+/// See: <https://docs.discord.food/resources/guild#modify-guild>
 pub struct GuildModifySchema {
     /// The name of the guild (2-100 characters, excluding trailing and leading whitespace)
     pub name: Option<String>,
 
-    /// See <https://docs.discord.sex/reference#cdn-data>
+    /// See <https://docs.discord.food/reference#cdn-data>
     pub icon: Option<String>,
 
-    /// See <https://docs.discord.sex/reference#cdn-data>
+    /// See <https://docs.discord.food/reference#cdn-data>
     pub banner: Option<String>,
 
     /// The guild's banner
     ///
     /// For it tobe shown, the guild must have the BANNER feature
     ///
-    /// See <https://docs.discord.sex/reference#cdn-data>
+    /// See <https://docs.discord.food/reference#cdn-data>
     pub home_header: Option<String>,
 
     /// The guild's invite splash
     ///
     /// For it to be shown, the guild must have the INVITE_SPLASH feature
     ///
-    /// See <https://docs.discord.sex/reference#cdn-data>
+    /// See <https://docs.discord.food/reference#cdn-data>
     pub splash: Option<String>,
 
     /// The guild's discovery splash
@@ -242,7 +242,7 @@ pub struct GuildModifySchema {
     ///
     /// If set to Some(1), will create a new #rules channel
     ///
-    /// Reference: <https://docs.discord.sex/resources/guild#modify-guild>
+    /// Reference: <https://docs.discord.food/resources/guild#modify-guild>
     pub rules_channel_id: Option<Snowflake>,
 
     /// The ID of the channel where admins and moderators of community guilds receive notices from Discord
@@ -268,14 +268,14 @@ pub struct GuildModifySchema {
 /// Schema for the [crate::types::Guild::modify_mfa_level] route
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#modify-guild-mfa-level>
+/// See <https://docs.discord.food/resources/guild#modify-guild-mfa-level>
 pub(crate) struct GuildModifyMFALevelSchema {
     pub level: MFALevel,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq, Ord, PartialOrd, Copy)]
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#get-user-guilds>
+/// See <https://docs.discord.food/resources/guild#get-user-guilds>
 pub struct GetUserGuildsSchema {
     /// Get guilds before this guild id
     pub before: Option<Snowflake>,
@@ -343,7 +343,7 @@ pub struct GuildPreview {
 /// Schema for the [crate::types::Guild::get_members] route
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#get-guild-members>
+/// See <https://docs.discord.food/resources/guild#get-guild-members>
 pub struct GetGuildMembersSchema {
     /// Max number of members to return (1-1000, default 1)
     pub limit: Option<u16>,
@@ -381,7 +381,7 @@ impl Default for GetGuildMembersSchema {
 /// Schema for the [Guild::query_members](crate::types::Guild::query_members) route
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#query-guild-members>
+/// See <https://docs.discord.food/resources/guild#query-guild-members>
 pub struct QueryGuildMembersSchema {
     /// Query to match username(s) and nickname(s) against
     pub query: String,
@@ -423,7 +423,7 @@ pub struct GuildGetMembersQuery {
 /// Schema for the [Guild::modify_member](crate::types::Guild::modify_member) route.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#modify-guild-member>
+/// See <https://docs.discord.food/resources/guild#modify-guild-member>
 pub struct ModifyGuildMemberSchema {
     #[serde(rename = "nick")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -482,7 +482,7 @@ bitflags! {
     /// Represents the flags of a Guild Member.
     ///
     /// # Reference
-    /// See <https://discord-userdoccers.vercel.app/resources/guild#guild-member-flags>
+    /// See <https://docs.discord.food/resources/guild#guild-member-flags>
     pub struct GuildMemberFlags: u64 {
         const DID_REJOIN = 1 << 0;
         const COMPLETED_ONBOARDING = 1 << 1;
@@ -498,7 +498,7 @@ bitflags! {
 /// Schema for the [Guild::modify_current_member](crate::types::Guild::modify_current_member) route.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#modify-current-guild-member>
+/// See <https://docs.discord.food/resources/guild#modify-current-guild-member>
 pub struct ModifyCurrentGuildMemberSchema {
     #[serde(rename = "nick")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -543,7 +543,7 @@ pub struct ModifyCurrentGuildMemberSchema {
 /// [Guild::modify_current_member_profile](crate::types::Guild::modify_current_member_profile) route.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#modify-guild-member-profile>
+/// See <https://docs.discord.food/resources/guild#modify-guild-member-profile>
 pub struct ModifyGuildMemberProfileSchema {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The member's guild pronouns (up to 40 characters)
@@ -588,7 +588,7 @@ pub struct ModifyGuildMemberProfileSchema {
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, PartialOrd, Eq, Ord, Copy, Hash)]
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#get-guild-bans>
+/// See <https://docs.discord.food/resources/guild#get-guild-bans>
 pub struct GetGuildBansQuery {
     /// Get bans before this user ID
     pub before: Option<Snowflake>,
@@ -621,7 +621,7 @@ impl GetGuildBansQuery {
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#search-guild-bans>
+/// See <https://docs.discord.food/resources/guild#search-guild-bans>
 pub struct SearchGuildBansQuery {
     /// Query to match username(s) and display name(s) against
     ///
@@ -661,7 +661,7 @@ pub type GuildMembersSearchQuery = GenericSearchQueryWithLimit;
 ///  Certain guilds, such as those that are verified, are exempt from discovery requirements. These guilds will not have a fully populated discovery requirements object, and are guaranteed to receive only sufficient and sufficient_without_grace_period.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/discovery#discovery-requirements-object>
+/// See <https://docs.discord.food/resources/discovery#discovery-requirements-object>
 pub struct GuildDiscoveryRequirements {
     pub guild_id: Option<Snowflake>,
     pub safe_environment: Option<bool>,
@@ -684,7 +684,7 @@ pub struct GuildDiscoveryRequirements {
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 /// # Reference
-/// See <https://docs.discord.sex/resources/discovery#discovery-nsfw-properties-structure>
+/// See <https://docs.discord.food/resources/discovery#discovery-nsfw-properties-structure>
 pub struct GuildDiscoveryNsfwProperties {
     pub channels: Vec<Snowflake>,
     pub channel_banned_keywords: HashMap<Snowflake, Vec<String>>,
@@ -698,7 +698,7 @@ pub struct GuildDiscoveryNsfwProperties {
 /// Activity metrics are recalculated weekly, as an 8-week rolling average. If they are not yet eligible to be calculated, all fields will be null.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/discovery#discovery-health-score-structure>
+/// See <https://docs.discord.food/resources/discovery#discovery-health-score-structure>
 pub struct GuildDiscoveryHealthScore {
     pub avg_nonnew_communicators: u64,
     pub avg_nonnew_participators: u64,
@@ -708,11 +708,11 @@ pub struct GuildDiscoveryHealthScore {
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 /// # Reference
-/// See <https://docs.discord.sex/resources/emoji#create-guild-emoji>
+/// See <https://docs.discord.food/resources/emoji#create-guild-emoji>
 pub struct EmojiCreateSchema {
     pub name: Option<String>,
     /// # Reference:
-    /// See <https://docs.discord.sex/reference#cdn-data>
+    /// See <https://docs.discord.food/reference#cdn-data>
     pub image: String,
     #[serde(default)]
     pub roles: Vec<Snowflake>,
@@ -720,7 +720,7 @@ pub struct EmojiCreateSchema {
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 /// # Reference
-///  See <https://docs.discord.sex/resources/emoji#modify-guild-emoji>
+///  See <https://docs.discord.food/resources/emoji#modify-guild-emoji>
 pub struct EmojiModifySchema {
     pub name: Option<String>,
     pub roles: Option<Vec<Snowflake>>,
@@ -728,7 +728,7 @@ pub struct EmojiModifySchema {
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#get-guild-prune>
+/// See <https://docs.discord.food/resources/guild#get-guild-prune>
 pub struct GuildPruneQuerySchema {
     pub days: u8,
     /// Only used on POST
@@ -745,7 +745,7 @@ pub struct GuildPruneQuerySchema {
 /// a part of [GuildPruneSchema].
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#query-string-params>
+/// See <https://docs.discord.food/resources/guild#query-string-params>
 pub struct GuildPruneParameters {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Number of inactive days to count prune for.
@@ -783,7 +783,7 @@ impl GuildPruneParameters {
 /// Schema for the [Guild::prune](crate::types::Guild::prune) endpoint
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#query-string-params>
+/// See <https://docs.discord.food/resources/guild#query-string-params>
 pub struct GuildPruneSchema {
     #[serde(flatten)]
     /// Parameters which set how to prune the guild
@@ -800,7 +800,7 @@ pub struct GuildPruneSchema {
 /// Return schema for the [Guild::get_prune](crate::types::Guild::get_prune) endpoint
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#response-body>
+/// See <https://docs.discord.food/resources/guild#response-body>
 pub struct GetGuildPruneResult {
     pub pruned: usize,
 }
@@ -809,7 +809,7 @@ pub struct GetGuildPruneResult {
 /// Return schema for the [Guild::prune](crate::types::Guild::prune) endpoint
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#get-guild-prune>
+/// See <https://docs.discord.food/resources/guild#get-guild-prune>
 pub struct GuildPruneResult {
     /// `None` if `compute_prune_count` is `false`
     pub pruned: Option<usize>,
@@ -817,7 +817,7 @@ pub struct GuildPruneResult {
 
 #[derive(Default, Debug, Deserialize, Serialize, Clone, PartialEq)]
 /// # Reference
-/// See <https://docs.discord.sex/resources/sticker#create-guild-sticker>
+/// See <https://docs.discord.food/resources/sticker#create-guild-sticker>
 pub struct GuildCreateStickerSchema {
     pub name: String,
     #[serde(default)]
@@ -908,7 +908,7 @@ impl GuildCreateStickerSchema {
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 /// # Reference
-/// See <https://docs.discord.sex/resources/sticker#modify-guild-sticker>
+/// See <https://docs.discord.food/resources/sticker#modify-guild-sticker>
 pub struct GuildModifyStickerSchema {
     #[serde(default)]
     pub name: Option<String>,
@@ -920,7 +920,7 @@ pub struct GuildModifyStickerSchema {
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#modify-guild-welcome-screen>
+/// See <https://docs.discord.food/resources/guild#modify-guild-welcome-screen>
 pub struct GuildModifyWelcomeScreenSchema {
     pub enabled: Option<bool>,
     pub description: Option<String>,
@@ -930,7 +930,7 @@ pub struct GuildModifyWelcomeScreenSchema {
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 /// # Reference:
-/// See <https://docs.discord.sex/resources/guild-template#create-guild-template>
+/// See <https://docs.discord.food/resources/guild-template#create-guild-template>
 pub struct GuildTemplateCreateSchema {
     /// Name of the template (1-100 characters)
     pub name: String,
@@ -947,7 +947,7 @@ pub struct GuildTemplateCreateSchema {
 ///
 /// # Reference
 ///
-/// See <https://docs.discord.sex/resources/guild#search-guild-members>
+/// See <https://docs.discord.food/resources/guild#search-guild-members>
 pub enum SearchGuildMembersReturn {
     NotIndexed(SGMReturnNotIndexed),
     Ok(SGMReturnOk),
@@ -964,7 +964,7 @@ pub enum SearchGuildMembersReturn {
 ///
 /// # Reference
 ///
-/// See <https://docs.discord.sex/resources/guild#search-guild-members>
+/// See <https://docs.discord.food/resources/guild#search-guild-members>
 pub struct SGMReturnNotIndexed {
     pub message: String,
     pub code: u32,
@@ -980,7 +980,7 @@ pub struct SGMReturnNotIndexed {
 ///
 /// # Reference
 ///
-/// See <https://docs.discord.sex/resources/guild#search-guild-members>
+/// See <https://docs.discord.food/resources/guild#search-guild-members>
 pub struct SGMReturnOk {
     /// The id of the guild searchedd
     pub guild_id: Snowflake,
@@ -998,7 +998,7 @@ pub struct SGMReturnOk {
 ///
 /// # Reference
 ///
-/// See <https://docs.discord.sex/resources/guild#search-guild-members>
+/// See <https://docs.discord.food/resources/guild#search-guild-members>
 pub struct SearchGuildMembersSchema {
     /// Max number of members to return
     ///
@@ -1047,7 +1047,7 @@ pub struct SearchGuildMembersSchema {
 /// How a user joined a guild
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#join-source-type>
+/// See <https://docs.discord.food/resources/guild#join-source-type>
 pub enum MemberSortType {
     #[default]
     /// Sort by when the user joined the guild, descending (newest members first) (default)
@@ -1109,7 +1109,7 @@ impl<'r> sqlx::Decode<'r, sqlx::Postgres> for MemberSortType {
 ///
 /// # Reference
 ///
-/// See <https://docs.discord.sex/resources/guild#search-guild-members>
+/// See <https://docs.discord.food/resources/guild#search-guild-members>
 pub struct SGMPaginationFilter {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_id: Option<Snowflake>,
@@ -1124,7 +1124,7 @@ pub struct SGMPaginationFilter {
 ///
 /// # Reference
 ///
-/// See <https://docs.discord.sex/resources/guild#search-guild-members>
+/// See <https://docs.discord.food/resources/guild#search-guild-members>
 pub struct SearchGuildMembersFilter {
     /// Query to match user IDs against
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1168,7 +1168,7 @@ pub struct SearchGuildMembersFilter {
 ///
 /// # Reference
 ///
-/// See <https://docs.discord.sex/resources/guild#search-guild-members>
+/// See <https://docs.discord.food/resources/guild#search-guild-members>
 pub struct SGMSafetySignals {
     /// When the member's unusual activity flag will expire
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1193,7 +1193,7 @@ pub struct SGMSafetySignals {
 ///
 /// # Reference
 ///
-/// See <https://docs.discord.sex/resources/guild#search-guild-members>
+/// See <https://docs.discord.food/resources/guild#search-guild-members>
 pub enum SearchGuildMembersQuery {
     Snowflake(SGMSnowflakeQuery),
     String(SGMStringQuery),
@@ -1209,7 +1209,7 @@ pub enum SearchGuildMembersQuery {
 ///
 /// # Reference
 ///
-/// See <https://docs.discord.sex/resources/guild#search-guild-members>
+/// See <https://docs.discord.food/resources/guild#search-guild-members>
 pub struct SGMSnowflakeQuery {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     /// The values to match against using OR logic
@@ -1235,7 +1235,7 @@ pub struct SGMSnowflakeQuery {
 ///
 /// # Reference
 ///
-/// See <https://docs.discord.sex/resources/guild#search-guild-members>
+/// See <https://docs.discord.food/resources/guild#search-guild-members>
 pub struct SGMSnowflakeQueryRange {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "gte")]
@@ -1256,7 +1256,7 @@ pub struct SGMSnowflakeQueryRange {
 ///
 /// # Reference
 ///
-/// See <https://docs.discord.sex/resources/guild#search-guild-members>
+/// See <https://docs.discord.food/resources/guild#search-guild-members>
 pub struct SGMStringQuery {
     /// The values to match against using OR logic
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -1271,7 +1271,7 @@ pub struct SGMStringQuery {
 ///
 /// # Reference
 ///
-/// See <https://docs.discord.sex/resources/guild#search-guild-members>
+/// See <https://docs.discord.food/resources/guild#search-guild-members>
 pub struct SGMTimestampQuery {
     /// The range of values to match against
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1285,7 +1285,7 @@ pub struct SGMTimestampQuery {
 ///
 /// # Reference
 ///
-/// See <https://docs.discord.sex/resources/guild#search-guild-members>
+/// See <https://docs.discord.food/resources/guild#search-guild-members>
 pub struct SGMTimestampQueryRange {
     #[serde(with = "ts_milliseconds_option")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1306,7 +1306,7 @@ pub struct SGMTimestampQueryRange {
 ///
 /// # Reference
 ///
-/// See <https://docs.discord.sex/resources/guild#search-guild-members>
+/// See <https://docs.discord.food/resources/guild#search-guild-members>
 pub struct SGMJoinSourceQuery {
     /// The values to match against using OR logic
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -1317,7 +1317,7 @@ pub struct SGMJoinSourceQuery {
 /// Schema for the [Guild::get_members_supplemental](crate::types::Guild::get_members_supplemental) route
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#get-guild-members-supplemental>
+/// See <https://docs.discord.food/resources/guild#get-guild-members-supplemental>
 pub struct GetGuildMembersSupplementalSchema {
     /// The user IDs to fetch supplemental guild member information for (max 200)
     pub users: Vec<Snowflake>,
@@ -1327,7 +1327,7 @@ pub struct GetGuildMembersSupplementalSchema {
 /// Schema for the [Guild::add_member](crate::types::Guild::add_member) endpoint.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#add-guild-member>
+/// See <https://docs.discord.food/resources/guild#add-guild-member>
 pub struct AddGuildMemberSchema {
     /// The OAuth2 access token granted with guilds.join to the bot's application for the user you want to add
     pub access_token: String,
@@ -1373,7 +1373,7 @@ pub struct AddGuildMemberSchema {
 /// Return object for the [Guild::add_member](crate::types::Guild::add_member) route.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#add-guild-member>
+/// See <https://docs.discord.food/resources/guild#add-guild-member>
 pub enum AddGuildMemberReturn {
     /// The request succeeded, and the user is now a member
     Joined(GuildMember),
@@ -1386,7 +1386,7 @@ pub enum AddGuildMemberReturn {
 /// Return schema for the [Guild::get_widget_settings](crate::types::Guild::get_widget_settings) endpoint.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#guild-widget-settings-structure>
+/// See <https://docs.discord.food/resources/guild#guild-widget-settings-structure>
 pub struct GuildWidgetSettings {
     /// Whether the widget is enabled
     pub enabled: bool,
@@ -1399,7 +1399,7 @@ pub struct GuildWidgetSettings {
 /// Schema for the [Guild::modify_widget](crate::types::Guild::modify_widget) endpoint.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#json-params>
+/// See <https://docs.discord.food/resources/guild#json-params>
 pub struct ModifyGuildWidgetSchema {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Whether the widget is enabled
@@ -1421,7 +1421,7 @@ pub struct ModifyGuildWidgetSchema {
 /// [Guild::get_widget_image](crate::types::Guild::get_widget_image) endpoint
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#guild-widget-image-style-option>
+/// See <https://docs.discord.food/resources/guild#guild-widget-image-style-option>
 pub enum GuildWidgetImageStyle {
     #[default]
     /// Shield style widget with instance icon and online count
@@ -1440,7 +1440,7 @@ pub enum GuildWidgetImageStyle {
 /// Return schema for the [Guild::get_vanity_invite](crate::types::Guild::get_vanity_invite) endpoint.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#get-guild-vanity-invite>
+/// See <https://docs.discord.food/resources/guild#get-guild-vanity-invite>
 pub struct GuildVanityInviteInfo {
     /// The vanity invite code
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1454,7 +1454,7 @@ pub struct GuildVanityInviteInfo {
 /// Internal schema for the [Guild::modify_vanity_invite](crate::types::Guild::modify_vanity_invite) endpoint.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#modify-guild-vanity-invite>
+/// See <https://docs.discord.food/resources/guild#modify-guild-vanity-invite>
 pub(crate) struct GuildModifyVanityInviteSchema {
     /// The vanity invite code; None to clear
     pub code: Option<String>,
@@ -1462,7 +1462,7 @@ pub(crate) struct GuildModifyVanityInviteSchema {
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#get-guild-member-verification>
+/// See <https://docs.discord.food/resources/guild#get-guild-member-verification>
 pub struct GetGuildMemberVerificationQuery {
     /// Whether or not to include an object with guild info in the response (false by default)
     ///
@@ -1494,7 +1494,7 @@ impl GetGuildMemberVerificationQuery {
 /// Schema for the [Guild::modify_member_verification](crate::types::Guild::modify_member_verification) endpoint.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#json-params>
+/// See <https://docs.discord.food/resources/guild#json-params>
 pub struct ModifyGuildMemberVerificationSchema {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Whether the member verification gate is enabled
@@ -1516,7 +1516,7 @@ pub struct ModifyGuildMemberVerificationSchema {
 /// endpoint.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#get-guild-join-requests>
+/// See <https://docs.discord.food/resources/guild#get-guild-join-requests>
 pub struct GetGuildJoinRequestsQuery {
     /// The status of the join requests to filter by
     pub status: GuildJoinRequestStatus,
@@ -1559,7 +1559,7 @@ impl GetGuildJoinRequestsQuery {
 /// endpoint.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#response-body>
+/// See <https://docs.discord.food/resources/guild#response-body>
 pub struct GetGuildJoinRequestsReturn {
     /// The join requests for the guild.
     ///
@@ -1582,7 +1582,7 @@ pub struct GetGuildJoinRequestsReturn {
 /// endpoint.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#get-guild-join-request-cooldown>
+/// See <https://docs.discord.food/resources/guild#get-guild-join-request-cooldown>
 pub struct GuildJoinRequestCooldown {
     /// How long (in seconds) the current user has to wait until they can submit another join request
     #[serde(rename = "cooldown")]
@@ -1595,7 +1595,7 @@ pub struct GuildJoinRequestCooldown {
 /// endpoint.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#json-params>
+/// See <https://docs.discord.food/resources/guild#json-params>
 pub struct CreateGuildJoinRequestSchema {
     /// The answered member verification questions.
     ///
@@ -1615,7 +1615,7 @@ pub struct CreateGuildJoinRequestSchema {
 /// endpoint.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#action-guild-join-request>
+/// See <https://docs.discord.food/resources/guild#action-guild-join-request>
 pub struct ActionGuildJoinRequestSchema {
     /// The action to take on the join request.
     ///
@@ -1633,7 +1633,7 @@ pub struct ActionGuildJoinRequestSchema {
 /// endpoint.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#bulk-action-guild-join-requests>
+/// See <https://docs.discord.food/resources/guild#bulk-action-guild-join-requests>
 pub struct BulkActionGuildJoinRequestsSchema {
     /// The action to take on the join requests.
     ///
@@ -1647,7 +1647,7 @@ pub struct BulkActionGuildJoinRequestsSchema {
 /// endpoint.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#modify-guild-welcome-screen>
+/// See <https://docs.discord.food/resources/guild#modify-guild-welcome-screen>
 pub struct ModifyGuildWelcomeScreenSchema {
     /// Whether the welcome screen is enabled.
     ///
@@ -1683,7 +1683,7 @@ pub struct ModifyGuildWelcomeScreenSchema {
 /// endpoint.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#modify-guild-onboarding>
+/// See <https://docs.discord.food/resources/guild#modify-guild-onboarding>
 pub struct ModifyGuildOnboardingSchema {
     /// The prompts shown during onboarding and in community customization
     ///
@@ -1716,7 +1716,7 @@ pub struct ModifyGuildOnboardingSchema {
 /// endpoint.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#get-admin-community-eligibility>
+/// See <https://docs.discord.food/resources/guild#get-admin-community-eligibility>
 pub struct AdminCommunityEligibility {
     /// Whether the user is eligible to join the Discord Admin Community through the guild
     pub eligible_for_admin_server: bool,
@@ -1728,7 +1728,7 @@ pub struct AdminCommunityEligibility {
 /// endpoint.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#get-guild-members-with-unusual-dm-activity>
+/// See <https://docs.discord.food/resources/guild#get-guild-members-with-unusual-dm-activity>
 pub struct GetMembersWithUnusualDmActivitySchema {
     /// Max number of members to return (max 1000, default 100)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1762,7 +1762,7 @@ impl GetMembersWithUnusualDmActivitySchema {
 /// endpoint.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/guild#get-guild-members-with-unusual-dm-activity>
+/// See <https://docs.discord.food/resources/guild#get-guild-members-with-unusual-dm-activity>
 pub struct GuildMemberUnusualDMActivity {
     /// The ID of the user with unusual activity
     pub user_id: Snowflake,

--- a/src/types/schema/invites.rs
+++ b/src/types/schema/invites.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 /// Query parameters for the `Get Invite` route.
 ///
 /// # Reference:
-/// See <https://docs.discord.sex/resources/invite#query-string-params>
+/// See <https://docs.discord.food/resources/invite#query-string-params>
 pub struct GetInvitesSchema {
     pub with_counts: Option<bool>,
 }
@@ -17,14 +17,14 @@ pub struct GetInvitesSchema {
 /// JSON schema for the [crate::instance::ChorusUser::accept_invite] route
 ///
 /// # Reference:
-/// See <https://docs.discord.sex/resources/invite#json-params>
+/// See <https://docs.discord.food/resources/invite#json-params>
 pub(crate) struct AcceptInviteSchema {
     pub session_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, PartialOrd, Eq, Ord)]
 /// # Reference:
-/// See <https://docs.discord.sex/resources/guild#get-guild-vanity-invite>
+/// See <https://docs.discord.food/resources/guild#get-guild-vanity-invite>
 pub struct GuildVanityInviteResponse {
     pub code: String,
     #[serde(default)]
@@ -33,7 +33,7 @@ pub struct GuildVanityInviteResponse {
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, PartialOrd, Eq, Ord)]
 /// # Reference:
-/// See <https://docs.discord.sex/resources/guild#modify-guild-vanity-invite>
+/// See <https://docs.discord.food/resources/guild#modify-guild-vanity-invite>
 pub struct GuildCreateVanitySchema {
     pub code: String,
 }

--- a/src/types/schema/message.rs
+++ b/src/types/schema/message.rs
@@ -51,7 +51,7 @@ impl std::fmt::Display for MessageSearchEndpoint {
 /// The `channel_id` field is not applicable when using the `GET /channels/{channel.id}/messages/search` endpoint.
 ///
 /// # Reference:
-/// See <https://discord-userdoccers.vercel.app/resources/message#search-messages>
+/// See <https://docs.discord.food/resources/message#search-messages>
 pub struct MessageSearchQuery {
     pub attachment_extension: Option<Vec<String>>,
     pub attachment_filename: Option<Vec<String>>,

--- a/src/types/schema/mfa.rs
+++ b/src/types/schema/mfa.rs
@@ -102,7 +102,7 @@ pub struct MfaMethod {
 /// A multi-factor authentication authenticator.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/user#authenticator-object>
+/// See <https://docs.discord.food/resources/user#authenticator-object>
 pub struct MfaAuthenticator {
     pub id: Snowflake,
     #[serde(rename = "type")]
@@ -214,7 +214,7 @@ impl Display for MfaAuthenticationType {
 /// An mfa backup code.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/user#backup-code-object>
+/// See <https://docs.discord.food/resources/user#backup-code-object>
 pub struct MfaBackupCode {
     pub user_id: Snowflake,
     pub code: String,
@@ -300,7 +300,7 @@ pub struct SendMfaSmsResponse {
 // TODO: Json error codes
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/user#enable-totp-mfa>
+/// See <https://docs.discord.food/resources/user#enable-totp-mfa>
 pub struct EnableTotpMfaSchema {
     pub password: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -313,7 +313,7 @@ pub struct EnableTotpMfaSchema {
 /// Response type for the Enable TOTP MFA route
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/user#enable-totp-mfa>
+/// See <https://docs.discord.food/resources/user#enable-totp-mfa>
 pub struct EnableTotpMfaResponse {
     pub token: String,
     pub backup_codes: Vec<MfaBackupCode>,
@@ -323,8 +323,8 @@ pub struct EnableTotpMfaResponse {
 /// A schema for SMS MFA Enable and Disable routes.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/user#enable-sms-mfa> and
-/// <https://docs.discord.sex/resources/user#disable-sms-mfa>
+/// See <https://docs.discord.food/resources/user#enable-sms-mfa> and
+/// <https://docs.discord.food/resources/user#disable-sms-mfa>
 pub struct SmsMfaRouteSchema {
     /// The user's current password
     pub password: String,
@@ -336,7 +336,7 @@ pub struct SmsMfaRouteSchema {
 /// Includes the MFA ticket and a stringified JSON object of the public key credential challenge.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/user#create-webauthn-authenticator>
+/// See <https://docs.discord.food/resources/user#create-webauthn-authenticator>
 pub struct BeginWebAuthnAuthenticatorCreationReturn {
     pub ticket: String,
     /// Stringified JSON public key credential request options challenge
@@ -347,7 +347,7 @@ pub struct BeginWebAuthnAuthenticatorCreationReturn {
 /// A schema for the [ChorusUser::finish_webauthn_authenticator_creation] route (Create WebAuthn Authenticator).
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/user#create-webauthn-authenticator>
+/// See <https://docs.discord.food/resources/user#create-webauthn-authenticator>
 pub struct FinishWebAuthnAuthenticatorCreationSchema {
     /// Name of the authenticator to create (1 - 32 characters)
     pub name: String,
@@ -363,7 +363,7 @@ pub struct FinishWebAuthnAuthenticatorCreationSchema {
 /// Includes the MFA ticket and a stringified JSON object of the public key credential challenge.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/user#create-webauthn-authenticator>
+/// See <https://docs.discord.food/resources/user#create-webauthn-authenticator>
 pub struct FinishWebAuthnAuthenticatorCreationReturn {
     #[serde(flatten)]
     /// The created authenticator object
@@ -376,7 +376,7 @@ pub struct FinishWebAuthnAuthenticatorCreationReturn {
 /// A schema for the Modify WebAuthn Authenticator route.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/user#modify-webauthn-authenticator>
+/// See <https://docs.discord.food/resources/user#modify-webauthn-authenticator>
 pub struct ModifyWebAuthnAuthenticatorSchema {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// New name of the authenticator (1 - 32 characters)
@@ -387,7 +387,7 @@ pub struct ModifyWebAuthnAuthenticatorSchema {
 /// A schema for the Send Backup Codes Challenge route.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/user#send-backup-codes-challenge>
+/// See <https://docs.discord.food/resources/user#send-backup-codes-challenge>
 pub struct SendBackupCodesChallengeSchema {
     /// The user's current password
     pub password: String,
@@ -397,7 +397,7 @@ pub struct SendBackupCodesChallengeSchema {
 /// A return type for the Send Backup Codes Challenge route.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/user#send-backup-codes-challenge>
+/// See <https://docs.discord.food/resources/user#send-backup-codes-challenge>
 pub struct SendBackupCodesChallengeReturn {
     /// A one-time verification nonce used to view the backup codes
     ///
@@ -416,7 +416,7 @@ pub struct SendBackupCodesChallengeReturn {
 /// A schema for the Get Backup Codes route.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/user#get-backup-codes>
+/// See <https://docs.discord.food/resources/user#get-backup-codes>
 pub struct GetBackupCodesSchema {
     /// The one-time verification nonce used to view or regenerate the backup codes.
     ///

--- a/src/types/schema/relationship.rs
+++ b/src/types/schema/relationship.rs
@@ -20,7 +20,7 @@ pub struct FriendRequestSendSchema {
 /// * friend_token: The friend token of the user to add a direct friend relationship to
 ///
 /// # Reference
-/// See <https://discord-userdoccers.vercel.app/resources/user#create-user-relationship>
+/// See <https://docs.discord.food/resources/user#create-user-relationship>
 #[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq, Eq)]
 pub struct CreateUserRelationshipSchema {
     #[serde(rename = "type")]
@@ -34,7 +34,7 @@ pub struct CreateUserRelationshipSchema {
 /// route.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/resources/relationships#bulk-remove-relationships>
+/// See <https://docs.discord.food/resources/relationships#bulk-remove-relationships>
 #[derive(Deserialize, Serialize, Debug, Copy, Default, Clone, PartialEq, Eq)]
 pub struct BulkRemoveRelationshipsQuery {
     /// Remove relationships with this type (default [RelationshipType::Incoming], only

--- a/src/types/schema/user.rs
+++ b/src/types/schema/user.rs
@@ -19,7 +19,7 @@ use crate::{
 #[serde(rename_all = "snake_case")]
 /// A schema used to modify a user.
 ///
-/// See <https://docs.discord.sex/resources/user#json-params>
+/// See <https://docs.discord.food/resources/user#json-params>
 pub struct UserModifySchema {
     /// The user's new username (2-32 characters)
     ///
@@ -49,7 +49,7 @@ pub struct UserModifySchema {
     ///
     /// See:
     ///
-    /// - the endpoints <https://docs.discord.sex/resources/user#modify-user-email> and <https://docs.discord.sex/resources/user#verify-user-email-change>
+    /// - the endpoints <https://docs.discord.food/resources/user#modify-user-email> and <https://docs.discord.food/resources/user#verify-user-email-change>
     ///
     /// - the relevant methods [`ChorusUser::initiate_email_change`](crate::instance::ChorusUser::initiate_email_change) and [`ChorusUser::verify_email_change`](crate::instance::ChorusUser::verify_email_change)
     ///
@@ -115,7 +115,7 @@ pub struct UserModifySchema {
 /// - nicks: A mapping of user IDs to their respective nicknames. Only usable for OAuth2 requests (which can only create group DMs).
 ///
 /// # Reference:
-/// Read: <https://discord-userdoccers.vercel.app/resources/channel#json-params>
+/// Read: <https://docs.discord.food/resources/channel#json-params>
 #[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub struct PrivateChannelCreateSchema {
     pub recipients: Option<Vec<Snowflake>>,
@@ -128,7 +128,7 @@ pub struct PrivateChannelCreateSchema {
 ///
 /// Similar to [crate::types::UserProfileMetadata]
 ///
-/// See <https://docs.discord.sex/resources/user#modify-user-profile>
+/// See <https://docs.discord.food/resources/user#modify-user-profile>
 pub struct UserModifyProfileSchema {
     // Note: one of these causes a 500 if it is sent
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -167,8 +167,8 @@ pub struct UserModifyProfileSchema {
 #[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq)]
 /// A schema used to delete or disable the current user's profile.
 ///
-/// See <https://docs.discord.sex/resources/user#disable-user> and
-/// <https://docs.discord.sex/resources/user#delete-user>
+/// See <https://docs.discord.food/resources/user#disable-user> and
+/// <https://docs.discord.food/resources/user#delete-user>
 pub struct DeleteDisableUserSchema {
     /// The user's current password, if any
     pub password: Option<String>,
@@ -177,7 +177,7 @@ pub struct DeleteDisableUserSchema {
 #[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq)]
 /// A schema used for [ChorusUser::verify_email_change](crate::instance::ChorusUser::verify_email_change)
 ///
-/// See <https://docs.discord.sex/resources/user#verify-user-email-change>
+/// See <https://docs.discord.food/resources/user#verify-user-email-change>
 pub struct VerifyUserEmailChangeSchema {
     /// The verification code sent to the user's email
     pub code: String,
@@ -186,7 +186,7 @@ pub struct VerifyUserEmailChangeSchema {
 #[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq)]
 /// The return type of [ChorusUser::verify_email_change](crate::instance::ChorusUser::verify_email_change)
 ///
-/// See <https://docs.discord.sex/resources/user#verify-user-email-change>
+/// See <https://docs.discord.food/resources/user#verify-user-email-change>
 pub struct VerifyUserEmailChangeResponse {
     /// The email_token to be used in [ChorusUser::modify](crate::instance::ChorusUser::modify)
     #[serde(rename = "token")]
@@ -197,7 +197,7 @@ pub struct VerifyUserEmailChangeResponse {
 /// Query string parameters for the route GET /users/{user.id}/profile
 /// ([crate::types::User::get_profile])
 ///
-/// See <https://docs.discord.sex/resources/user#get-user-profile>
+/// See <https://docs.discord.food/resources/user#get-user-profile>
 pub struct GetUserProfileSchema {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Whether to include the mutual guilds between the current user.
@@ -232,7 +232,7 @@ pub struct GetUserProfileSchema {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 /// Internal type for the [crate::instance::ChorusUser::get_pomelo_suggestions] endpoint.
 ///
-/// See <https://docs.discord.sex/resources/user#get-pomelo-suggestions>
+/// See <https://docs.discord.food/resources/user#get-pomelo-suggestions>
 pub(crate) struct GetPomeloSuggestionsReturn {
     pub username: String,
 }
@@ -240,7 +240,7 @@ pub(crate) struct GetPomeloSuggestionsReturn {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 /// Internal type for the [crate::instance::ChorusUser::get_pomelo_eligibility] endpoint.
 ///
-/// See <https://docs.discord.sex/resources/user#get-pomelo-eligibility>
+/// See <https://docs.discord.food/resources/user#get-pomelo-eligibility>
 pub(crate) struct GetPomeloEligibilityReturn {
     pub taken: bool,
 }
@@ -249,7 +249,7 @@ pub(crate) struct GetPomeloEligibilityReturn {
 /// Query string parameters for the route GET /users/@me/mentions
 /// ([crate::instance::ChorusUser::get_recent_mentions])
 ///
-/// See <https://docs.discord.sex/resources/user#get-recent-mentions>
+/// See <https://docs.discord.food/resources/user#get-recent-mentions>
 pub struct GetRecentMentionsSchema {
     /// Only fetch messages before this message id
     ///
@@ -279,7 +279,7 @@ pub struct GetRecentMentionsSchema {
 // (koza): imo it's nicer if the user can just pass a vec, instead of having to bother with
 // a specific type
 ///
-/// See <https://docs.discord.sex/resources/user#create-user-harvest>
+/// See <https://docs.discord.food/resources/user#create-user-harvest>
 pub(crate) struct CreateUserHarvestSchema {
     pub backends: Option<Vec<HarvestBackendType>>,
 }
@@ -287,7 +287,7 @@ pub(crate) struct CreateUserHarvestSchema {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 /// Internal type for the [crate::instance::ChorusUser::set_user_note] endpoint.
 ///
-/// See <https://docs.discord.sex/resources/user#modify-user-note>
+/// See <https://docs.discord.food/resources/user#modify-user-note>
 pub(crate) struct ModifyUserNoteSchema {
     pub note: Option<String>,
 }
@@ -296,7 +296,7 @@ pub(crate) struct ModifyUserNoteSchema {
 /// Query string parameters for the route GET /connections/{connection.type}/authorize
 /// ([crate::instance::ChorusUser::authorize_connection])
 ///
-/// See <https://docs.discord.sex/resources/user#authorize-user-connection>
+/// See <https://docs.discord.food/resources/user#authorize-user-connection>
 pub struct AuthorizeConnectionSchema {
     /// The type of two-way link ([TwoWayLinkType]) to create
     pub two_way_link_type: Option<TwoWayLinkType>,
@@ -309,7 +309,7 @@ pub struct AuthorizeConnectionSchema {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 /// Internal type for the [crate::instance::ChorusUser::authorize_connection] endpoint.
 ///
-/// See <https://docs.discord.sex/resources/user#authorize-user-connection>
+/// See <https://docs.discord.food/resources/user#authorize-user-connection>
 pub(crate) struct AuthorizeConnectionReturn {
     pub url: String,
 }
@@ -317,7 +317,7 @@ pub(crate) struct AuthorizeConnectionReturn {
 #[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq)]
 /// Json schema for the route POST /connections/{connection.type}/callback ([crate::instance::ChorusUser::create_connection_callback]).
 ///
-/// See <https://docs.discord.sex/resources/user#create-user-connection-callback>
+/// See <https://docs.discord.food/resources/user#create-user-connection-callback>
 pub struct CreateConnectionCallbackSchema {
     /// The authorization code for the connection
     pub code: String,
@@ -336,7 +336,7 @@ pub struct CreateConnectionCallbackSchema {
 #[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq, Eq)]
 /// Json schema for the route PUT /users/@me/connections/contacts/{connection.id} ([crate::instance::ChorusUser::create_contact_sync_connection]).
 ///
-/// See <https://docs.discord.sex/resources/user#create-contact-sync-connection>
+/// See <https://docs.discord.food/resources/user#create-contact-sync-connection>
 pub struct CreateContactSyncConnectionSchema {
     /// The username of the connection account
     pub name: String,
@@ -349,7 +349,7 @@ pub struct CreateContactSyncConnectionSchema {
 ///
 /// Note: not all connection types support all parameters.
 ///
-/// See <https://docs.discord.sex/resources/user#modify-user-connection>
+/// See <https://docs.discord.food/resources/user#modify-user-connection>
 pub struct ModifyConnectionSchema {
     /// The connection account's username
     ///
@@ -386,7 +386,7 @@ pub struct ModifyConnectionSchema {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 /// Internal type for the [crate::instance::ChorusUser::get_connection_access_token] endpoint.
 ///
-/// See <https://docs.discord.sex/resources/user#get-user-connection-access-token>
+/// See <https://docs.discord.food/resources/user#get-user-connection-access-token>
 pub(crate) struct GetConnectionAccessTokenReturn {
     pub access_token: String,
 }
@@ -394,7 +394,7 @@ pub(crate) struct GetConnectionAccessTokenReturn {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, PartialOrd)]
 /// Return type for the [crate::instance::ChorusUser::get_user_affinities] endpoint.
 ///
-/// See <https://docs.discord.sex/resources/user#get-user-affinities>
+/// See <https://docs.discord.food/resources/user#get-user-affinities>
 pub struct UserAffinities {
     pub user_affinities: Vec<UserAffinity>,
     // FIXME: Is this also a UserAffinity vec?
@@ -405,7 +405,7 @@ pub struct UserAffinities {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, PartialOrd)]
 /// Return type for the [crate::instance::ChorusUser::get_guild_affinities] endpoint.
 ///
-/// See <https://docs.discord.sex/resources/user#get-guild-affinities>
+/// See <https://docs.discord.food/resources/user#get-guild-affinities>
 pub struct GuildAffinities {
     pub guild_affinities: Vec<GuildAffinity>,
 }
@@ -415,7 +415,7 @@ pub struct GuildAffinities {
 ///
 /// This allows us to retrieve the needed proof for actually verifying the connection.
 ///
-/// See <https://docs.discord.sex/resources/user#create-domain-connection>
+/// See <https://docs.discord.food/resources/user#create-domain-connection>
 pub(crate) struct CreateDomainConnectionError {
     #[serde(flatten)]
     pub error: JsonError,
@@ -425,7 +425,7 @@ pub(crate) struct CreateDomainConnectionError {
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Return type for the [crate::instance::ChorusUser::create_domain_connection] endpoint.
 ///
-/// See <https://docs.discord.sex/resources/user#create-domain-connection>
+/// See <https://docs.discord.food/resources/user#create-domain-connection>
 pub enum CreateDomainConnectionReturn {
     /// Additional proof is needed to verify domain ownership.
     ///

--- a/src/types/schema/voice_state.rs
+++ b/src/types/schema/voice_state.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, PartialOrd, Copy)]
 /// # Reference:
-/// See <https://docs.discord.sex/resources/voice#json-params>
+/// See <https://docs.discord.food/resources/voice#json-params>
 pub struct VoiceStateUpdateSchema {
     /// The ID of the channel the user is currently in
     pub channel_id: Option<Snowflake>,

--- a/src/types/utils/opcode.rs
+++ b/src/types/utils/opcode.rs
@@ -148,7 +148,7 @@ impl TryFrom<u8> for Opcode {
 /// When the gateway server closes your connection, it tells you what happened throught a close code.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/topics/opcodes-and-status-codes#gateway-close-event-codes>
+/// See <https://docs.discord.food/topics/opcodes-and-status-codes#gateway-close-event-codes>
 pub enum CloseCode {
     UnknownError = 4000,
     UnknownOpcode = 4001,
@@ -235,7 +235,7 @@ impl TryFrom<u16> for CloseCode {
 /// When the voice gateway server closes your connection, it tells you what happened throught a close code.
 ///
 /// # Reference
-/// See <https://docs.discord.sex/topics/opcodes-and-status-codes#voice-close-event-codes>
+/// See <https://docs.discord.food/topics/opcodes-and-status-codes#voice-close-event-codes>
 pub enum VoiceCloseCode {
     UnknownOpcode = 4001,
     FailedToDecodePayload = 4002,

--- a/src/voice/crypto.rs
+++ b/src/voice/crypto.rs
@@ -8,7 +8,7 @@
 
 /// Gets an `xsalsa20_poly1305` nonce from an rtppacket.
 ///
-/// See <https://discord-userdoccers.vercel.app/topics/voice-connections#encryption-mode>
+/// See <https://docs.discord.food/topics/voice-connections#encryption-mode>
 pub(crate) fn get_xsalsa20_poly1305_nonce(packet: &[u8]) -> Vec<u8> {
     let mut rtp_header = Vec::with_capacity(24);
     rtp_header.append(&mut packet[0..12].to_vec());
@@ -23,7 +23,7 @@ pub(crate) fn get_xsalsa20_poly1305_nonce(packet: &[u8]) -> Vec<u8> {
 
 /// Gets an `xsalsa20_poly1305_suffix` nonce from an rtppacket.
 ///
-/// See <https://discord-userdoccers.vercel.app/topics/voice-connections#encryption-mode>
+/// See <https://docs.discord.food/topics/voice-connections#encryption-mode>
 pub(crate) fn get_xsalsa20_poly1305_suffix_nonce(packet: &[u8]) -> Vec<u8> {
     let mut nonce = Vec::with_capacity(24);
 
@@ -34,7 +34,7 @@ pub(crate) fn get_xsalsa20_poly1305_suffix_nonce(packet: &[u8]) -> Vec<u8> {
 
 /// Gets an `xsalsa20_poly1305_lite` nonce from an rtppacket.
 ///
-/// See <https://discord-userdoccers.vercel.app/topics/voice-connections#encryption-mode>
+/// See <https://docs.discord.food/topics/voice-connections#encryption-mode>
 pub(crate) fn get_xsalsa20_poly1305_lite_nonce(packet: &[u8]) -> Vec<u8> {
     let mut nonce = Vec::with_capacity(24);
 

--- a/src/voice/udp/mod.rs
+++ b/src/voice/udp/mod.rs
@@ -4,7 +4,7 @@
 
 //! Defines the UDP component of voice communications, sending and receiving raw rtp data.
 
-/// See <https://discord-userdoccers.vercel.app/topics/voice-connections#voice-packet-structure>
+/// See <https://docs.discord.food/topics/voice-connections#voice-packet-structure>
 /// This always adds up to 12 bytes
 const RTP_HEADER_SIZE: u8 = 12;
 


### PR DESCRIPTION
Updates all links to reflect the new url of Discord Userdoccers:

> Important Notice
>
>Effective immediately, the project is now available under [docs.discord.food](https://docs.discord.food/). The previous domain, [docs.discord.sex](https://docs.discord.sex/), no longer works. Please update your bookmarks accordingly.
>
>— The Userdoccers Team