### PR TITLE
Fix cloning of instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,26 @@ chorus = "0.19.0"
 To connect to a Polyphony/Spacebar compatible server, you'll need to create an [`Instance`](https://docs.rs/chorus/latest/chorus/instance/struct.Instance.html) like this:
 
 ```rust
-use chorus::instance::Instance;
+use chorus::{instance::Instance, types::IntoShared};
 
 #[tokio::main]
 async fn main() {
+
+    // This instance will later need to be shared across threads and users, so we'll
+    // store it inside of the `Shared` type (note the `into_shared()` method call)
     let instance = Instance::new("https://example.com", None)
         .await
-        .expect("Failed to connect to the Spacebar server");
+        .expect("Failed to connect to the Spacebar server")
+		  .into_shared();
+
     // You can create as many instances of `Instance` as you want, but each `Instance` should likely be unique.
-    dbg!(instance.instance_info);
-    dbg!(instance.limits_information);
+
+    // Each time we want to access the underlying `Instance` we need to lock
+    // its reference so other threads don't modify the data while we're reading or changing it
+    let instance_lock = instance.read().unwrap();
+
+    dbg!(&instance_lock.instance_info);
+    dbg!(&instance_lock.limits_information);
 }
 ```
 
@@ -84,8 +94,10 @@ let login_schema = LoginSchema {
 };
 // Each user connects to the Gateway. Each users' Gateway connection lives on a separate thread. Depending on
 // the runtime feature you choose, this can potentially take advantage of all of your computers' threads.
-let user = instance
-    .login_account(login_schema)
+//
+// Note that we clone the reference to the instance here, not the instance itself
+// (we do this because each user needs its own access to the instance's data)
+let user = Instance::login_account(instance.clone(), login_schema)
     .await
     .expect("An error occurred during the login process");
 dbg!(user.belongs_to);

--- a/examples/instance.rs
+++ b/examples/instance.rs
@@ -2,13 +2,23 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use chorus::instance::Instance;
+use chorus::{instance::Instance, types::IntoShared};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    let instance = Instance::new("https://example.com/", None)
+    // This instance will later need to be shared across threads and users, so we'll
+    // store it inside of the `Shared` type (note the `into_shared()` method call)
+    let instance = Instance::new("https://example.com", None)
         .await
-        .expect("Failed to connect to the Spacebar server");
-    dbg!(instance.instance_info);
-    dbg!(instance.limits_information);
+        .expect("Failed to connect to the Spacebar server")
+        .into_shared();
+
+    // You can create as many instances of `Instance` as you want, but each `Instance` should likely be unique.
+
+    // Each time we want to access the underlying `Instance` we need to lock
+    // its reference so other threads don't modify the data while we're reading or changing it
+    let instance_lock = instance.read().unwrap();
+
+    dbg!(&instance_lock.instance_info);
+    dbg!(&instance_lock.limits_information);
 }

--- a/examples/login.rs
+++ b/examples/login.rs
@@ -3,13 +3,14 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use chorus::instance::Instance;
-use chorus::types::LoginSchema;
+use chorus::types::{IntoShared, LoginSchema};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    let mut instance = Instance::new("https://example.com/", None)
+    let instance = Instance::new("https://example.com/", None)
         .await
-        .expect("Failed to connect to the Spacebar server");
+        .expect("Failed to connect to the Spacebar server")
+        .into_shared();
     // Assume, you already have an account created on this instance. Registering an account works
     // the same way, but you'd use the Register-specific Structs and methods instead.
     let login_schema = LoginSchema {
@@ -17,10 +18,12 @@ async fn main() {
         password: "Correct-Horse-Battery-Staple".to_string(),
         ..Default::default()
     };
-    // Each user connects to the Gateway. The Gateway connection lives on a separate thread. Depending on
+    // Each user connects to the Gateway. Each users' Gateway connection lives on a separate thread. Depending on
     // the runtime feature you choose, this can potentially take advantage of all of your computers' threads.
-    let user = instance
-        .login_account(login_schema)
+    //
+    // Note that we clone the reference to the instance here, not the instance itself
+    // (we do this because each user needs its own access to the instance's data)
+    let user = Instance::login_account(instance.clone(), login_schema)
         .await
         .expect("An error occurred during the login process");
     dbg!(user.belongs_to);

--- a/src/api/auth/login.rs
+++ b/src/api/auth/login.rs
@@ -13,8 +13,8 @@ use crate::instance::{ChorusUser, Instance};
 use crate::ratelimiter::ChorusRequest;
 use crate::types::{
     ClientProperties, GatewayIdentifyPayload, LimitType, LoginResult, LoginSchema,
-    MfaAuthenticationType, SendMfaSmsResponse, SendMfaSmsSchema, User, VerifyMFALoginResponse,
-    VerifyMFALoginSchema,
+    MfaAuthenticationType, SendMfaSmsResponse, SendMfaSmsSchema, Shared, User,
+    VerifyMFALoginResponse, VerifyMFALoginSchema,
 };
 
 impl Instance {
@@ -22,8 +22,11 @@ impl Instance {
     ///
     /// # Reference
     /// See <https://docs.spacebar.chat/routes/#post-/auth/login/>
-    pub async fn login_account(&mut self, login_schema: LoginSchema) -> ChorusResult<ChorusUser> {
-        let endpoint_url = self.urls.api.clone() + "/auth/login";
+    pub async fn login_account(
+        instance: Shared<Instance>,
+        login_schema: LoginSchema,
+    ) -> ChorusResult<ChorusUser> {
+        let endpoint_url = instance.read().unwrap().urls.api.clone() + "/auth/login";
         let chorus_request = ChorusRequest {
             request: Client::new().post(endpoint_url).json(&login_schema),
             limit_type: LimitType::AuthLogin,
@@ -34,7 +37,7 @@ impl Instance {
         // We do not have a user yet, and the UserRateLimits will not be affected by a login
         // request (since login is an instance wide limit), which is why we are just cloning the
         // instances' limits to pass them on as user_rate_limits later.
-        let mut user = ChorusUser::shell(Arc::new(RwLock::new(self.clone())), "None").await;
+        let mut user = ChorusUser::shell(instance, "None").await;
 
         let login_result = chorus_request
             .send_and_deserialize_response::<LoginResult>(&mut user)
@@ -51,11 +54,12 @@ impl Instance {
     /// # Reference
     /// See <https://docs.discord.food/authentication#verify-mfa-login>
     pub async fn verify_mfa_login(
-        &mut self,
+        instance: Shared<Instance>,
         authenticator: MfaAuthenticationType,
         schema: VerifyMFALoginSchema,
     ) -> ChorusResult<ChorusUser> {
-        let endpoint_url = self.urls.api.clone() + "/auth/mfa/" + &authenticator.to_string();
+        let endpoint_url =
+            instance.read().unwrap().urls.api.clone() + "/auth/mfa/" + &authenticator.to_string();
 
         let chorus_request = ChorusRequest {
             request: Client::new().post(endpoint_url).json(&schema),
@@ -64,7 +68,7 @@ impl Instance {
         // Note: yes, this is still sent even for login and register
         .with_client_properties(&ClientProperties::default());
 
-        let mut user = ChorusUser::shell(Arc::new(RwLock::new(self.clone())), "None").await;
+        let mut user = ChorusUser::shell(instance, "None").await;
 
         match chorus_request
             .send_and_deserialize_response::<VerifyMFALoginResponse>(&mut user)
@@ -93,8 +97,6 @@ impl Instance {
     ///
     /// # Reference
     /// See <https://docs.discord.food/authentication#send-mfa-sms>
-    // FIXME: This uses ChorusUser::shell, when it *really* shouldn't, but
-    // there is no other way to send a ratelimited request
     pub async fn send_mfa_sms(
         &mut self,
         schema: SendMfaSmsSchema,
@@ -108,10 +110,8 @@ impl Instance {
             limit_type: LimitType::Ip,
         };
 
-        let mut chorus_user = ChorusUser::shell(Arc::new(RwLock::new(self.clone())), "None").await;
-
         let send_mfa_sms_response = chorus_request
-            .send_and_deserialize_response::<SendMfaSmsResponse>(&mut chorus_user)
+            .send_anonymous_and_deserialize_response::<SendMfaSmsResponse>(self)
             .await?;
 
         Ok(send_mfa_sms_response)

--- a/src/api/auth/mod.rs
+++ b/src/api/auth/mod.rs
@@ -11,6 +11,7 @@ pub use login::*;
 pub use register::*;
 
 use crate::gateway::Gateway;
+use crate::types::Shared;
 use crate::{
     errors::ChorusResult,
     instance::{ChorusUser, Instance},
@@ -22,8 +23,11 @@ pub mod register;
 
 impl Instance {
     /// Logs into an existing account on the spacebar server, using only a token.
-    pub async fn login_with_token(&mut self, token: &str) -> ChorusResult<ChorusUser> {
-        let mut user = ChorusUser::shell(Arc::new(RwLock::new(self.clone())), token).await;
+    pub async fn login_with_token(
+        instance: Shared<Instance>,
+        token: &str,
+    ) -> ChorusResult<ChorusUser> {
+        let mut user = ChorusUser::shell(instance, token).await;
 
         user.update_with_login_data(token.to_string(), None).await?;
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -29,7 +29,7 @@ mod utils;
 ///
 /// While `T` does not have to implement `Composite` to be used with `Shared`,
 /// the primary use of `Shared` is with types that implement `Composite`.
-/// 
+///
 /// When the `client` feature is disabled, this does nothing (same as just `T`),
 /// since `Composite` structures are disabled.
 #[cfg(feature = "client")]

--- a/tests/instance.rs
+++ b/tests/instance.rs
@@ -12,24 +12,34 @@ wasm_bindgen_test_configure!(run_in_browser);
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
 async fn generate_general_configuration_schema() {
-    let mut bundle = common::setup().await;
+    let bundle = common::setup().await;
+
     bundle
         .instance
+        .write()
+        .unwrap()
         .general_configuration_schema()
         .await
         .unwrap();
+
     common::teardown(bundle).await;
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
 #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
 async fn detect_instance_software() {
-    let mut bundle = common::setup().await;
+    let bundle = common::setup().await;
 
-    let software = bundle.instance.detect_software().await;
+    let mut instance_lock = bundle.instance.write().unwrap();
+
+    let software = instance_lock.detect_software().await;
     assert_eq!(software, InstanceSoftware::SpacebarTypescript);
 
-    assert_eq!(bundle.instance.software(), InstanceSoftware::SpacebarTypescript);
+    assert_eq!(
+        instance_lock.software(),
+        InstanceSoftware::SpacebarTypescript
+    );
+    drop(instance_lock);
 
     common::teardown(bundle).await;
 }


### PR DESCRIPTION
This is a pretty old bug (#133) that I don't know why we / I didn't fix earlier

Makes the code reuse `Instance` references, requiring them to be passed in auth methods.

As such the examples and tests were also updated to make the best-practice saving `Instance` under `Shared<Instance>`

Also fixes the `send_mfa_sms` method to use anonymous requests instead of cloning the instance with `ChorusUser::shell`